### PR TITLE
Ladeleistung-Anzeige verschoben

### DIFF
--- a/web/themes/dark19_01/processAllMqttMsg.js
+++ b/web/themes/dark19_01/processAllMqttMsg.js
@@ -613,11 +613,9 @@ function processLpMessages(mqttmsg, mqttpayload) {
 			}
 		}
 		if ( isAnyEvPlugged ) {
-			console.log("is plugged");
 			$("#powerAllLpspan").show();
 			$("#powerAllLpInactivespan").hide();
 		} else {
-			console.log("is not plugged");
 			$("#powerAllLpspan").hide();
 			$("#powerAllLpInactivespan").text("0 W");
 			$("#powerAllLpInactivespan").show();

--- a/web/themes/dark19_01/processAllMqttMsg.js
+++ b/web/themes/dark19_01/processAllMqttMsg.js
@@ -603,22 +603,24 @@ function processLpMessages(mqttmsg, mqttpayload) {
 			$("#targetCurrentLp" + index + "span").hide();
 			$("#actualPowerTargetCurrentUnpluggedLp" + index + "span").text("- / -");
 			$("#actualPowerTargetCurrentUnpluggedLp" + index + "span").show();
-			var isAnyEvPlugged = false;
-			// show total values only if ev is/are plugged
-			for ( index = 1; index <= 8; index++) {
-				if ( $("#plugstatlp" + index + "div").is(':visible') ) {
-					isAnyEvPlugged = true;
-					break;
-				}
+		}
+		var isAnyEvPlugged = false;
+		// show total values only if ev is/are plugged
+		for ( index = 1; index <= 8; index++) {
+			if ( $("#plugstatlp" + index + "div").is(':visible') ) {
+				isAnyEvPlugged = true;
+				break;
 			}
-			if ( isAnyEvPlugged ) {
-				$("#powerAllLpspan").show();
-				$("#powerAllLpInactivespan").hide();
-			} else {
-				$("#powerAllLpspan").hide();
-				$("#powerAllLpInactivespan").text("-");
-				$("#powerAllLpInactivespan").show();
-			}
+		}
+		if ( isAnyEvPlugged ) {
+			console.log("is plugged");
+			$("#powerAllLpspan").show();
+			$("#powerAllLpInactivespan").hide();
+		} else {
+			console.log("is not plugged");
+			$("#powerAllLpspan").hide();
+			$("#powerAllLpInactivespan").text("0 W");
+			$("#powerAllLpInactivespan").show();
 		}
 	}
 	else if ( mqttmsg.match( /^openwb\/lp\/[1-9][0-9]*\/boolchargestat$/i ) ) {

--- a/web/themes/dark19_01/theme.php
+++ b/web/themes/dark19_01/theme.php
@@ -128,11 +128,9 @@ EXTDEVICEDIVMIDDLE;
 			}  // end if hook configured
 		?>
 
-		<br>
-
 		<!-- interactive chart.js -->
 		<!-- will be refreshed using MQTT (in live.js)-->
-		<div class="row justify-content-center mb-2" id="thegraph">
+		<div class="row justify-content-center my-2" id="thegraph">
 			<div class="col-sm-12" style="height: 350px; text-align: center;">
 				<div id="waitforgraphloadingdiv">
 					Graph lädt, bitte warten...

--- a/web/themes/dark19_01/theme.php
+++ b/web/themes/dark19_01/theme.php
@@ -83,15 +83,21 @@
 		</div>
 
 		<?php
+			echo '<div class="row justify-content-center">';
+
 			if ( $hausverbrauchstatold == 1 ) {
 echo <<<HAUSVERBRAUCHDIV
-			<div class="row justify-content-center">
-				<div class="col-sm-12 pvInfoStyle" style="background-color:#fefedf;">
+				<div class="col-sm-6 pvInfoStyle" style="background-color:#fefedf;">
 					Hausverbrauch: <span id="hausverbrauchdiv">0 W</span>
 				</div>
-			</div>
+				<div class="col-sm-6 pvInfoStyle" style="background-color:#d0d7e6;">
 HAUSVERBRAUCHDIV;
+			} else {
+				echo '<div class="col-sm-12 pvInfoStyle" style="background-color:#d0d7e6;">';
 			}
+			echo 'Ladeleistung: <span id="powerAllLpspan" style="display: none;">lade Daten</span><span id="powerAllLpInactivespan">lade Daten</span>';
+			echo '    </div>';
+			echo '</div>';
 			// if speichermodul is not "none", show the info
 			if ( strcmp(trim($speicherstatold),"none") != 0 ) {
 echo <<<SPEICHERDIV
@@ -195,13 +201,6 @@ EXTDEVICEDIVMIDDLE;
 				echo '            </div>'."\n";
 				echo '        </div>'."\n\n";
 				echo '        ';
-			}
-			if ( $countLpConfigured > 1 ) {
-				echo '        <div id="powerAllLpdiv" class="row justify-content-center">';
-				echo '            <div class="col-sm-5 chargePointInfoStyle">';
-				echo '                Gesamt-Ladeleistung: <span id="powerAllLpspan" style="display: none;">lade Daten</span><span id="powerAllLpInactivespan">lade Daten</span>';
-				echo '            </div>';
-				echo '        </div>';
 			}
 		?>
 


### PR DESCRIPTION
Dark-Theme: Anzeige "Gesamt-Ladeleistung" verschoben vom Block "LP-Anzeige" in den oberen Block der aktuellen Werte. Erscheint entweder anstelle der Zeile Hausverbrauch (wenn diese ausgeschaltet) oder daneben.