### PR TITLE
Optionally use last known charging phase for slave mode load mangement

### DIFF
--- a/rfidtag.sh
+++ b/rfidtag.sh
@@ -50,11 +50,11 @@ rfid() {
 		fi
 		if [ "$lasttag" == "$rfidlp1start1" ] || [ "$lasttag" == "$rfidlp1start2" ] || [ "$lasttag" == "$rfidlp1start3" ] ; then
 			mosquitto_pub -r -t openWB/set/lp1/ChargePointEnabled -m "1"
-			lp1enabled=0
+			lp1enabled=1
 		fi
 		if [ "$lasttag" == "$rfidlp2start1" ] || [ "$lasttag" == "$rfidlp2start2" ] || [ "$lasttag" == "$rfidlp2start3" ] ; then
 			mosquitto_pub -r -t openWB/set/lp2/ChargePointEnabled -m "1"
-			lp2enabled=0
+			lp2enabled=1
 		fi
 
 		# check all CPs that we support for whether the tag is valid for that CP

--- a/runs/atreboot.sh
+++ b/runs/atreboot.sh
@@ -2488,6 +2488,10 @@ if ! grep -Fq "slavemode=" /var/www/html/openWB/openwb.conf
 then
 	echo "slavemode=0" >> /var/www/html/openWB/openwb.conf
 fi
+if ! grep -Fq "slaveModeUseLastChargingPhase=" /var/www/html/openWB/openwb.conf
+then
+	echo "slaveModeUseLastChargingPhase=1" >> /var/www/html/openWB/openwb.conf
+fi
 if ! grep -Fq "solarworld_emanagerip=" /var/www/html/openWB/openwb.conf
 then
 	echo "solarworld_emanagerip=192.192.192.192" >> /var/www/html/openWB/openwb.conf


### PR DESCRIPTION
With this commit the slave mode respects the phase(s) on which the last chargings have occurred instead of blindly checking all 3 phases.

The behaviour can be disabled in `openwb.conf` using `slaveModeUseLastChargingPhase=0`. That should be done if user is known to run different EV on the same charge point.  
If always the same EV is connected it's preferable to use the smart default `slaveModeUseLastChargingPhase=1`.