### PR TITLE
change json content-type to application/json

### DIFF
--- a/web/api.php
+++ b/web/api.php
@@ -63,7 +63,7 @@ if(isset($_GET["get"])) {
 			"pvw"	=>	(explode(PHP_EOL, file_get_contents('/var/www/html/openWB/ramdisk/pvwatt'))[0] / 1000),
 			"socLP2"	=>	explode(PHP_EOL, file_get_contents('/var/www/html/openWB/ramdisk/soc1'))[0]
 		);
-		header("Content-type: text/json");
+		header("Content-type: application/json");
 		echo json_encode($json);
 	}
 	if($_GET["get"] == "all") {
@@ -131,7 +131,7 @@ if(isset($_GET["get"])) {
 			"lla2LP3"	=>	explode(PHP_EOL, file_get_contents('/var/www/html/openWB/ramdisk/llas22'))[0],
 			"lla3LP3"	=>	explode(PHP_EOL, file_get_contents('/var/www/html/openWB/ramdisk/llas23'))[0]
 		);
-		header("Content-type: text/json");
+		header("Content-type: application/json");
 		echo json_encode($json);
 	}
 }

--- a/web/tools/dailychargelp1.php
+++ b/web/tools/dailychargelp1.php
@@ -14,7 +14,7 @@ class Ajaxloader{
 
 		if($call == "loadfile"){
 			$result = $dailyevlp1;
-			header("Content-type: text/json");
+			header("Content-type: application/json");
 			echo json_encode(array("text"=> $result));
 		}
 	}

--- a/web/tools/dailychargelp2.php
+++ b/web/tools/dailychargelp2.php
@@ -14,7 +14,7 @@ class Ajaxloader{
 
 		if($call == "loadfile"){
 			$result = $dailyevlp2;
-			header("Content-type: text/json");
+			header("Content-type: application/json");
 			echo json_encode(array("text"=> $result));
 		}
 	}

--- a/web/tools/dailychargelp3.php
+++ b/web/tools/dailychargelp3.php
@@ -14,7 +14,7 @@ class Ajaxloader{
 
 		if($call == "loadfile"){
 			$result = $dailyevlp3;
-			header("Content-type: text/json");
+			header("Content-type: application/json");
 			echo json_encode(array("text"=> $result));
 		}
 	}

--- a/web/tools/dailychargelpg.php
+++ b/web/tools/dailychargelpg.php
@@ -15,7 +15,7 @@ class Ajaxloader{
 
 		if($call == "loadfile"){
 			$result = $dailyevlp1;
-			header("Content-type: text/json");
+			header("Content-type: application/json");
 			echo json_encode(array("text"=> $result));
 		}
 	}

--- a/web/tools/debugmode.php
+++ b/web/tools/debugmode.php
@@ -18,7 +18,7 @@ class Ajaxloader{
 
 		if($call == "loadfile"){
 			$result = $debugold;
-			header("Content-type: text/json");
+			header("Content-type: application/json");
 			echo json_encode(array("text"=> $result));
 		}
 	}

--- a/web/tools/getsofortll.php
+++ b/web/tools/getsofortll.php
@@ -15,7 +15,7 @@ class Ajaxloader{
 		$call = $_POST['call'];
 		if($call == "loadfile"){
 			$result = $sofortllold;
-			header("Content-type: text/json");
+			header("Content-type: application/json");
 			echo json_encode(array("text"=> $result));
 		}
 	}

--- a/web/tools/lademodus.php
+++ b/web/tools/lademodus.php
@@ -11,7 +11,7 @@ class Ajaxloader{
 
 		if($call == "loadfile"){
 			$result = $text;
-			header("Content-type: text/json");
+			header("Content-type: application/json");
 			echo json_encode(array("text"=> $result));
 		}
 	}

--- a/web/tools/programmloggerinfo.php
+++ b/web/tools/programmloggerinfo.php
@@ -24,6 +24,6 @@ $arr = array(
 	'wlanaddr' => $wlanaddr	
 );
 
-header("Content-type: text/json");
+header("Content-type: application/json");
 echo json_encode($arr);
 ?>


### PR DESCRIPTION
The correct Media Types / MIME type for json is `application/json` (https://www.iana.org/assignments/media-types/application/json and https://www.ietf.org/rfc/rfc4627.txt).

This enables xml like formatting with either https://developer.mozilla.org/en-US/docs/Tools/JSON_viewer or https://addons.mozilla.org/en-US/firefox/addon/jsonview/.