### PR TITLE
Allow UI configuration of display-on on plugin

### DIFF
--- a/web/misc.php
+++ b/web/misc.php
@@ -49,6 +49,9 @@ foreach($lines as $line) {
 	if(strpos($line, "displayaktiv=") !== false) {
 		list(, $displayaktivold) = explode("=", $line);
 	}
+	if(strpos($line, "displayEinBeimAnstecken=") !== false) {
+		list(, $displayEinBeimAnsteckenOld) = explode("=", $line);
+	}
 	if(strpos($line, "displaytagesgraph=") !== false) {
 		list(, $displaytagesgraphold) = explode("=", $line);
 	}
@@ -1271,10 +1274,13 @@ $(function() {
 		<b><label for="displaysleep">Display ausschalten nach x Sekunden:</label></b>
 	       	<input type="text" name="displaysleep" id="displaysleep" value="<?php echo $displaysleepold ?>"><br><br>
 	</div>
-
-
-
-
+	<div class="row">
+		<b><label for="displayEinBeimAnstecken">Display beim Einstecken des Fahrzeugs einschalten<br/><small>(f&uuml;r oben konfigurierte Dauer):</small></label></b>
+			<select type="text" name="displayEinBeimAnstecken" id="displayEinBeimAnstecken">
+ 			<option <?php if($displayEinBeimAnsteckenOld == 0) echo selected ?> value="0">Nein</option>
+  			<option <?php if($displayEinBeimAnsteckenOld == 1) echo selected ?> value="1">Ja</option>
+		</select><br>
+	</div>
 
 </div>
 

--- a/web/tools/savemisc.php
+++ b/web/tools/savemisc.php
@@ -242,6 +242,10 @@ foreach($lines as $line) {
 	    $result .= 'displaysleep='.$_POST[displaysleep]."\n";
 	    $writeit = '1';
 	    } 
+       if(strpos($line, "displayEinBeimAnstecken=") !== false) {
+		$result .= 'displayEinBeimAnstecken='.$_POST[displayEinBeimAnstecken]."\n";
+		$writeit = '1';
+		} 
 	   if(strpos($line, "displayaktiv=") !== false) {
 	    $result .= 'displayaktiv='.$_POST[displayaktiv]."\n";
 	    $writeit = '1';


### PR DESCRIPTION
After I've learned some minimal web development for the MQTT feature, I've now added the setting for the recently merged PR #253 to the "Misc" tab (Display section).

The should allow all users to enable the "Display on when plugged in" feature.