### PR TITLE
Ladetaster.py um Taster für Standby erweitert

### DIFF
--- a/runs/ladetaster.py
+++ b/runs/ladetaster.py
@@ -7,12 +7,14 @@ GPIO.setup(12, GPIO.IN, pull_up_down=GPIO.PUD_UP)#Sofortladen
 GPIO.setup(16, GPIO.IN, pull_up_down=GPIO.PUD_UP)#Min+PV
 GPIO.setup(6, GPIO.IN, pull_up_down=GPIO.PUD_UP)#NURPV
 GPIO.setup(13, GPIO.IN, pull_up_down=GPIO.PUD_UP)#AUS
+GPIO.setup(21, GPIO.IN, pull_up_down=GPIO.PUD_UP)#STANDBY
 try:
     while True:
         button1_state = GPIO.input(12)
         button2_state = GPIO.input(16)
         button3_state = GPIO.input(6)
         button4_state = GPIO.input(13)
+        button5_state = GPIO.input(21)
         time.sleep(1)
         if button1_state == False:
              file = open("/var/www/html/openWB/ramdisk/lademodus","w") 
@@ -32,6 +34,11 @@ try:
         if button4_state == False:
             file = open("/var/www/html/openWB/ramdisk/lademodus","w") 
             file.write("3")
+            file.close()
+            time.sleep(0.2)
+        if button5_state == False:
+            file = open("/var/www/html/openWB/ramdisk/lademodus","w") 
+            file.write("4")
             file.close()
             time.sleep(0.2)
 except:


### PR DESCRIPTION
Ein weiterer Taster für den Modus Standby kann damit zwischen Ground und GPIO 21, PIN 40 angeschlossen werden.