### PR TITLE
Kostal smart energy meter Bezugsmodul

### DIFF
--- a/modules/bezug_ksem/main.sh
+++ b/modules/bezug_ksem/main.sh
@@ -1,0 +1,6 @@
+#!/bin/bash
+. /var/www/html/openWB/openwb.conf
+sudo python /var/www/html/openWB/modules/bezug_ksem/readksem.py $ksemip
+
+wattbezug=$(</var/www/html/openWB/ramdisk/wattbezug)
+echo $wattbezug

--- a/modules/bezug_ksem/readksem.py
+++ b/modules/bezug_ksem/readksem.py
@@ -1,0 +1,102 @@
+#!/usr/bin/python
+import sys
+import os
+import time
+import getopt
+import struct
+from pymodbus.client.sync import ModbusTcpClient
+from pymodbus.constants import Endian
+from pymodbus.payload import BinaryPayloadDecoder
+
+class KSEM:
+    def __init__(self, ip):
+        self.client = ModbusTcpClient(ip, port="502")
+        self.client.connect()
+
+    def ReadUInt32(self,addr):
+        data=self.client.read_holding_registers(addr, 2, unit=71)
+        UInt32register = BinaryPayloadDecoder.fromRegisters(data.registers, byteorder=Endian.Big, wordorder=Endian.Big)
+        result = UInt32register.decode_32bit_uint()
+        return(result)
+
+    def ReadInt32(self,addr):
+        data=self.client.read_holding_registers(addr, 2, unit=71)
+        Int32register = BinaryPayloadDecoder.fromRegisters(data.registers, byteorder=Endian.Big, wordorder=Endian.Big)
+        result = Int32register.decode_32bit_int()
+        return(result)
+
+    def ReadUInt64(self,addr):
+        data=self.client.read_holding_registers(addr,4,unit=71)
+        UInt64register = BinaryPayloadDecoder.fromRegisters(data.registers, byteorder=Endian.Big, wordorder=Endian.Big)
+        result = UInt64register.decode_64bit_uint()
+        return(result)
+
+    def write(self, filename, value):
+        # print(filename + ": " + str(value))
+        f = open(filename, 'w')
+        f.write(str(value))
+        f.close
+        
+    def run(self):
+        voltage1 = self.ReadUInt32(62) * 0.001
+        self.write('/var/www/html/openWB/ramdisk/evuv1', voltage1)
+
+        voltage2 = self.ReadUInt32(102) * 0.001
+        self.write('/var/www/html/openWB/ramdisk/evuv2', voltage2)
+
+        voltage3 = self.ReadUInt32(142) * 0.001
+        self.write('/var/www/html/openWB/ramdisk/evuv3', voltage3)
+
+        bezugkwh = self.ReadUInt64(512) * 0.1 * 0.001
+        self.write('/var/www/html/openWB/ramdisk/bezugkwh', bezugkwh)
+
+        bezugw1p = self.ReadUInt32(40) * 0.1
+        bezugw1m = self.ReadUInt32(42) * 0.1
+        bezugw1 = bezugw1p if bezugw1p >= bezugw1m else -bezugw1m
+        self.write('/var/www/html/openWB/ramdisk/bezugw1', bezugw1)
+
+        bezugw2p = self.ReadUInt32(80) * 0.1
+        bezugw2m = self.ReadUInt32(82) * 0.1
+        bezugw2 = bezugw2p if bezugw2p >= bezugw2m else -bezugw2m
+        self.write('/var/www/html/openWB/ramdisk/bezugw2', bezugw2)
+
+        bezugw3p = self.ReadUInt32(120) * 0.1
+        bezugw3m = self.ReadUInt32(122) * 0.1
+        bezugw3 = bezugw3p if bezugw3p >= bezugw3m else -bezugw3m
+        self.write('/var/www/html/openWB/ramdisk/bezugw3', bezugw3)
+
+        bezuga1 = self.ReadUInt32(60) * 0.001
+        self.write('/var/www/html/openWB/ramdisk/bezuga1', bezuga1)
+
+        bezuga2 = self.ReadUInt32(100) * 0.001
+        self.write('/var/www/html/openWB/ramdisk/bezuga2', bezuga2)
+
+        bezuga3 = self.ReadUInt32(140) * 0.001
+        self.write('/var/www/html/openWB/ramdisk/bezuga3', bezuga3)
+
+        wattbezugp = self.ReadUInt32(0) * 0.1
+        wattbezugm = self.ReadUInt32(2) * 0.1
+        wattbezug = wattbezugp if wattbezugp >= wattbezugm else -wattbezugm
+        self.write('/var/www/html/openWB/ramdisk/wattbezug', wattbezug)
+
+        einspeisungkwh = self.ReadUInt64(516) * 0.1 * 0.001
+        self.write('/var/www/html/openWB/ramdisk/einspeisungkwh', einspeisungkwh)
+
+        evuhz = self.ReadUInt32(26) * 0.001
+        self.write('/var/www/html/openWB/ramdisk/evuhz', evuhz)
+
+        evupf1 = self.ReadInt32(64) * 0.001
+        self.write('/var/www/html/openWB/ramdisk/evupf1', evupf1)
+
+        evupf2 = self.ReadInt32(104) * 0.001
+        self.write('/var/www/html/openWB/ramdisk/evupf2', evupf2)
+
+        evupf3 = self.ReadInt32(144) * 0.001
+        self.write('/var/www/html/openWB/ramdisk/evupf3', evupf3)
+
+def main(argv=None):
+    runner = KSEM(argv[1])
+    runner.run()
+
+if __name__ == "__main__":
+    main(sys.argv)

--- a/runs/atreboot.sh
+++ b/runs/atreboot.sh
@@ -2161,6 +2161,10 @@ if ! grep -Fq "discovergypvid=" /var/www/html/openWB/openwb.conf
 then
 	echo "discovergypvid=idesmeters" >> /var/www/html/openWB/openwb.conf
 fi
+if ! grep -Fq "ksemip=" /var/www/html/openWB/openwb.conf
+then
+        echo "ksemip=ipdesmeters" >> /var/www/html/openWB/openwb.conf
+fi
 if ! grep -Fq "mollp1moab=" /var/www/html/openWB/openwb.conf
 then
 	echo "mollp1moab=06:00" >> /var/www/html/openWB/openwb.conf

--- a/web/settings/modulconfig.php
+++ b/web/settings/modulconfig.php
@@ -220,6 +220,9 @@
 				if(strpos($line, "discovergypvid=") !== false) {
 					list(, $discovergypvidold) = explode("=", $line);
 				}
+				if(strpos($line, "ksemip=") !== false) {
+                                        list(, $ksemipold) = explode("=", $line);
+                                }
 
 				if(strpos($line, "solarview_hostname=") !== false) {
 					list(, $solarview_hostnameold) = explode("=", $line);
@@ -3399,6 +3402,7 @@
 							<option <?php if($wattbezugmodulold == "bezug_sbs25\n") echo "selected" ?> value="bezug_sbs25">SMA SBS2.5 Speicher</option>
 							<option <?php if($wattbezugmodulold == "bezug_kostalplenticoreem300haus\n") echo "selected" ?> value="bezug_kostalplenticoreem300haus">Kostal Plenticore mit EM300/KSEM</option>
 							<option <?php if($wattbezugmodulold == "bezug_kostalpiko\n") echo "selected" ?> value="bezug_kostalpiko">Kostal Piko mit Energy Meter</option>
+							<option <?php if($wattbezugmodulold == "bezug_ksem\n") echo selected ?> value="bezug_ksem">Kostal Smart Energy Meter oder TQ EM410</option>
 							<option <?php if($wattbezugmodulold == "bezug_smartfox\n") echo "selected" ?> value="bezug_smartfox">Smartfox</option>
 							<option <?php if($wattbezugmodulold == "bezug_powerwall\n") echo "selected" ?> value="bezug_powerwall">Tesla Powerwall</option>
 							<option <?php if($wattbezugmodulold == "bezug_victrongx\n") echo "selected" ?> value="bezug_victrongx">Victron (z.B. GX)</option>
@@ -3489,6 +3493,12 @@
 							Gültige Werte ID. Um die ID herauszufinden mit dem Browser die Adresse "https://api.discovergy.com/public/v1/meters" aufrufen und dort Benutzername und Passwort eingeben. Hier wird nun u.a. die ID des Zählers angezeigt.
 						</div>
 					</div>
+					<div id="wattbezugkostalsmartenergymeter">
+                                                <div class="row" style="background-color:#febebe">
+                                                        <b><label for="ksemip">Kostal Smart Energy Meter / TQ EM410 - IP Adresse:</label></b>
+                                                        <input type="text" name="ksemip" id="ksemip" value="<?php echo $ksemipold ?>"><br>
+                                                </div>
+                                        </div>
 					<div id="wattbezugkostalpiko">
 						<div class="row" style="background-color:#febebe">
 							IP Adresse wird im PV Modul konfiguriert. Angeschlossenes Meter erforderlich. Der WR liefert Werte nur solange er auch PV Leistung liefert. Nachts geht er in den Standby.<br>
@@ -3848,6 +3858,7 @@
 							$('#wattbezugethmpm3pm').hide();
 							$('#wattbezugplentihaus').hide();
 							$('#wattbezugkostalpiko').hide();
+							$('#wattbezugkostalsmartenergymeter').hide();
 							$('#wattbezugsmartfox').hide();
 							$('#wattbezugpowerwall').hide();
 							$('#wattbezugvictrongx').hide();
@@ -3938,6 +3949,9 @@
 							if($('#wattbezugmodul').val() == 'bezug_kostalpiko')   {
 								$('#wattbezugkostalpiko').show();
 							}
+							if($('#wattbezugmodul').val() == 'bezug_ksem')   {
+                                                                $('#wattbezugkostalsmartenergymeter').show();
+                                                        }
 							if($('#wattbezugmodul').val() == 'bezug_smartfox')   {
 								$('#wattbezugsmartfox').show();
 							}

--- a/web/tools/savemodul.php
+++ b/web/tools/savemodul.php
@@ -1327,6 +1327,10 @@ if(isset($_POST['evsecon'])) {
 			$result .= 'discovergypvid='.$_POST['discovergypvid']."\n";
 			$writeit = '1';
 		}
+		if(strpos($line, "ksemip=") !== false) {
+                	$result .= 'ksemip='.$_POST[ksemip]."\n";
+                	$writeit = '1';
+        	}
 
 		if ( $writeit == '0') {
 			$result .= $line;


### PR DESCRIPTION
Support für den Kostal Smart Energy Meter respektive TQ EM410. Zur Zeit wird der KSEM nur zusammen mit Kostal Plenticore und Piko IQ unterstützt. Zusammen mit dem Piko (ohne IQ) wird dieser nicht unterstützt. Da die Daten nicht an den Wechselrichter gesendet werden, können die Informationen auch nicht vom WR ausgelesen werden.

Diese Implementation unterstützt das direkte auslesen der KSEM über Modbus TCP. Vermutlich wird auch der TQ EM300 unterstützt.