### PR TITLE
Optional master heartbeat via LastControllerPublish

### DIFF
--- a/runs/mqttsub.py
+++ b/runs/mqttsub.py
@@ -67,6 +67,10 @@ def on_message(client, userdata, msg):
         f = open('/var/www/html/openWB/ramdisk/AllowedRfidsForLp2', 'w')
         f.write(msg.payload.decode("utf-8"))
         f.close()
+    if (msg.topic == "openWB/set/configure/LastControllerPublish"):
+        f = open('/var/www/html/openWB/ramdisk/LastControllerPublish', 'w')
+        f.write(msg.payload.decode("utf-8"))
+        f.close()
     if (msg.topic == "openWB/set/configure/TotalCurrentConsumptionOnL1"):
         if (float(msg.payload) >= 0 and float(msg.payload) <=200):
             f = open('/var/www/html/openWB/ramdisk/TotalCurrentConsumptionOnL1', 'w')
@@ -187,7 +191,7 @@ def on_message(client, userdata, msg):
     if (msg.topic == "openWB/set/system/debug/RequestDebugInfo"):
         if (int(msg.payload) == 1):
             sendcommand = ["/var/www/html/openWB/runs/sendmqttdebug.sh"]
-            subprocess.Popen(sendcommand)            
+            subprocess.Popen(sendcommand)
     if (msg.topic == "openWB/set/graph/RequestMonthLadelog"):
         if (int(msg.payload) >= 1 and int(msg.payload) <= 205012):
             sendcommand = ["/var/www/html/openWB/runs/sendladelog.sh", msg.payload]


### PR DESCRIPTION
At least with MPM3PM meter which only delivers Amps with 2 decimal digits it
seems that the heartbeat falsely triggers far too often.

With this commit, the LastControllerPublish MQTT message is the preferred
heartbeat value while current on phase with maximum current (the previous
implementation) is now the fallback in case LastControllerPublish message is
not published by master at all.