### PR TITLE
Send RFID tag ID via MQTT

### DIFF
--- a/loadvars.sh
+++ b/loadvars.sh
@@ -1074,9 +1074,35 @@ if [[ "$oawattarmaxprice" != "$awattarmaxprice" ]]; then
 	tempPubList="${tempPubList}\nopenWB/global/awattar/MaxPriceForCharging=${awattarmaxprice}"
 	echo $awattarmaxprice > ramdisk/mqttawattarmaxprice
 fi
+
+
+# publish last RFID scans as CSV with timestamp
+timestamp="$(date +%s)"
+
+orfidlp1=$(<ramdisk/mqttrfidlp1)
+arfidlp1=$(<ramdisk/rfidlp1)
+if [[ "$orfidlp1" != "$arfidlp1" ]]; then
+	tempPubList="${tempPubList}\nopenWB/lp/1/lastRfId=${arfidlp1},${timestamp}"
+	echo $arfidlp1 > ramdisk/mqttrfidlp1
+fi
+
+orfidlp2=$(<ramdisk/mqttrfidlp2)
+arfidlp2=$(<ramdisk/rfidlp2)
+if [[ "$orfidlp2" != "$arfidlp2" ]]; then
+	tempPubList="${tempPubList}\nopenWB/lp/2/lastRfId=${arfidlp2},${timestamp}"
+	echo $arfidlp2 > ramdisk/mqttrfidlp2
+fi
+
+orfidlast=$(<ramdisk/mqttrfidlasttag)
+arfidlast=$(<ramdisk/rfidlasttag)
+if [[ "$orfidlast" != "$arfidlast" ]]; then
+	tempPubList="${tempPubList}\nopenWB/system/lastRfId=${arfidlast},${timestamp}"
+	echo $arfidlast > ramdisk/mqttrfidlasttag
+fi
+
 tempPubList="${tempPubList}\nopenWB/system/Uptime=$(uptime)"
 tempPubList="${tempPubList}\nopenWB/system/Date=$(date)"
-tempPubList="${tempPubList}\nopenWB/system/Timestamp=$(date +%s)"
+tempPubList="${tempPubList}\nopenWB/system/Timestamp=${timestamp}"
 
 echo -e $tempPubList | python3 runs/mqttpub.py -q 0 -r &
 

--- a/runs/atreboot.sh
+++ b/runs/atreboot.sh
@@ -78,8 +78,11 @@ echo 0 > /var/www/html/openWB/ramdisk/progevsedinlp22000
 echo 0 > /var/www/html/openWB/ramdisk/progevsedinlp22007
 echo 0 > /var/www/html/openWB/ramdisk/readtag
 echo 0 > /var/www/html/openWB/ramdisk/rfidlp1
+echo 0 > /var/www/html/openWB/ramdisk/mqttrfidlp1
 echo 0 > /var/www/html/openWB/ramdisk/rfidlp2
+echo 0 > /var/www/html/openWB/ramdisk/mqttrfidlp2
 echo 0 > /var/www/html/openWB/ramdisk/rfidlasttag
+echo 0 > /var/www/html/openWB/ramdisk/mqttrfidlasttag
 echo 1 > /var/www/html/openWB/ramdisk/reloaddisplay
 echo 0 > /var/www/html/openWB/ramdisk/ledstatus
 echo 1 > /var/www/html/openWB/ramdisk/execdisplay


### PR DESCRIPTION
I have a very specific use-case for which it is very helpful to get the RFID tag ID via MQTT together with the (approximate +- control interval) timestamp when that ID has been scanned. The timestamp is exactly the same as reported via `openWB/system/Timestamp`.

I'd therefore highly appreciate if this PR could be accepted.

Topics added are:
```
openWB/lp/1/lastRfId=${arfidlp1},${timestamp}
openWB/lp/2/lastRfId=${arfidlp2},${timestamp}
openWB/system/lastRfId=${arfidlast},${timestamp}
```

`atreboot.sh` has been extended to add to the ramdisk the "mqttrfid*" topics matching the "rfid*" topics.

Anything else I need to add?