### PR TITLE
Subscribe to MQTT set topics with QoS 2 and always the same client ID

### DIFF
--- a/runs/mqttsub.py
+++ b/runs/mqttsub.py
@@ -21,13 +21,21 @@ def replaceAll(changeval,newval):
         time.sleep(0.1)
         inaction=0
 
+def getserial():
+    # Extract serial from cpuinfo file
+    with open('/proc/cpuinfo','r') as f:
+        for line in f:
+            if line[0:6] == 'Serial':
+                return line[10:26]
+        return "0000000000000000"
+
 mqtt_broker_ip = "localhost"
-client = mqtt.Client()
+client = mqtt.Client("openWB-mqttsub-" + getserial())
 
 # connect to broker and subscribe to set topics
 def on_connect(client, userdata, flags, rc):
     #subscribe to all set topics
-    client.subscribe("openWB/set/#")
+    client.subscribe("openWB/set/#", 2)
 # handle each set topic
 def on_message(client, userdata, msg):
     if (msg.topic == "openWB/set/graph/RequestLiveGraph"):


### PR DESCRIPTION
**As mentioned in [this forum post](https://openwb.de/forum/viewtopic.php?f=4&t=833#p6866) I think it would be beneficial to subscribe the MQTT set topics with QoS 2 (ExactlyOnce) and always the same client ID.**   
This will allow the MQTT server to do its best to provide all latest values to openWB even though server or client got restarted and/or connections (re-)established.

The correponding changes required are included in this PR.

**To be safe and prepared for any kinds of setups where multiple openWB might subscribe to a single MQTT server (even though such setups do not exist atm) the RASPI CPU serial number is included with the client ID.**  
This will result in always the same ID while ensuring that subscriptions of multiple, different, openWBs to the same MQTT server could be unambiguously distinguished (as long as they have different RASPIs).

If you think this is not needed or not useful, feel free to just close this PR without merging.

**The code has been tested carefully on my openWB ser 2.**  
Settings are performed and GUI is working seamless. I didn't see any problems with the change.