### PR TITLE
Fixed some missing spaces between value and unit in the standard theme.

### DIFF
--- a/web/themes/standard/index.html
+++ b/web/themes/standard/index.html
@@ -123,7 +123,7 @@ echo '
 		<span id="lp1enableddiv" class="fa" style="cursor: pointer;" onclick="lp1enabledclick()"></span><?php echo $lp1nameold ?><span id="plugstatlp1div"></span>
 	</div>
 	<div class="col-xs-4 text-center bg-primary" style="font-size: 2vw">
-		<span id="lldiv"></span>, <span id="llsolldiv"></span>A Soll
+		<span id="lldiv"></span>, <span id="llsolldiv"></span> A Soll
 	</div>
 	<div class="col-xs-2 text-center bg-primary" style="font-size: 2vw">
 		<span id="pluggedladungbishergeladendiv"></span> kWh
@@ -144,7 +144,7 @@ echo '
 	</div>
 
 	<div class="col-xs-4 text-center bg-primary" style="font-size: 2vw">
-		<span id="lllp2div"></span>,  <span id="llsolllp2div"></span>A Soll
+		<span id="lllp2div"></span>,  <span id="llsolllp2div"></span> A Soll
 	</div>
 	<div class="col-xs-2 text-center bg-primary" style="font-size: 2vw">
 		<span id="pluggedladungbishergeladenlp2div"></span> kWh
@@ -165,7 +165,7 @@ echo '
 	</div>
 
 	<div class="col-xs-4 text-center bg-primary" style="font-size: 2vw">
-		<span id="lllp3div"></span>, <span id="llsolllp3div"></span>A Soll<br></span>
+		<span id="lllp3div"></span>, <span id="llsolllp3div"></span> A Soll<br></span>
 	</div>
 	<div class="col-xs-2 text-center bg-primary" style="font-size: 2vw">
 		<span id="pluggedladungbishergeladenlp3div"></span> kWh
@@ -181,7 +181,7 @@ echo '
 	</div>
 
 	<div class="col-xs-4 text-center bg-primary" style="font-size: 2vw">
-		<span id="lllp4div"></span>, <span id="llsolllp4div"></span>A Soll<br></span>
+		<span id="lllp4div"></span>, <span id="llsolllp4div"></span> A Soll<br></span>
 	</div>
 	<div class="col-xs-2 text-center bg-primary" style="font-size: 2vw">
 		<span id="pluggedladungbishergeladenlp4div"></span> kWh
@@ -196,7 +196,7 @@ echo '
 	</div>
 
 	<div class="col-xs-4 text-center bg-primary" style="font-size: 2vw">
-		<span id="lllp5div"></span>, <span id="llsolllp5div"></span>A Soll<br></span>
+		<span id="lllp5div"></span>, <span id="llsolllp5div"></span> A Soll<br></span>
 	</div>
 	<div class="col-xs-2 text-center bg-primary" style="font-size: 2vw">
 		<span id="pluggedladungbishergeladenlp5div"></span> kWh
@@ -211,7 +211,7 @@ echo '
 	</div>
 
 	<div class="col-xs-4 text-center bg-primary" style="font-size: 2vw">
-		<span id="lllp6div"></span>, <span id="llsolllp6div"></span>A Soll<br></span>
+		<span id="lllp6div"></span>, <span id="llsolllp6div"></span> A Soll<br></span>
 	</div>
 	<div class="col-xs-2 text-center bg-primary" style="font-size: 2vw">
 		<span id="pluggedladungbishergeladenlp6div"></span> kWh
@@ -226,7 +226,7 @@ echo '
 	</div>
 
 	<div class="col-xs-4 text-center bg-primary" style="font-size: 2vw">
-		<span id="lllp7div"></span>, <span id="llsolllp7div"></span>A Soll<br></span>
+		<span id="lllp7div"></span>, <span id="llsolllp7div"></span> A Soll<br></span>
 	</div>
 	<div class="col-xs-2 text-center bg-primary" style="font-size: 2vw">
 		<span id="pluggedladungbishergeladenlp7div"></span> kWh
@@ -241,7 +241,7 @@ echo '
 	</div>
 
 	<div class="col-xs-4 text-center bg-primary" style="font-size: 2vw">
-		<span id="lllp8div"></span>, <span id="llsolllp8div"></span>A Soll<br></span>
+		<span id="lllp8div"></span>, <span id="llsolllp8div"></span> A Soll<br></span>
 	</div>
 	<div class="col-xs-2 text-center bg-primary" style="font-size: 2vw">
 		<span id="pluggedladungbishergeladenlp8div"></span> kWh
@@ -333,24 +333,24 @@ echo '
 	</div>
 	<div class="row" style="font-size: 2vw">
 		<div class="col-xs-4 text-center">
-			<span id="gelrlp1div"></span>km
+			<span id="gelrlp1div"></span> km
 		</div>
 		<div id="ladepunkts111div" class="col-xs-4 text-center">
-			<span id="gelrlp2div"></span>km
+			<span id="gelrlp2div"></span> km
 		</div>
 		<div id="ladepunkts222div" class="col-xs-4 text-center">
-			<span id="gelrlp3div"></span>km
+			<span id="gelrlp3div"></span> km
 		</div>
 	</div>
 	<div class="row" style="font-size: 2vw">
 		<div class="col-xs-4 text-center">
-			<span id="aktgeladendiv"></span>kWh
+			<span id="aktgeladendiv"></span> kWh
 		</div>
 		<div id="ladepunkts1111div" class="col-xs-4 text-center">
-			<span id="aktgeladens1div"></span>kWh
+			<span id="aktgeladens1div"></span> kWh
 		</div>
 		<div id="ladepunkts2222div" class="col-xs-4 text-center">
-			<span id="aktgeladens2div"></span>kWh
+			<span id="aktgeladens2div"></span> kWh
 		</div>
 	</div>
 	<div id="heutegeladendiv">


### PR DESCRIPTION
Ich wollte eigentlich nur die fehlenden Leerzeichen zwischen den Werten und der zugehörigen Einheit korrigieren und war etwas erschlagen von den vielen Ergebnissen in meiner Suche nach "A Soll" im Repository.

Wenn ich das überall korrigieren möchte, muss ich offenbar die folgenden Dateien anfassen:
- web/simplemode.html
- web/themes/standard/index.html
- web/display/index.html
- web/display/standard.html
- web/themes/dark19_01/index.html
- web/themes/dark_gauges_1/index.html

Sehe ich das richtig? Oder werden die Dateien automatisch erzeugt und es gibt irgendwo eine Art "Template"?
Ich habe es jetzt erst mal nur in "web/themes/standard/index.html" angepasst, weil es so in meiner meistgenutzten Ansicht korrekt angezeigt wird...