### PR TITLE
Add docker config

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,16 +1,11 @@
 FROM debian
 
-# PHP 7.0 repo
-RUN apt-get update && apt-get install -y wget gnupg
-RUN wget -q https://packages.sury.org/php/apt.gpg -O- | apt-key add -
-RUN echo "deb https://packages.sury.org/php/ stretch main" | tee /etc/apt/sources.list.d/php.list
-
 # packages
 ENV DEBIAN_FRONTEND=noninteractive
 RUN apt-get update
 RUN apt-get install -y \
     apache2 \
-    php7.0 php7.0-gd php7.0-xml \
+    php php-gd php-xml \
     python-pip python3-pip \
     cron \
     curl \

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,11 +1,16 @@
 FROM debian
 
+# PHP 7.0 repo
+RUN apt-get update && apt-get install -y wget gnupg
+RUN wget -q https://packages.sury.org/php/apt.gpg -O- | apt-key add -
+RUN echo "deb https://packages.sury.org/php/ stretch main" | tee /etc/apt/sources.list.d/php.list
+
 # packages
 ENV DEBIAN_FRONTEND=noninteractive
 RUN apt-get update
 RUN apt-get install -y \
     apache2 \
-    php php-gd php-xml \
+    php7.0 php7.0-gd php7.0-xml \
     python-pip python3-pip \
     cron \
     curl \

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,52 @@
+FROM debian
+
+# packages
+ENV DEBIAN_FRONTEND=noninteractive
+RUN apt-get update
+RUN apt-get install -y \
+    apache2 \
+    php php-gd php-xml \
+    python-pip python3-pip \
+    cron \
+    curl \
+    jq \
+    mosquitto-clients \
+    nano \
+    socat \
+    supervisor
+
+# fix invoke-rc.d: policy-rc.d denied execution of start
+RUN printf "#!/bin/sh\nexit 0" > /usr/sbin/policy-rc.d
+RUN apt-get install -y mosquitto
+
+RUN pip install evdev
+RUN pip3 install paho-mqtt
+RUN pip install -U pymodbus
+
+# DOCUMENT_ROOT
+ENV APACHE_DOCUMENT_ROOT /var/www/html/openWB
+RUN sed -ri -e 's!/var/www/html!${APACHE_DOCUMENT_ROOT}!g' /etc/apache2/sites-available/*.conf /etc/apache2/sites-enabled/*.conf
+RUN sed -ri -e 's!/var/www/!${APACHE_DOCUMENT_ROOT}!g' /etc/apache2/apache2.conf /etc/apache2/conf-available/*.conf
+
+# sources
+COPY . ${APACHE_DOCUMENT_ROOT}
+RUN ln -s ${APACHE_DOCUMENT_ROOT} /openWB
+
+# install
+RUN touch /var/log/openWB.log
+
+# dockerize atreboot.sh
+RUN mkdir -p ${APACHE_DOCUMENT_ROOT}/ramdisk
+RUN sed -ri -e 's!sudo !!g' ${APACHE_DOCUMENT_ROOT}/runs/atreboot.sh
+RUN sed -ri -e 's!ifconfig .*!true!g' ${APACHE_DOCUMENT_ROOT}/runs/atreboot.sh
+RUN sed -ri -e 's!service .*!true!g' ${APACHE_DOCUMENT_ROOT}/runs/atreboot.sh
+RUN sed -ri -e 's!/pi!/root!g' ${APACHE_DOCUMENT_ROOT}/runs/atreboot.sh
+RUN sed -ri -e 's!-u pi!-u root!g' ${APACHE_DOCUMENT_ROOT}/runs/atreboot.sh
+
+# http and mosquitto
+EXPOSE 80
+EXPOSE 1883
+
+WORKDIR ${APACHE_DOCUMENT_ROOT}
+COPY supervisord.conf /etc/supervisord.conf
+CMD ["/usr/bin/supervisord"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -13,7 +13,9 @@ RUN apt-get install -y \
     mosquitto-clients \
     nano \
     socat \
-    supervisor
+    supervisor \
+    sudo \
+    bc
 
 # fix invoke-rc.d: policy-rc.d denied execution of start
 RUN printf "#!/bin/sh\nexit 0" > /usr/sbin/policy-rc.d

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,11 +1,16 @@
 FROM debian
 
+# PHP 7.0 repo
+RUN apt-get update && apt-get install -y wget gnupg
+RUN wget -q https://packages.sury.org/php/apt.gpg -O- | apt-key add -
+RUN echo "deb https://packages.sury.org/php/ stretch main" | tee /etc/apt/sources.list.d/php.list
+
 # packages
 ENV DEBIAN_FRONTEND=noninteractive
 RUN apt-get update
 RUN apt-get install -y \
     apache2 \
-    php php-gd php-xml \
+    php7.0 php7.0-gd php7.0-xml \
     python-pip python3-pip \
     cron \
     curl \
@@ -24,29 +29,36 @@ RUN pip3 install paho-mqtt
 RUN pip install -U pymodbus
 
 # DOCUMENT_ROOT
-ENV APACHE_DOCUMENT_ROOT /var/www/html/openWB
+ENV APACHE_DOCUMENT_ROOT /var/www/html
+ENV OWB ${APACHE_DOCUMENT_ROOT}/openWB
 RUN sed -ri -e 's!/var/www/html!${APACHE_DOCUMENT_ROOT}!g' /etc/apache2/sites-available/*.conf /etc/apache2/sites-enabled/*.conf
 RUN sed -ri -e 's!/var/www/!${APACHE_DOCUMENT_ROOT}!g' /etc/apache2/apache2.conf /etc/apache2/conf-available/*.conf
 
 # sources
-COPY . ${APACHE_DOCUMENT_ROOT}
-RUN ln -s ${APACHE_DOCUMENT_ROOT} /openWB
+COPY . ${OWB}
 
 # install
 RUN touch /var/log/openWB.log
 
 # dockerize atreboot.sh
-RUN mkdir -p ${APACHE_DOCUMENT_ROOT}/ramdisk
-RUN sed -ri -e 's!sudo !!g' ${APACHE_DOCUMENT_ROOT}/runs/atreboot.sh
-RUN sed -ri -e 's!ifconfig .*!true!g' ${APACHE_DOCUMENT_ROOT}/runs/atreboot.sh
-RUN sed -ri -e 's!service .*!true!g' ${APACHE_DOCUMENT_ROOT}/runs/atreboot.sh
-RUN sed -ri -e 's!/pi!/root!g' ${APACHE_DOCUMENT_ROOT}/runs/atreboot.sh
-RUN sed -ri -e 's!-u pi!-u root!g' ${APACHE_DOCUMENT_ROOT}/runs/atreboot.sh
+RUN mkdir -p ${OWB}/ramdisk
+RUN sed -ri -e 's!sudo !!g' ${OWB}/runs/atreboot.sh
+RUN sed -ri -e 's!ifconfig .*!true!g' ${OWB}/runs/atreboot.sh
+RUN sed -ri -e 's!service .*!true!g' ${OWB}/runs/atreboot.sh
+RUN sed -ri -e 's!/pi!/root!g' ${OWB}/runs/atreboot.sh
+RUN sed -ri -e 's!-u pi!-u root!g' ${OWB}/runs/atreboot.sh
+
+RUN (crontab -l ; echo "* * * * * ${OWB}/regel.sh >> /var/log/openWB.log 2>&1") | crontab -
+RUN (crontab -l ; echo "* * * * * sleep 10 && ${OWB}/regel.sh >> /var/log/openWB.log 2>&1") | crontab -
+RUN (crontab -l ; echo "* * * * * sleep 20 && ${OWB}/regel.sh >> /var/log/openWB.log 2>&1") | crontab -
+RUN (crontab -l ; echo "* * * * * sleep 30 && ${OWB}/regel.sh >> /var/log/openWB.log 2>&1") | crontab -
+RUN (crontab -l ; echo "* * * * * sleep 40 && ${OWB}/regel.sh >> /var/log/openWB.log 2>&1") | crontab -
+RUN (crontab -l ; echo "* * * * * sleep 50 && ${OWB}/regel.sh >> /var/log/openWB.log 2>&1") | crontab -
 
 # http and mosquitto
 EXPOSE 80
 EXPOSE 1883
 
-WORKDIR ${APACHE_DOCUMENT_ROOT}
+WORKDIR ${OWB}
 COPY supervisord.conf /etc/supervisord.conf
 CMD ["/usr/bin/supervisord"]

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # openWB
 
-
+**Dieser Fork von OpenWB ermöglicht es, OpenWB als Docker Image zu bauen und betreiben. Mit EVCC steht unter  https://github.com/andig/evcc eine alternative, vollständig Docker-kompatible und leichtgewichtigere Alternative zu OpenWB steht zur Verfügung.**
 
 
 Die Software steht frei für jeden zur Verfügung, siehe GPLv3 Bedingungen.

--- a/supervisord.conf
+++ b/supervisord.conf
@@ -1,0 +1,25 @@
+[supervisord]
+nodaemon=true
+loglevel=info
+
+[program:cron]
+command=cron -f -L 15
+autostart=true
+autorestart=false
+
+[program:apache2]
+command=/bin/bash -c "source /etc/apache2/envvars && exec /usr/sbin/apache2 -DFOREGROUND"
+autostart=true
+autorestart=true
+killasgroup=true
+stopasgroup=true
+
+[program:mosquitto]
+command=/usr/sbin/mosquitto
+autostart=true
+autorestart=true
+
+[program:atreboot]
+command=/bin/bash -c /var/www/html/openWB/runs/atreboot.sh
+autostart=true
+autorestart=false


### PR DESCRIPTION
This PR provides initial docker support:

- based on debian image
- uses supervisord to run apache, cron, mosquitto
- executes `atreboot.sh` once on container startup
- run `regel.sh` each 10 seconds

I have not extensively tested this but its sufficient to get the UI up and running:

<img width="1231" alt="Screenshot 2019-10-25 at 11 03 26" src="https://user-images.githubusercontent.com/184815/67558347-1cbd7e80-f717-11e9-81a1-b404adad1063.png">

Two things I have noticed during testing that seem wrong- and I'm not sure if I did cause them or if they're inherent:

- the apache `DocumentRoot` gives read access to the shell scripts, potentially leaking password
- ~~the js scripts use `/openWB/...` as path instead of `/ramdisk`- hacked this by symlinking- might not be correct~~

Various items that could be config (especially the pathes) are duplicated over the code- might be nice to put them into env vars or similar.