### PR TITLE
Giving client name to MQTT bulk publisher

### DIFF
--- a/runs/mqttpub.py
+++ b/runs/mqttpub.py
@@ -5,6 +5,7 @@ import sys
 import time
 import fileinput
 import argparse
+import os
 
 def main():
 
@@ -15,7 +16,7 @@ def main():
 
   args = parser.parse_args()
 
-  client = mqtt.Client()
+  client = mqtt.Client("openWB-python-bulkpublisher-" + str(os.getpid()))
   client.connect("localhost")
 
   for line in sys.stdin:


### PR DESCRIPTION
As part of [this forum discussion](https://openwb.de/forum/viewtopic.php?f=9&t=637&start=20) it was hard for me to identify whether the `mqttpub.py` script is actually submitting data.  
After some investigation it turned out that the script's connection look like
```
1575996586: New client connected from ::1 as 7c2933e8-b437-4385-9f53-20a82c1bf156 (c1, k60).
```
which is kind-of odd (nothing in this line points to the python script).

But paho-mqtt has the possibility to set the client name.

With this very simple PR I've used that possibility to send a client name made of the constant prefix
'openWB-python-bulkpublisher-' concatenated with the current process id. An approach pretty similar to what 'mosquitto_pub' seems to be doing.
On Mosquitto `mqttpub.py` connections will then look like
```
1576005746: New client connected from ::1 as openWB-python-bulkpublisher-11199 (c1, k60).
```