### PR TITLE
Beim Anstecken eines Fahrzeugs das Display einschalten

### DIFF
--- a/loadvars.sh
+++ b/loadvars.sh
@@ -59,9 +59,14 @@ if [[ $evsecon == "modbusevse" ]]; then
 	if [ "$evseplugstate" -ge "0" ] && [ "$evseplugstate" -le "10" ] ; then
 		if [[ $evseplugstate > "1" ]]; then
 			plugstat=$(</var/www/html/openWB/ramdisk/plugstat)
-			if [[ $plugstat == "0" ]] && [[ $pushbplug == "1" ]] && [[ $ladestatuslp1 == "0" ]] && [[ $pushbenachrichtigung == "1" ]] ; then
-				message="Fahrzeug eingesteckt. Ladung startet bei erfüllter Ladebedingung automatisch."
-				/var/www/html/openWB/runs/pushover.sh "$message"
+			if [[ $plugstat == "0" ]] ; then
+				if [[ $pushbplug == "1" ]] && [[ $ladestatuslp1 == "0" ]] && [[ $pushbenachrichtigung == "1" ]] ; then
+					message="Fahrzeug eingesteckt. Ladung startet bei erfüllter Ladebedingung automatisch."
+					/var/www/html/openWB/runs/pushover.sh "$message"
+				fi
+				if [[ $displayconfigured == "1" ]] && [[ $displayEinBeimAnstecken == "1" ]] ; then
+					export DISPLAY=:0 && xset dpms force on && xset dpms $displaysleep $displaysleep $displaysleep
+				fi
 			fi
 				echo 1 > /var/www/html/openWB/ramdisk/plugstat
 				plugstat=1

--- a/regel.sh
+++ b/regel.sh
@@ -84,7 +84,7 @@ fi
 if (( displayaktiv == 1 )); then
 	execdisplay=$(<ramdisk/execdisplay)
 	if (( execdisplay == 1 )); then
-	        export DISPLAY=:0 && xset s $displaysleep
+	        export DISPLAY=:0 && xset s $displaysleep && xset dpms $displaysleep $displaysleep $displaysleep
 	        echo 0 > ramdisk/execdisplay
 	fi
 fi

--- a/runs/atreboot.sh
+++ b/runs/atreboot.sh
@@ -960,6 +960,10 @@ if ! grep -Fq "displaytagesgraph=" /var/www/html/openWB/openwb.conf
 then
 	  echo "displaytagesgraph=1" >> /var/www/html/openWB/openwb.conf
 fi
+if ! grep -Fq "displayEinBeimAnstecken=" /var/www/html/openWB/openwb.conf
+then
+	  echo "displayEinBeimAnstecken=1" >> /var/www/html/openWB/openwb.conf
+fi
 if ! grep -Fq "speicherleistung_http=" /var/www/html/openWB/openwb.conf
 then
 	  echo "speicherleistung_http=192.168.0.10/watt" >> /var/www/html/openWB/openwb.conf


### PR DESCRIPTION
Hallo und erst einmal Vielen Dank an alle Aktiven für die Arbeit an der openWB Hard- und Software !  

**Ich hätte eine kleine Ergänzung anzubieten die das Display der openWB series2 beim Anstecken eines Fahrzeugs für die unter "Einstellungen -> Misc" eingestellte Zeit aktiviert.  
Die Funktion wird über das Config-Setting `displayEinBeimAnstecken` aktiviert. Der Default (in `atreboot.sh`) wäre `ein`.**

Weder im Forum noch per Google-Suche noch per Reverse-Engineering habe ich eine entsprechende Funktion gefunden. Ich finde das aber sehr praktisch da ich nach dem Anstecken des Autos sowieso an der Box vorbei gehe und mir so ganz einfach, ohne Antippen des Displays, einen Überblick über den Stand der Anlage verschaffen kann.

Da ich aber neu bin in openWB (hab das E-Auto noch nicht lange) habe ich gerade erst begonnen die Software zu untersuchen.  
**Ich bin deshalb nicht sicher alle Randbedingungen berücksichtigt zu haben !**  
Die Änderungen sind aber recht übersichtlich und ich bin gerne bereit produktive Kommentare umzusetzen. Auch den Default `ein` für die Funktion kann ich gerne in `aus` ändern.

Mir ist aber, beispielsweise, noch nicht klar ob die Funktion, wie von mir implementiert, auch für LP2 und höher greift. Das kann ich leider auch nicht testen da ich nur eine openWB series2 mit einem einzigen LP habe.