### PR TITLE
Bugfix, cleanup and simplification.

### DIFF
--- a/modules/wr_fronius/main.sh
+++ b/modules/wr_fronius/main.sh
@@ -1,38 +1,32 @@
 #!/bin/bash
 
-#Auslesen eine Fronius Symo WR über die integrierte API des WR. Rückgabewert ist die aktuelle Wattleistung
+# Auslesen eine Fronius Symo WR über die integrierte API des WR. Rückgabewert ist die aktuelle Wirkleistung in [W].
 . /var/www/html/openWB/openwb.conf
 
-#pvwatttmp=$(curl --connect-timeout 5 -s $wrfroniusip/solar_api/v1/GetInverterRealtimeData.cgi?Scope=System)
-#pvwatt=$(echo $pvwatttmp | jq '.Body.Data.PAC.Values' | sed 's/.*://' | tr -d '\n' | sed 's/^.\{2\}//' | sed 's/.$//' )
-pvwatttmp=$(curl --connect-timeout 5 -s "$wrfroniusip/solar_api/v1/GetPowerFlowRealtimeData.fcgi?Scope?System")
-pvwatt=$(echo $pvwatttmp | jq '.Body.Data.Site.P_PV' |sed 's/\..*$//')
+pvwatttmp=$(curl --connect-timeout 3 -s "$wrfroniusip/solar_api/v1/GetPowerFlowRealtimeData.fcgi?Scope?System")
+pvwatt=$(echo $pvwatttmp | jq '.Body.Data.Site.P_PV' | sed 's/\..*$//')
 
-#wenn WR aus bzw. im standby (keine Antwort) ersetze leeren Wert durch eine 0
+# Wenn WR aus bzw. im Standby (keine Antwort), ersetze leeren Wert durch eine 0
 re='^-?[0-9]+$'
 if ! [[ $pvwatt =~ $re ]] ; then
    pvwatt="0"
 fi
 
+pvkwh=$(echo $pvwatttmp | jq '.Body.Data.Site.E_Total')
 
-pvwatttmp=$(curl --connect-timeout 5 -s $wrfroniusip/solar_api/v1/GetInverterRealtimeData.cgi?Scope=System)
-
-pvkwh=$(echo $pvwatttmp | jq '.Body.Data.TOTAL_ENERGY.Values' | sed '2!d' |sed 's/.*: //' )
-
-if [[ wrfronius2ip != "none" ]]; then
-	pv2watttmp=$(curl --connect-timeout 5 -s "$wrfronius2ip/solar_api/v1/GetPowerFlowRealtimeData.fcgi?Scope?System")
-	pv2watt=$(echo $pv2watttmp | jq '.Body.Data.Site.P_PV' |sed 's/\..*$//')
-	#wenn WR aus bzw. im standby (keine Antwort) ersetze leeren Wert durch eine 0
+if [[ $wrfronius2ip != "none" ]]; then
+	pv2watttmp=$(curl --connect-timeout 3 -s "$wrfronius2ip/solar_api/v1/GetPowerFlowRealtimeData.fcgi?Scope?System")
+	pv2watt=$(echo $pv2watttmp | jq '.Body.Data.Site.P_PV' | sed 's/\..*$//')
+	# Wenn WR aus bzw. im Standby (keine Antwort), ersetze leeren Wert durch eine 0
 	re='^-?[0-9]+$'
 	if ! [[ $pv2watt =~ $re ]] ; then
 	   pv2watt="0"
 	fi
 	pvwatt=$(echo "($pvwatt + $pv2watt) * -1" | bc)
 	echo $pvwatt
-	#zur weiteren verwendung im webinterface
+	# Zur weiteren Verwendung im Webinterface
 	echo $pvwatt > /var/www/html/openWB/ramdisk/pvwatt
-	pv2watttmp=$(curl --connect-timeout 5 -s $wrfronius2ip/solar_api/v1/GetInverterRealtimeData.cgi?Scope=System)
-	pv2kwh=$(echo $pvwatttmp | jq '.Body.Data.TOTAL_ENERGY.Values' | sed '2!d' |sed 's/.*: //' )
+	pv2kwh=$(echo $pvwatttmp | jq '.Body.Data.Site.E_Total')
 	pvgkwh=$(echo "$pvkwh + $pv2kwh" | bc)
 	if [[ $pvgkwh =~ $re ]] ; then
 		if (( pvgkwh > 0 )); then
@@ -42,12 +36,11 @@ if [[ wrfronius2ip != "none" ]]; then
 else
 	pvwatt=$(echo "$pvwatt * -1" | bc)
 	echo $pvwatt
-	#zur weiteren verwendung im webinterface
+	# Zur weiteren Verwendung im Webinterface
 	echo $pvwatt > /var/www/html/openWB/ramdisk/pvwatt
 	if [[ $pvkwh =~ $re ]] ; then
 		if (( pvkwh > 0 )); then
 			echo $pvkwh > /var/www/html/openWB/ramdisk/pvkwh
 		fi
 	fi
-
 fi

--- a/modules/wr_fronius/main.sh
+++ b/modules/wr_fronius/main.sh
@@ -31,6 +31,8 @@ if [[ $wrfronius2ip != "none" ]]; then
 	if [[ $pvgkwh =~ $re ]] ; then
 		if (( pvgkwh > 0 )); then
 			echo $pvgkwh > /var/www/html/openWB/ramdisk/pvkwh
+			pvkwhk=$(echo "scale=3; $pvgkwh / 1000" | bc)
+			echo $pvkwhk > /var/www/html/openWB/ramdisk/pvkwhk
 		fi
 	fi
 else
@@ -41,6 +43,8 @@ else
 	if [[ $pvkwh =~ $re ]] ; then
 		if (( pvkwh > 0 )); then
 			echo $pvkwh > /var/www/html/openWB/ramdisk/pvkwh
+			pvkwhk=$(echo "scale=3; $pvkwh / 1000" | bc)
+			echo $pvkwhk > /var/www/html/openWB/ramdisk/pvkwhk
 		fi
 	fi
 fi


### PR DESCRIPTION
Ein paar Änderungen am Skript für die Abfrage der PV-Leistung und des PV-Energiezählers.

**Bugfix:**
In "if [[ wrfronius2ip != "none" ]]; then" fehlte ein "$" vor "wrfronius2ip", was dazu geführt hat, dass immer der Zweig ausgeführt wurde, der eigentlich für das Vorhandensein von 2 Fronius Wechselrichtern gedacht war.

**Vereinfachung:**
Bei Fronius Wechselrichtern mit neuerer Firmware dauert die FastCGI-Abfrage von "$wrfroniusip/solar_api/v1/GetPowerFlowRealtimeData.fcgi?Scope?System" im Schnitt ca. 0.2 Sekunden, während die CGI-Abfrage von "$wrfroniusip/solar_api/v1/GetInverterRealtimeData.cgi?Scope=System" zwischen 1-2 Sekunden (manchmal noch länger) dauert.
Letztere ist aber (zumindest in meiner Konfiuguration mit einem Wechselrichter) gar nicht nötig, da die Gesamt-PV-Energie auch in der ersten Abfrage enthalten ist (dies bitte mal beim Vorhandensein mehrerer Wechselrichter prüfen, siehe auch die beiden Beispielausgaben unten).

Das Resultat (im Logfile "ramdisk/openWB.log")
- Vorher: ... "Zeit zum abfragen aller Werte 6 Sekunden" ...
- Nachher: ... "Zeit zum abfragen aller Werte 4 Sekunden" ...

Dies mag nicht nach einem riesigen Fortschritt klingen, allerdings sieht bei mir der (errechnete) Hausverbrauch bei schnellen Änderungen der PV-Leistung deutlich besser aus als vorher.

Die folgende Grafik veranschaulicht das Problem (hier hat die PV-Leistung aufgrund von Bewölkung wirklich stark geschwankt, der Hausverbrauch war aber nahezu konstant):
![IMG_2395](https://user-images.githubusercontent.com/1446989/71600700-78115000-2b50-11ea-8336-bac5c9abf656.png)

In diesem Zuge habe ich noch den Timeout von 5 Sekunden auf 3 Sekunden reduziert... wenn man 2 Wechselrichter hat und beide sind nicht erreichbar, dann würde das schon die normalerweise übliche Regelzeit von 10 Sekunden sprengen...

Ein Punkt der mir noch nicht ganz klar ist und der überprüft werden sollte:
Wenn für die Gesamtenergie nicht die der "Site", sondern die des einzelnen Wechselrichters benötigt wird, dann müsste in Zeile 15 und 29 jeweils "pvkwh=$(echo $pvwatttmp | jq '.Body.Data.Site.E_Total')" ersetzt werden durch "pvkwh=$(echo $pvwatttmp | jq '.Body.Data.Inverters.1.E_Total')" (bzw. da Zahlen bei der Decodierung des JSON-Strings soweit ich weiß nicht funktionieren, müsste hier die entsprechende Zeile z.B. mit "sed" geparst werden).



**Aufräumen:**
Auskommentierter Code wurde gelöscht und ein paar Kommentare wurden korrigiert .


**Ausgaben auf die beiden FastCGI- bzw. CGI-Requests:**
Nochmal zum Vergleich die Antwort auf ""$wrfroniusip/solar_api/v1/GetPowerFlowRealtimeData.fcgi?Scope?System":
```
{
   "Body" : {
      "Data" : {
         "Inverters" : {
            "1" : {
               "DT" : 232,
               "E_Day" : 10094,
               "E_Total" : 9016580,
               "E_Year" : 9016590,
               "P" : 334
            }
         },
         "SecondaryMeters" : {
            "16711681" : {
               "Category" : "METER_CAT_HEATPUMP",
               "Label" : "WÃ¤rmepumpe",
               "MLoc" : 256,
               "P" : -875.72000000000003
            }
         },
         "Site" : {
            "E_Day" : 10094,
            "E_Total" : 9016580,
            "E_Year" : 9016590,
            "Meter_Location" : "grid",
            "Mode" : "meter",
            "P_Akku" : null,
            "P_Grid" : 871.17999999999995,
            "P_Load" : -1205.1799999999998,
            "P_PV" : 334,
            "rel_Autonomy" : 27.713702517466277,
            "rel_SelfConsumption" : 100
         },
         "Version" : "12"
      }
   },
   "Head" : {
      "RequestArguments" : {},
      "Status" : {
         "Code" : 0,
         "Reason" : "",
         "UserMessage" : ""
      },
      "Timestamp" : "2019-12-30T15:21:56+01:00"
   }
}
```

... und hier die Antwort auf "$wrfroniusip/solar_api/v1/GetInverterRealtimeData.cgi?Scope=System":
```
{
   "Body" : {
      "Data" : {
         "DAY_ENERGY" : {
            "Unit" : "Wh",
            "Values" : {
               "1" : 10096
            }
         },
         "PAC" : {
            "Unit" : "W",
            "Values" : {
               "1" : 332
            }
         },
         "TOTAL_ENERGY" : {
            "Unit" : "Wh",
            "Values" : {
               "1" : 9016590
            }
         },
         "YEAR_ENERGY" : {
            "Unit" : "Wh",
            "Values" : {
               "1" : 9016592
            }
         }
      }
   },
   "Head" : {
      "RequestArguments" : {
         "DeviceClass" : "Inverter",
         "Scope" : "System"
      },
      "Status" : {
         "Code" : 0,
         "Reason" : "",
         "UserMessage" : ""
      },
      "Timestamp" : "2019-12-30T15:22:17+01:00"
   }
}
```