### PR TITLE
Bugfix: Bulk publish (and hence retain) also for ChargeMode

### DIFF
--- a/loadvars.sh
+++ b/loadvars.sh
@@ -621,7 +621,7 @@ if (( oladestatus != ladestatus )); then
 	echo $ladestatus > ramdisk/mqttlastladestatus
 fi
 if (( olademodus != lademodus )); then
-	mosquitto_pub -t openWB/global/ChargeMode -m "$lademodus"
+	tempPubList="${tempPubList}\nopenWB/global/ChargeMode=${lademodus}"
 	echo $lademodus > ramdisk/mqttlastlademodus
 fi
 if (( ohausverbrauch != hausverbrauch )); then


### PR DESCRIPTION
It seems the bulk publish is missing for `global/ChargeMode` and the `mosquitto_pub` command line is missing the `-r` flag. Hence ChargeMode is not retained by MQTT Broker.

The PR includes  `global/ChargeMode` in bulk publish which is using retention anyway.

Fix for observation reported in [this](https://openwb.de/forum/viewtopic.php?f=6&t=577&start=50#p4495) forum post.