### PR TITLE
Allow running openwb an a webserver accessed by https

### DIFF
--- a/web/live.js
+++ b/web/live.js
@@ -879,8 +879,10 @@ client.onMessageArrived = function (message) {
 var retries = 0;
 
 //Connect Options
+var isSSL = location.protocol == 'https:';
 var options = {
 	timeout: 5,
+	useSSL: isSSL,
 	//Gets Called if the connection has sucessfully been established
 	onSuccess: function () {
 		retries = 0;

--- a/web/logging/dailychart.js
+++ b/web/logging/dailychart.js
@@ -123,8 +123,10 @@ client.onMessageArrived = function (message) {
 var retries = 0;
 
 //Connect Options
+var isSSL = location.protocol == 'https:';
 var options = {
 	timeout: 5,
+	useSSL: isSSL,
 	//Gets Called if the connection has sucessfully been established
 	onSuccess: function () {
 		retries = 0;

--- a/web/logging/monthlychart.js
+++ b/web/logging/monthlychart.js
@@ -83,8 +83,10 @@ client.onMessageArrived = function (message) {
 var retries = 0;
 
 //Connect Options
+var isSSL = location.protocol == 'https:';
 var options = {
 	timeout: 5,
+	useSSL: isSSL,
 	//Gets Called if the connection has sucessfully been established
 	onSuccess: function () {
 		retries = 0;

--- a/web/settings/setupMqttServices.js
+++ b/web/settings/setupMqttServices.js
@@ -29,8 +29,10 @@ var topicsToSubscribe = [
 ];
 
 //Connect Options
+var isSSL = location.protocol == 'https:'
 var options = {
 	timeout: 5,
+	useSSL: isSSL,
 	//Gets Called if the connection has sucessfully been established
 	onSuccess: function () {
 		topicsToSubscribe.forEach((topic) => {

--- a/web/themes/dark19_01/setupMqttServices.js
+++ b/web/themes/dark19_01/setupMqttServices.js
@@ -51,8 +51,10 @@ var topicsToSubscribe = [
 var retries = 0;
 
 //Connect Options
+var isSSL = location.protocol == 'https:'
 var options = {
 	timeout: 5,
+	useSSL: isSSL,
 	//Gets Called if the connection has sucessfully been established
 	onSuccess: function () {
 		retries = 0;

--- a/web/themes/dark_gauges/processAllMqttMsg.js
+++ b/web/themes/dark_gauges/processAllMqttMsg.js
@@ -1031,8 +1031,10 @@ client.onMessageArrived = function (message) {
 var retries = 0;
 
 //Connect Options
+var isSSL = location.protocol == 'https:';
 var options = {
 	timeout: 5,
+	useSSL: isSSL,
 	//Gets Called if the connection has sucessfully been established
 	onSuccess: function () {
 		retries = 0;

--- a/web/themes/standard/processAllMqttMsg.js
+++ b/web/themes/standard/processAllMqttMsg.js
@@ -1089,9 +1089,11 @@ client.onMessageArrived = function (message) {
 };
 var retries = 0;
 
+var isSSL = location.protocol == 'https:'
 //Connect Options
 var options = {
 	timeout: 5,
+	useSSL: isSSL,
 	//Gets Called if the connection has sucessfully been established
 	onSuccess: function () {
 		retries = 0;


### PR DESCRIPTION
Da es nicht gewünscht zu sein scheint, den Benutzern generell anzubieten ihre openWB über die Einstellungen einfach sicherer zu betreiben, habe ich dies nun darauf reduziert dass es durch die Implementierung von openWB nicht mehr verunmöglicht wird dies wenigstens selber so einzurichten zu können.

Die Änderung benutzt anhängig vom HTTP/HTTPS Protokoll das richtige WebSocket Protokoll ws/wss.