### PR TITLE
rfidtag.sh bugfix and slavemode improvement

### DIFF
--- a/slavemode.sh
+++ b/slavemode.sh
@@ -71,8 +71,9 @@ function computeAndSetCurrentForChargePoint() {
 	fi
 
 	if (( chargingVehiclesAdjustedForThisCp == 0 )); then
-		echo "$NowItIs: Slave Mode INTERNAL ERROR: chargingVehiclesAdjustedForThisCp == 0 - skipping slave loop for CP#${chargePoint} - is your CONTROLLER USING A TOO HIGH LIMIT FOR DETECTING CHARGING PHASES ??"
-		return 1
+		# this can happen in transient when master has not yet detected us as charging but we have already detected us as charging and no other car is charging
+		$dbgWrite "$NowItIs: Slave Mode INTERNAL ERROR: chargingVehiclesAdjustedForThisCp == 0 - forcing chargingVehiclesAdjustedForThisCp=1 for CP#${chargePoint}"
+		chargingVehiclesAdjustedForThisCp=1
 	fi
 
 	# compute difference between allowed current on the total current of the phase that has the highest total current and is actually used for charging


### PR DESCRIPTION
* Bugfix: Don't enable CP if in Slave mode and EV is already plugged as that constellation could not be handled properly for accounting: It would be unclear which CP the tag is for if another CP of the same box is also "plugged-in".

* Improvement: Avoid `rfidtag.sh: Zeile 29: [: 0002392926: Einstelliger (unärer) Operator erwartet.` message on empty tag by using string comparison.

* Improvement: Avoid `Slave Mode INTERNAL ERROR: chargingVehiclesAdjustedForThisCp == 0 - skipping slave loop for CP#1 - is your CONTROLLER USING A TOO HIGH LIMIT FOR DETECTING CHARGING PHASES ??` error message in transient situations when master has not yet detected us as charging but we have already detected ourself as charging and at same time no other car is charging

* Improvement: Made some more bash variables local if they're really only needed inside function.