### PR TITLE
Fix typo in mqttsub.py

### DIFF
--- a/runs/mqttsub.py
+++ b/runs/mqttsub.py
@@ -34,7 +34,7 @@ def on_message(client, userdata, msg):
             f = open('/var/www/html/openWB/ramdisk/lademodus', 'w')
             f.write(msg.payload.decode("utf-8"))
             f.close()
-            client.pubslih("openWB/global/ChargeMode", msg.payload.decode("utf-8"), qos=0, retain=True)
+            client.publish("openWB/global/ChargeMode", msg.payload.decode("utf-8"), qos=0, retain=True)
     if (msg.topic == "openWB/set/lp1/ChargePointEnabled"):
         if (int(msg.payload) >= 0 and int(msg.payload) <=1):
             f = open('/var/www/html/openWB/ramdisk/lp1enabled', 'w')


### PR DESCRIPTION
Fixes a little typo introduced by commit b06740592e1bfe62d9f659cbe1cdd9773121cc47 (`pubslih` --> `publish`).