### PR TITLE
Updaten graph-live.php (graphsocdyn)

### DIFF
--- a/web/themes/standard/graph-live.php
+++ b/web/themes/standard/graph-live.php
@@ -4,6 +4,9 @@ foreach($lines as $line) {
 	if(strpos($line, "graphsocdyn=") !== false) {
 		list(, $graphsocdyn) = explode("=", $line, 2);
 	}
+	if(strpos($line, "chartlegendmain=") !== false) {
+		list(, $chartlegendmain) = explode("=", $line, 2);
+	}
 }
 
 session_start();
@@ -144,7 +147,9 @@ $myImage->setGraphArea(70,25,1070,175);
 //$myImage->drawGradientArea(0, 0, $width, $height, DIRECTION_VERTICAL, $Settings);
 
 $myImage->drawScale($ScaleSettings);
-$myImage->drawLegend(240,12,array("Style"=>LEGEND_NOBORDER,"Mode"=>LEGEND_HORIZONTAL));
+if ($chartlegendmain == 1) {
+	$myImage->drawLegend(240,12,array("Style"=>LEGEND_NOBORDER,"Mode"=>LEGEND_HORIZONTAL));
+}
 $myData->setSerieDrawable("PV",false);
 $myData->setSerieDrawable("EVU",false);
 if ($speichervorhanden == 1) {

--- a/web/themes/standard/graph-live.php
+++ b/web/themes/standard/graph-live.php
@@ -1,4 +1,11 @@
 <?php
+$lines = file('/var/www/html/openWB/openwb.conf');
+foreach($lines as $line) {
+	if(strpos($line, "graphsocdyn=") !== false) {
+		list(, $graphsocdyn) = explode("=", $line, 2);
+	}
+}
+
 session_start();
 require_once "/var/www/html/openWB/web/class/pDraw.class.php";
 require_once "/var/www/html/openWB/web/class/pImage.class.php";
@@ -115,6 +122,10 @@ $myData->setAxisPosition(2,AXIS_POSITION_RIGHT);
 $myData->setAxisName(1,"% SoC");
 $myData->setAxisDisplay(0,AXIS_FORMAT_CUSTOM,"YAxisFormat");
 
+if ($graphsocdyn == 0) {
+	$minsoc = 0;
+	$maxsoc = 100;
+} 
 $AxisBoundaries = array(0=>array("Min"=>$loweste,"Max"=>$highest),1=>array("Min"=>$minsoc,"Max"=>$maxsoc));
 $ScaleSettings  = array("DrawYLines"=>array(0),"GridR"=>128,"GridG"=>128,"GridB"=>128,"GridTicks"=>0,"GridAlpha"=>5,"DrawXLines"=>FALSE,"Mode"=>SCALE_MODE_MANUAL,
 						"ManualScale"=>$AxisBoundaries,"LabelSkip"=>24);


### PR DESCRIPTION
Variable graphsocdyn hinzugefügt. Skalierung der SoC-Achse 0-100% oder dynamisch.
In den Einstellungen kann festgelegt werden, ob die Skalierung der SoC Achse dynamisch anhand der aktuellen Werte oder immer fest von 0 bis 100% festgelegt wird. Standard bleibt dynamisch.
Einstelungen zur Anzeige der Legende werden jetzt wieder berücksichtigt.