### PR TITLE
Anpassung Theme Dark_Gauges_1

### DIFF
--- a/web/setGaugeScaleCookie.php
+++ b/web/setGaugeScaleCookie.php
@@ -1,0 +1,5 @@
+<?php
+ 	$gauge_to_scale = $_GET['name'];
+    $max_value = $_GET['value'];
+	setcookie($gauge_to_scale, $max_value, time()+(60*60*24*365*2), '/');
+?>

--- a/web/setThemeCookie.php
+++ b/web/setThemeCookie.php
@@ -1,4 +1,4 @@
 <?php
  	$themeCookie = $_GET['theme'];
-	setcookie('openWBTheme', $themeCookie, time()+(60*60*24*365*2));
+	setcookie('openWBTheme', $themeCookie, time()+(60*60*24*365*2), '/');
 ?>

--- a/web/themes/dark_gauges_1/index.html
+++ b/web/themes/dark_gauges_1/index.html
@@ -13,7 +13,8 @@
 	var soc1vorhanden = <?php echo $soc1vorhanden ?>;
 	var speichervorhanden = <?php echo $speichervorhanden ?>;
 	var chartlegend = <?php echo $chartlegendmainold ?>;
-	var defaultScaleCounter = 3600;  // Standardwert Zähler zur Anpassung Gauge-Skala, je 2 Sekunden
+	// Standardwert Zähler zur Anpassung Gauge-Skala, je 5 Sekunden Gauge-Update-Zyklus
+	var defaultScaleCounter = 8640;  // ca. 12 Stunden
 </script>
 
 <?php

--- a/web/themes/dark_gauges_1/index.html
+++ b/web/themes/dark_gauges_1/index.html
@@ -13,8 +13,29 @@
 	var soc1vorhanden = <?php echo $soc1vorhanden ?>;
 	var speichervorhanden = <?php echo $speichervorhanden ?>;
 	var chartlegend = <?php echo $chartlegendmainold ?>;
-	var defaultScaleCounter = 120;  // Standardwert Zähler zur Anpassung Gauge-Skala, je 5 Sekunden
+	var defaultScaleCounter = 3600;  // Standardwert Zähler zur Anpassung Gauge-Skala, je 2 Sekunden
 </script>
+
+<?php
+	// Check ob Gauge-Skala-Cookies existiert - dann Werte übernehmen, sonst Standard setzen
+	if((isset($_COOKIE['dark_gauges_1_pvData']) === true)) {
+		$pvDataScaleMax = $_COOKIE['dark_gauges_1_pvData'];
+	} else {
+		$pvDataScaleMax = 1000;
+	}
+
+	if((isset($_COOKIE['dark_gauges_1_battData']) === true)) {
+		$battDataScaleMax = $_COOKIE['dark_gauges_1_battData'];
+	} else {
+		$battDataScaleMax = 1000;
+	}
+
+	if((isset($_COOKIE['dark_gauges_1_evuData']) === true)) {
+		$evuDataScaleMax = $_COOKIE['dark_gauges_1_evuData'];
+	} else {
+		$evuDataScaleMax = 1000;
+	}
+?>
 
 <div class="row">
 	<div class="col-xs-12 text-center">
@@ -52,17 +73,16 @@
 </div>
 
 <script>
-
     gaugePV = new RGraph.Gauge({
         id: 'pvData',
         min: 0,
-        max: 1000,
+        max: <?php echo $pvDataScaleMax?>,
         value: 0,
         options: {
 			radius: 102,
 			titleTop: 'kW',
 			labelsCount: 2,
-			labelsSpecific: ['0', '0.5', '1'],
+			labelsSpecific: ['0', '<?php echo $pvDataScaleMax/2000?>', '<?php echo $pvDataScaleMax/1000?>'],
 			tickmarksLarge: 4,
 			tickmarksSmall: 20,
 			marginTop: 5,
@@ -79,9 +99,9 @@
 			labelsValueBold: true,
             labelsValueItalic: true,
 			labelsValueSize: 17,
-            adjustable: true,
+            adjustable: false,
             textAccessible: false,
-			colorsRanges: [[0, 1000, 'green', 3]],
+			colorsRanges: [[0, <?php echo $pvDataScaleMax?>, 'green', 3]],
 			colorsRedWidth: 0,
             colorsYellowWidth: 0,
 			anglesStart: RGraph.PI - 0.55,
@@ -92,15 +112,15 @@
 
 	gaugeBatt = new RGraph.Gauge({
         id: 'battData',
-        min: -1000,
-        max: 1000,
+        min: <?php echo $battDataScaleMax*-1?>,
+        max: <?php echo $battDataScaleMax?>,
         value: 0,
 		options: {
 			centerx: 110,
 			radius: 102,
 			titleTop: 'kW',
 			labelsCount: 2,
-			labelsSpecific: ['-1', '0', '1'],
+			labelsSpecific: ['<?php echo $battDataScaleMax/-1000?>', '0', '<?php echo $battDataScaleMax/1000?>'],
 			tickmarksLarge: 4,
 			tickmarksSmall: 20,
 			marginTop: 5,
@@ -120,9 +140,9 @@
 			titleBottomPos: 0.61,
 			titleBottomBold: true,
 			titleBottomSize: 11,
-            adjustable: true,
+            adjustable: false,
             textAccessible: false,
-			colorsRanges: [[-1000,0, 'red', 3], [0, 1000, 'green', 3]],
+			colorsRanges: [[<?php echo $battDataScaleMax*-1?>, 0, 'red', 3], [0, <?php echo $battDataScaleMax?>, 'green', 3]],
 			anglesStart: RGraph.PI - 0.55,
             anglesEnd: RGraph.TWOPI + 0.55
         }
@@ -151,14 +171,14 @@
 
 	gaugeEVU = new RGraph.Gauge({
         id: 'evuData',
-        min: -1000,
-        max: 1000,
+        min: <?php echo $evuDataScaleMax*-1?>,
+        max: <?php echo $evuDataScaleMax?>,
         value: 0,
 		options: {
 			radius: 102,
 			titleTop: 'kW',
 			labelsCount: 2,
-			labelsSpecific: ['-1', '0', '1'],
+			labelsSpecific: ['<?php echo $evuDataScaleMax/-1000?>', '0', '<?php echo $evuDataScaleMax/1000?>'],
 			tickmarksLarge: 4,
 			tickmarksSmall: 20,
 			marginTop: 5,
@@ -178,9 +198,9 @@
 			titleBottomPos: 0.61,
 			titleBottomBold: true,
 			titleBottomSize: 11,
-            adjustable: true,
+            adjustable: false,
             textAccessible: false,
-			colorsRanges: [[-1000,0, 'red', 3], [0, 1000, 'green', 3]],
+			colorsRanges: [[<?php echo $evuDataScaleMax*-1?>, 0, 'red', 3], [0, <?php echo $evuDataScaleMax?>, 'green', 3]],
 			anglesStart: RGraph.PI - 0.55,
             anglesEnd: RGraph.TWOPI + 0.55
         }
@@ -214,7 +234,7 @@
 			labelsValueBold: true,
             labelsValueItalic: true,
 			labelsValueSize: 17,
-            adjustable: true,
+            adjustable: false,
             textAccessible: false,
 			colorsRanges: [[0, 1000, 'green', 3]],
 			colorsRedWidth: 0,
@@ -778,3 +798,10 @@ echo '
 
 <!-- load amcharts js for graph -->
 <script src="/openWB/web/themes/standard/livegraph.js"></script>
+
+<!-- after pageload update all gauges -->
+<script type="text/javascript">
+	$(function() {
+		getfile();
+	});
+</script>

--- a/web/themes/dark_gauges_1/updateGauges.js
+++ b/web/themes/dark_gauges_1/updateGauges.js
@@ -151,4 +151,4 @@ function getfile() {
   });
 }
 
-doInterval = setInterval(getfile, 2000);
+doInterval = setInterval(getfile, 5000);

--- a/web/themes/dark_gauges_1/updateGauges.js
+++ b/web/themes/dark_gauges_1/updateGauges.js
@@ -1,10 +1,11 @@
 var doInterval;
 
-function updateGauge(gauge, value, isSymmetric, bottomText) {
+function updateGauge(gauge, value, isSymmetric, bottomText, autoRescale) {
     // gauge: zu erneuernde Gauge
     // value: neuer Wert
     // isSymmetric: symmetrische Gauge oder nicht (min-max or 0-max)
     // bottomText: Text unter der Leistungsanzeige
+    // autoRescale: Skala passt sich nach defaultScaleCounter-Aufrufen selbst nach unten an
     // setzt neuen Wert und passt Skala an
     if(isNaN(value)){
         // es wurde keine Zahl als Wert übergeben
@@ -13,21 +14,36 @@ function updateGauge(gauge, value, isSymmetric, bottomText) {
     var needsScaling = false;
     var newGaugeMax = Math.ceil((Math.abs(value) / 1000)) * 1000;
     if (gauge.max < newGaugeMax) {
-        // aktuelles Maximum ist größer als Skala
+        // benötigtes Maximum ist größer als Skala
         gauge.max = newGaugeMax;  // Skala positiv anpassen
         gauge.scaleCounter = defaultScaleCounter;  // Counter reset
         needsScaling = true;
+        if (!autoRescale) {
+            // neues Maximum der Gauge als Cookie speichern
+            gauge_identifier = 'dark_gauges_1_' + gauge.id;
+            $.ajax({
+                type: "GET",
+                url: "./setGaugeScaleCookie.php",
+                data: {
+                    name: gauge_identifier,
+                    value: newGaugeMax
+                }
+            });
+        }
     } else if (gauge.max > newGaugeMax) {
         // Skala ist aktuell eigentlich zu groß
-        gauge.scaleCounter -= 1; // dann Counter reduzieren
-        if (gauge.scaleCounter == 0) {
-            // wenn Zeit rum
-            gauge.scaleCounter = defaultScaleCounter;  // Counter reset
-            gauge.max = gauge.max-(Math.ceil((gauge.max-newGaugeMax) / 2000) * 1000);  // Skala anpassen
-            needsScaling = true;
+        if (autoRescale) {
+            // und Anpassung soll automatisch erfolgen
+            gauge.scaleCounter -= 1; // dann Counter reduzieren
+            if (gauge.scaleCounter == 0) {
+                // wenn Zeit rum
+                gauge.scaleCounter = defaultScaleCounter;  // Counter reset
+                gauge.max = gauge.max-(Math.ceil((gauge.max-newGaugeMax) / 2000) * 1000);  // Skala anpassen
+                needsScaling = true;
+            }
         }
     } else {
-        // Skala soll bleiben
+        // Skala soll bleiben, keine automatische Anpassung
         if (gauge.scaleCounter < defaultScaleCounter) {
             // aber Zähler zum Wechsel ist schon angelaufen
             gauge.scaleCounter = defaultScaleCounter;  // Counter reset
@@ -73,7 +89,7 @@ function getfile() {
             value = 0;
         }
         // Gauge mit Rückgabewert erneuern, asymmetrische Gauge 0-Max
-        updateGauge(gaugeHome, value, false, '');
+        updateGauge(gaugeHome, value, false, '', true);
     }
   });
 
@@ -83,7 +99,7 @@ function getfile() {
     complete: function(request){
         // Erzeugung bei Übergabe in positiven Wert umwandeln, liegt zur Regelung negativ vor
         // Gauge mit Rückgabewert erneuern, asymmetrische Gauge 0-Max
-        updateGauge(gaugePV, (parseInt(request.responseText,10) * -1), false, '');
+        updateGauge(gaugePV, (parseInt(request.responseText,10) * -1), false, '', false);
     }
   });
 
@@ -101,7 +117,7 @@ function getfile() {
         } else if (value < 0) {
             text = 'Entadung';
         }
-        updateGauge(gaugeBatt, value, true, text);
+        updateGauge(gaugeBatt, value, true, text, false);
     }
   });
 
@@ -130,9 +146,9 @@ function getfile() {
         } else if (value < 0) {
             text = 'Bezug';
         }
-        updateGauge(gaugeEVU, value, true, text);
+        updateGauge(gaugeEVU, value, true, text, false);
     }
   });
 }
 
-doInterval = setInterval(getfile, 5000);
+doInterval = setInterval(getfile, 2000);


### PR DESCRIPTION
Kleine Bugfixes. Erste Werte werden jetzt umgehend nach Page-Load angezeigt. Zudem: Gauges für PV, Batt und EVU passen die Skala nicht mehr automatisch nach unten an. Maximalwerte der jeweiligen Skalen werden als Cookies gespeichert, bei neuen Maximalwerten angepasst und bei Page-Reload geladen. Änderung erfolgt, weil man so optisch besser zwischen "viel" und "wenig" unterscheiden kann, was nicht geht, wenn die Skala auch automatisch nach unten korrigiert wird und dabei ein Zeiger auf "Anschlag rechts" innerhalb einer Gauge mal 1kW und mal 8kW entspricht. Skala der Gauge für Hausverbrauch passt sich weiterhin auch nach unten an, aber langsamer. Dies deswegen, um Ausreißer durch Berechnungsfehler auszugleichen.