### PR TITLE
Adding openwb/system topic to bridge

### DIFF
--- a/web/tools/savemqtt.php
+++ b/web/tools/savemqtt.php
@@ -202,6 +202,9 @@ if ($exportStatus)
 # export global data to remote
 topic openWB/global/# out 2 "" $remotePrefix
 
+# export global data to remote
+topic openWB/system/# out 2 "" $remotePrefix
+
 # export all EVU data to remote
 topic openWB/evu/# out 2 "" $remotePrefix
 
@@ -242,12 +245,6 @@ EOS
 if ($subscribeConfigs)
 {
 	fwrite($configFile, <<<EOS
-# allow MQTT setting of main charge mode
-# 0 = Direct
-# 1 = Min + PV
-# 2 = PV only
-# 3 = Stop
-# 4 = Standby
 topic openWB/set/# in 2 "" $remotePrefix
 EOS
 	);


### PR DESCRIPTION
I had to notice that I missed out the openwb/system topics in bridge config.  
Hence timestamps are currently not available on remote MQTT server, making it impossible to track how up-to-date the retrieved data is.

To apply the change on an already configured bridge, after updating openWB, simply re-save the unmodified settings in "Settings -> MQTT" tab.

Additionally a wrong (left-over) comment for the set topic bridge setting has been removed.