### PR TITLE
Allow setting of minimum and maximum charge current via MQTT

### DIFF
--- a/runs/mqttsub.py
+++ b/runs/mqttsub.py
@@ -298,6 +298,13 @@ def on_message(client, userdata, msg):
         if (int(msg.payload) >= 0 and int(msg.payload) <=100):
             replaceAll("lademkwhlp5=",msg.payload.decode("utf-8"))
 
+    if (msg.topic == "openWB/set/directChargeMinCurrent"):
+        if (int(msg.payload) >= 6 and int(msg.payload) <= 32):
+            replaceAll("minimalstromstaerke=",msg.payload.decode("utf-8"))
+    if (msg.topic == "openWB/set/directChargeMaxCurrent"):
+        if (int(msg.payload) >= 6 and int(msg.payload) <= 32):
+            replaceAll("maximalstromstaerke=",msg.payload.decode("utf-8"))
+
     if (msg.topic == "openWB/set/lp6/kWhDirectChargeToCharge"):
         if (int(msg.payload) >= 0 and int(msg.payload) <=100):
             replaceAll("lademkwhlp6=",msg.payload.decode("utf-8"))


### PR DESCRIPTION
I'd like to be able to set minimum and maximum charge current via MQTT.

New MQTT set topics:
* `openWB/set/directChargeMinCurrent`
* `openWB/set/directChargeMaxCurrent`

When published, it will change corresponding `openwb.conf` parameters
* `minimalstromstaerke`
* `maximalstromstaerke`
