### PR TITLE
Allow lower Schieflast values

### DIFF
--- a/web/settings/settings.php
+++ b/web/settings/settings.php
@@ -949,6 +949,12 @@
 							<div class="col">
 								<b>Schieflastbegrenzung in A:</b>
 								<select name="schieflastmaxa" id="schieflastmaxa">
+									<option <?php if($schieflastmaxaold == 10) echo "selected" ?> value="10">10</option>
+									<option <?php if($schieflastmaxaold == 11) echo "selected" ?> value="11">11</option>
+									<option <?php if($schieflastmaxaold == 12) echo "selected" ?> value="12">12</option>
+									<option <?php if($schieflastmaxaold == 13) echo "selected" ?> value="13">13</option>
+									<option <?php if($schieflastmaxaold == 14) echo "selected" ?> value="14">14</option>
+									<option <?php if($schieflastmaxaold == 15) echo "selected" ?> value="15">15</option>
 									<option <?php if($schieflastmaxaold == 16) echo "selected" ?> value="16">16</option>
 									<option <?php if($schieflastmaxaold == 17) echo "selected" ?> value="17">17</option>
 									<option <?php if($schieflastmaxaold == 18) echo "selected" ?> value="18">18</option>


### PR DESCRIPTION
Extended list of Schieflast values down to 10A.

This makes sense if the car only supports charging with 2 Phases. e.g. VW e-golf. In this case one may want to switch from 1 to 3 phase at a lower current than 16A. E.g. After 1 Phase 11A it shall change to 2 Phase 6A instead of going to 1 Phase 12A.