### PR TITLE
Fixed the position of the debug output message. Now the correct value…

### DIFF
--- a/regel.sh
+++ b/regel.sh
@@ -280,17 +280,10 @@ fi
 mindestuberschussphasen=$(echo "($mindestuberschuss*$anzahlphasen)" | bc)
 wattkombiniert=$(echo "($ladeleistung+$uberschuss)" | bc)
 abschaltungw=$(echo "(($abschaltuberschuss-1320)*-1*$anzahlphasen)" | bc)
-schaltschwelle=$(echo "(230*$anzahlphasen)" | bc)
-if [[ $debug == "1" ]]; then
-	echo anzahlphasen "$anzahlphasen"
-fi
-if [[ $debug == "2" ]]; then
-	echo "$date"
-	echo "uberschuss" $uberschuss "wattbezug" $wattbezug "ladestatus" $ladestatus "llsoll" $llalt "pvwatt" $pvwatt "mindestuberschussphasen" $mindestuberschussphasen "wattkombiniert" $wattkombiniert "abschaltungw" $abschaltungw "schaltschwelle" $schaltschwelle
-fi
 #PV Regelmodus
 if [[ $pvbezugeinspeisung == "0" ]]; then
 	pvregelungm="0"
+        schaltschwelle=$(echo "(230*$anzahlphasen)" | bc)
 fi
 if [[ $pvbezugeinspeisung == "1" ]]; then
 	pvregelungm=$(echo "(230*$anzahlphasen*-1)" | bc)
@@ -299,6 +292,14 @@ fi
 if [[ $pvbezugeinspeisung == "2" ]]; then
 	pvregelungm=$offsetpv
 	schaltschwelle=$((schaltschwelle + offsetpv))
+fi
+# Debug Ausgaben
+if [[ $debug == "1" ]]; then
+	echo anzahlphasen "$anzahlphasen"
+fi
+if [[ $debug == "2" ]]; then
+	echo "$date"
+	echo "uberschuss" $uberschuss "wattbezug" $wattbezug "ladestatus" $ladestatus "llsoll" $llalt "pvwatt" $pvwatt "mindestuberschussphasen" $mindestuberschussphasen "wattkombiniert" $wattkombiniert "abschaltungw" $abschaltungw "schaltschwelle" $schaltschwelle
 fi
 ########################
 #Min Ladung + PV Uberschussregelung lademodus 1


### PR DESCRIPTION
… for $schaltschwelle is written.

In German:

1. Da in zwei der drei "if [[ $pvbezugeinspeisung == ..."-Abfragen der Wert von $schaltschwelle NACH der Debug-Ausgabe geändert wird, verwendet die anschließende Regelung in diesen zwei Fällen einen anderen Wert als das, was in das Logfile geschrieben wird.
Daher habe ich die Ausgabe HINTER die Berechnung geschoben, somit wird jetzt mit dem Wert gerechnet, der auch geloggt wird.

2. Da "$pvbezugeinspeisung" bei Konfiguration über die Website nur die drei Werte 0, 1 und 2 annehmen kann, habe ich die Berechnung "schaltschwelle=$(echo "(230*$anzahlphasen)" | bc)" dorthin gepackt, wo sie auch verwendet wird.
Das finde ich übersichtlicher, allerdings besteht die Gefahr, dass wenn jemand (warum auch immer) "$schaltschwelle" händisch andere Werte als 0, 1 oder 2  zuweist, die Schaltschwelle nicht mehr berechnet werden würde, was in der aktuellen Konfiguration aber der Fall wäre.
Daher entscheide bitte, ob Du das für sinnvoll erachtest oder nicht.