### PR TITLE
Scope request fix in bezug_fronius_sm

### DIFF
--- a/modules/bezug_fronius_sm/main.sh
+++ b/modules/bezug_fronius_sm/main.sh
@@ -36,7 +36,7 @@ if [[ $meter_location != "1" ]]; then
 # ... ansonsten, wenn das SmartMeter im Verbrauchszweig sitzt, kombiniere dessen Werte mit denen des Wechselrichters.
 else
     # Lese die aktuelle PV-Leistung des Wechselrichters ein.
-    response_fi=$(curl --connect-timeout 3 -s "$wrfroniusip/solar_api/v1/GetPowerFlowRealtimeData.fcgi?Scope?System")
+    response_fi=$(curl --connect-timeout 3 -s "$wrfroniusip/solar_api/v1/GetPowerFlowRealtimeData.fcgi?Scope=System")
     pvwatt=$(echo $response_fi | jq '.Body.Data.Site.P_PV' | sed 's/\..*$//')
     # Wenn WR aus bzw. im Standby (keine Antwort), ersetze leeren Wert durch eine 0.
     re='^-?[0-9]+$'


### PR DESCRIPTION
Even with "?" it was working as the parser in the frequency inverter seems to be tolerant here, but the correct request is with "=".

Sorry for creating two pull requests regarding this "problem", but I have done it directly on GitHub via the edit-function in the browser.