### PR TITLE
Change installer to raspbian buster

### DIFF
--- a/openwb-install.sh
+++ b/openwb-install.sh
@@ -37,11 +37,11 @@ if ! [ -x "$(command -v apachectl)" ]; then
 	sleep 1
 	apt-get -qq install -y php-gd
 	sleep 1
-	apt-get -qq install -y php7.0-xml
+	apt-get -qq install -y php7.3-xml
 	sleep 2
         apt-get -qq install -y php-curl
 	sleep 1	
-	apt-get -qq install -y libapache2-mod-php7.0
+	apt-get -qq install -y libapache2-mod-php7.3
 	sleep 2
 	apt-get -qq install -y jq
 	sleep 2
@@ -139,16 +139,17 @@ fi
 
 
 echo "disable cronjob logging"
-if grep -Fxq "EXTRA_OPTS="-L 0"" /etc/default/cron
+if grep -Fxq 'EXTRA_OPTS="-L 0"' /etc/default/cron
 then
 	echo "...ok"
 else
-	echo "EXTRA_OPTS="-L 0"" >> /etc/default/cron
+	echo 'EXTRA_OPTS="-L 0"' >> /etc/default/cron
 fi
-sudo /bin/su -c "echo 'upload_max_filesize = 30M' > /etc/php/7.0/apache2/conf.d/20-uploadlimit.ini"
+sudo /bin/su -c "echo 'upload_max_filesize = 30M' > /etc/php/7.3/apache2/conf.d/20-uploadlimit.ini"
 sudo apt-get -qq install -y python-pip
 sudo pip install  -U pymodbus
-echo "www-data ALL=(ALL) NOPASSWD: ALL" >> /etc/sudoers.d/010_pi-nopasswd
+echo "www-data ALL=(ALL) NOPASSWD: ALL" > /etc/sudoers.d/010_www-data-nopassed
+chmod 440 /etc/sudoers.d/010_www-data-nopasswd
 
 chmod 777 /var/www/html/openWB/openwb.conf
 chmod +x /var/www/html/openWB/modules/*                     


### PR DESCRIPTION
Aktuelles Image auf [Raspberrypi.org](https://www.raspberrypi.org/downloads/raspbian/) ist Buster.
Installer sollte dafür funktionieren.
Auto-magischer Fallback auf PHP 7.0 bei Erkennen von (hier Name des entsprechenden Releases) kann ich auf Wunsch einbauen