### PR TITLE
Schönheitskorrektur Anzeige Bezug/Einspeisung auf Hauptseite

### DIFF
--- a/web/index.php
+++ b/web/index.php
@@ -206,7 +206,7 @@
 					PV: <span id="pvdiv"></span> 
 				</div>
 				<div id="evudiv" class="col-xs-6 text-center" style="background-color:#febebe;font-size: 2vw" >
-					EVU: <span id="bezugdiv"></span><span id="evuglaettungdiv">(<span id="bezugglattdiv"></span>)</span> 
+					EVU: <span id="bezugdiv"></span><span id="evuglaettungdiv"> ( <span id="bezugglattdiv"></span>)</span> 
 				</div>
 				</div>
 			</div>


### PR DESCRIPTION
Lehrzeichen für die Anzeige der geglätteten Leistung eingefügt.
In dem folgenden Codeschnippsel aus der der loadvars.sh wird in die Datei ramdisk/glattwattbezug noch ein Linefeed geschrieben. Der müsste, der Optik wegen, eigentlich raus. Übersteigt aber meine Fähigkeiten :-/. Wenn das geht, könnte das eingefügte Leerzeichen nach der öffnenden Klammer wieder entfallen.
	#evu glaettung
	if (( evuglaettungakt == 1 )); then
		ganzahl=$(( evuglaettung / 10 ))
		for ((i=ganzahl;i>=1;i--)); do
			i2=$(( i + 1 ))	
			cp ramdisk/glaettung$i ramdisk/glaettung$i2
		done
		echo $wattbezug > ramdisk/glaettung1
		for ((i=1;i<=ganzahl;i++)); do
			glaettung=$(<ramdisk/glaettung$i)
			glaettungw=$(( glaettung + glaettungw))
		done
		glaettungfinal=$((glaettungw / ganzahl))
		echo $glaettungfinal > ramdisk/glattwattbezug
		wattbezug=$glaettungfinal
	fi