### PR TITLE
Slave slow ramping & min adjustment interval

### DIFF
--- a/runs/atreboot.sh
+++ b/runs/atreboot.sh
@@ -38,7 +38,7 @@ echo 1 > /var/www/html/openWB/ramdisk/mqttawattarprice
 echo 0 > /var/www/html/openWB/ramdisk/awattarmaxprice
 echo 1 > /var/www/html/openWB/ramdisk/mqttawattarmaxprice
 echo 1 > /var/www/html/openWB/ramdisk/mqtt.log
-echo 1 > /var/www/html/openWB/ramdisk/mqttsoc1
+echo 2 > /var/www/html/openWB/ramdisk/mqttsoc1
 echo 1 > /var/www/html/openWB/ramdisk/lp1enabled
 echo 0 > /var/www/html/openWB/ramdisk/device1_wh
 echo 0 > /var/www/html/openWB/ramdisk/device2_wh
@@ -146,8 +146,8 @@ echo 0 > /var/www/html/openWB/ramdisk/mqttlastchargestat
 echo 0 > /var/www/html/openWB/ramdisk/mqttlastchargestats1
 echo 0 > /var/www/html/openWB/ramdisk/mqttlastplugstats1
 echo 0 > /var/www/html/openWB/ramdisk/mqttspeichervorhanden
-echo 3 > /var/www/html/openWB/ramdisk/mqttspeichersoc
-echo 2 > /var/www/html/openWB/ramdisk/mqttspeicherleistung
+echo 0 > /var/www/html/openWB/ramdisk/mqttspeichersoc
+echo 0 > /var/www/html/openWB/ramdisk/mqttspeicherleistung
 echo 0 > /var/www/html/openWB/ramdisk/mqttladeleistungs1
 echo 0 > /var/www/html/openWB/ramdisk/mqttladeleistungs2
 echo 0 > /var/www/html/openWB/ramdisk/mqttladeleistunglp1
@@ -317,7 +317,7 @@ touch /var/www/html/openWB/ramdisk/yearly_pvkwhk2
 echo 0 > /var/www/html/openWB/ramdisk/yearly_pvkwhk2
 # SoC Speicher am WR 1
 touch /var/www/html/openWB/ramdisk/speichersoc
-echo 4 > /var/www/html/openWB/ramdisk/speichersoc
+echo 0 > /var/www/html/openWB/ramdisk/speichersoc
 # SoC Speicher am WR 2
 touch /var/www/html/openWB/ramdisk/speichersoc2
 echo 0 > /var/www/html/openWB/ramdisk/speichersoc2
@@ -486,11 +486,13 @@ echo 1 > /var/www/html/openWB/ramdisk/llaktuelllp6
 echo 1 > /var/www/html/openWB/ramdisk/llaktuelllp7
 echo 1 > /var/www/html/openWB/ramdisk/llaktuelllp8
 echo 0 > /var/www/html/openWB/ramdisk/soc
-echo 2 > /var/www/html/openWB/ramdisk/soc1
+echo 0 > /var/www/html/openWB/ramdisk/soc1
 echo 0 > /var/www/html/openWB/ramdisk/soc1vorhanden
 echo 0 > /var/www/html/openWB/ramdisk/lla1
 echo 0 > /var/www/html/openWB/ramdisk/lla2
 echo 0 > /var/www/html/openWB/ramdisk/lla3
+echo 0 > /var/www/html/openWB/ramdisk/llaktuells1
+echo 0 > /var/www/html/openWB/ramdisk/llaktuells2
 touch /var/www/html/openWB/ramdisk/llog1
 touch /var/www/html/openWB/ramdisk/llogs1
 touch /var/www/html/openWB/ramdisk/llogs2
@@ -2489,6 +2491,10 @@ fi
 if ! grep -Fq "slaveModeUseLastChargingPhase=" /var/www/html/openWB/openwb.conf
 then
 	echo "slaveModeUseLastChargingPhase=1" >> /var/www/html/openWB/openwb.conf
+fi
+if ! grep -Fq "slaveModeSlowRamping=" /var/www/html/openWB/openwb.conf
+then
+	echo "slaveModeSlowRamping=1" >> /var/www/html/openWB/openwb.conf
 fi
 if ! grep -Fq "solarworld_emanagerip=" /var/www/html/openWB/openwb.conf
 then

--- a/runs/atreboot.sh
+++ b/runs/atreboot.sh
@@ -2496,6 +2496,10 @@ if ! grep -Fq "slaveModeSlowRamping=" /var/www/html/openWB/openwb.conf
 then
 	echo "slaveModeSlowRamping=1" >> /var/www/html/openWB/openwb.conf
 fi
+if ! grep -Fq "slaveModeMinimumAdjustmentInterval=" /var/www/html/openWB/openwb.conf
+then
+	echo "slaveModeMinimumAdjustmentInterval=15" >> /var/www/html/openWB/openwb.conf
+fi
 if ! grep -Fq "solarworld_emanagerip=" /var/www/html/openWB/openwb.conf
 then
 	echo "solarworld_emanagerip=192.192.192.192" >> /var/www/html/openWB/openwb.conf

--- a/runs/atreboot.sh
+++ b/runs/atreboot.sh
@@ -38,7 +38,7 @@ echo 1 > /var/www/html/openWB/ramdisk/mqttawattarprice
 echo 0 > /var/www/html/openWB/ramdisk/awattarmaxprice
 echo 1 > /var/www/html/openWB/ramdisk/mqttawattarmaxprice
 echo 1 > /var/www/html/openWB/ramdisk/mqtt.log
-echo 2 > /var/www/html/openWB/ramdisk/mqttsoc1
+echo 1 > /var/www/html/openWB/ramdisk/mqttsoc1
 echo 1 > /var/www/html/openWB/ramdisk/lp1enabled
 echo 0 > /var/www/html/openWB/ramdisk/device1_wh
 echo 0 > /var/www/html/openWB/ramdisk/device2_wh
@@ -146,8 +146,8 @@ echo 0 > /var/www/html/openWB/ramdisk/mqttlastchargestat
 echo 0 > /var/www/html/openWB/ramdisk/mqttlastchargestats1
 echo 0 > /var/www/html/openWB/ramdisk/mqttlastplugstats1
 echo 0 > /var/www/html/openWB/ramdisk/mqttspeichervorhanden
-echo 0 > /var/www/html/openWB/ramdisk/mqttspeichersoc
-echo 0 > /var/www/html/openWB/ramdisk/mqttspeicherleistung
+echo 3 > /var/www/html/openWB/ramdisk/mqttspeichersoc
+echo 2 > /var/www/html/openWB/ramdisk/mqttspeicherleistung
 echo 0 > /var/www/html/openWB/ramdisk/mqttladeleistungs1
 echo 0 > /var/www/html/openWB/ramdisk/mqttladeleistungs2
 echo 0 > /var/www/html/openWB/ramdisk/mqttladeleistunglp1
@@ -317,7 +317,7 @@ touch /var/www/html/openWB/ramdisk/yearly_pvkwhk2
 echo 0 > /var/www/html/openWB/ramdisk/yearly_pvkwhk2
 # SoC Speicher am WR 1
 touch /var/www/html/openWB/ramdisk/speichersoc
-echo 0 > /var/www/html/openWB/ramdisk/speichersoc
+echo 4 > /var/www/html/openWB/ramdisk/speichersoc
 # SoC Speicher am WR 2
 touch /var/www/html/openWB/ramdisk/speichersoc2
 echo 0 > /var/www/html/openWB/ramdisk/speichersoc2
@@ -486,13 +486,11 @@ echo 1 > /var/www/html/openWB/ramdisk/llaktuelllp6
 echo 1 > /var/www/html/openWB/ramdisk/llaktuelllp7
 echo 1 > /var/www/html/openWB/ramdisk/llaktuelllp8
 echo 0 > /var/www/html/openWB/ramdisk/soc
-echo 0 > /var/www/html/openWB/ramdisk/soc1
+echo 2 > /var/www/html/openWB/ramdisk/soc1
 echo 0 > /var/www/html/openWB/ramdisk/soc1vorhanden
 echo 0 > /var/www/html/openWB/ramdisk/lla1
 echo 0 > /var/www/html/openWB/ramdisk/lla2
 echo 0 > /var/www/html/openWB/ramdisk/lla3
-echo 0 > /var/www/html/openWB/ramdisk/llaktuells1
-echo 0 > /var/www/html/openWB/ramdisk/llaktuells2
 touch /var/www/html/openWB/ramdisk/llog1
 touch /var/www/html/openWB/ramdisk/llogs1
 touch /var/www/html/openWB/ramdisk/llogs2

--- a/runs/mqttsub.py
+++ b/runs/mqttsub.py
@@ -277,6 +277,25 @@ def on_message(client, userdata, msg):
             subprocess.Popen(sendhook)
             client.publish("openWB/set/hook/HookControl", "", qos=0, retain=True)
             client.publish("openWB/hook/"+hooknmb+"/BoolHookStatus", hookact, qos=0, retain=True)
+
+
+
+
+    if (msg.topic == "openWB/config/set/slave/MinimumAdjustmentInterval"):
+        if (int(msg.payload) >= 10 and int(msg.payload) <= 300):
+            sendcommand = ["/var/www/html/openWB/runs/replaceinconfig.sh", "slaveModeMinimumAdjustmentInterval=", msg.payload.decode("utf-8")]
+            subprocess.Popen(sendcommand)
+            client.publish("openWB/config/get/slave/MinimumAdjustmentInterval", msg.payload.decode("utf-8"), qos=0, retain=True)
+    if (msg.topic == "openWB/config/set/slave/SlowRamping"):
+        if (int(msg.payload) >= 0 and int(msg.payload) <= 1):
+            sendcommand = ["/var/www/html/openWB/runs/replaceinconfig.sh", "slaveModeSlowRamping=", msg.payload.decode("utf-8")]
+            subprocess.Popen(sendcommand)
+            client.publish("openWB/config/get/slave/SlowRamping", msg.payload.decode("utf-8"), qos=0, retain=True)
+    if (msg.topic == "openWB/config/set/slave/UseLastChargingPhase"):
+        if (int(msg.payload) >= 0 and int(msg.payload) <= 1):
+            sendcommand = ["/var/www/html/openWB/runs/replaceinconfig.sh", "slaveModeUseLastChargingPhase=", msg.payload.decode("utf-8")]
+            subprocess.Popen(sendcommand)
+            client.publish("openWB/config/get/slave/UseLastChargingPhase", msg.payload.decode("utf-8"), qos=0, retain=True)
     if (msg.topic == "openWB/set/configure/AllowedTotalCurrentPerPhase"):
         if (float(msg.payload) >= 0 and float(msg.payload) <=200):
             f = open('/var/www/html/openWB/ramdisk/AllowedTotalCurrentPerPhase', 'w')
@@ -334,15 +353,18 @@ def on_message(client, userdata, msg):
             f = open('/var/www/html/openWB/ramdisk/ChargingVehiclesOnL3', 'w')
             f.write(msg.payload.decode("utf-8"))
             f.close()
-    if (msg.topic == "openWB/config/set/pv/priorityModeEVBattery"):
+
+
+
+
+    if (msg.topic == "openWB/set/system/priorityModeEVBattery"):
         if (int(msg.payload) >= 0 and int(msg.payload) <=1):
             einbeziehen=msg.payload.decode("utf-8")
             sendcommand = ["/var/www/html/openWB/runs/replaceinconfig.sh", "speicherpveinbeziehen=", einbeziehen]
             subprocess.Popen(sendcommand)
-            client.publish("openWB/config/get/pv/priorityModeEVBattery", einbeziehen, qos=0, retain=True)
+            client.publish("openWB/global/priorityModeEVBattery", einbeziehen, qos=0, retain=True)
     if (msg.topic == "openWB/set/graph/LiveGraphDuration"):
         if (int(msg.payload) >= 20 and int(msg.payload) <=120):
-
             sendcommand = ["/var/www/html/openWB/runs/replaceinconfig.sh", "livegraph=", msg.payload.decode("utf-8")]
             subprocess.Popen(sendcommand)
             client.publish("openWB/set/graph/LiveGraphDuration", "", qos=0, retain=True)

--- a/runs/mqttsub.py
+++ b/runs/mqttsub.py
@@ -357,12 +357,12 @@ def on_message(client, userdata, msg):
 
 
 
-    if (msg.topic == "openWB/set/system/priorityModeEVBattery"):
+    if (msg.topic == "openWB/config/set/pv/priorityModeEVBattery"):
         if (int(msg.payload) >= 0 and int(msg.payload) <=1):
             einbeziehen=msg.payload.decode("utf-8")
             sendcommand = ["/var/www/html/openWB/runs/replaceinconfig.sh", "speicherpveinbeziehen=", einbeziehen]
             subprocess.Popen(sendcommand)
-            client.publish("openWB/global/priorityModeEVBattery", einbeziehen, qos=0, retain=True)
+            client.publish("openWB/config/get/pv/priorityModeEVBattery", einbeziehen, qos=0, retain=True)
     if (msg.topic == "openWB/set/graph/LiveGraphDuration"):
         if (int(msg.payload) >= 20 and int(msg.payload) <=120):
             sendcommand = ["/var/www/html/openWB/runs/replaceinconfig.sh", "livegraph=", msg.payload.decode("utf-8")]

--- a/slavemode.sh
+++ b/slavemode.sh
@@ -111,11 +111,11 @@ function computeAndSetCurrentForChargePoint() {
 	if (( slaveModeSlowRamping == 1 )); then
 
 		local adjustment=0;
-		if (( `echo "$lldiff > 1" | bc` == 1 )); then
+		if (( `echo "$lldiff > 1.0" | bc` == 1 )); then
 			adjustment=1
-		elif (( `echo "$lldiff < -3" | bc` == 1 )); then
+		elif (( `echo "$lldiff < -3.0" | bc` == 1 )); then
 			adjustment=-3
-		elif (( `echo "$lldiff < 0" | bc` == 1 )); then
+		elif (( `echo "$lldiff < -0.5" | bc` == 1 )); then
 			adjustment=-1
 		fi
 

--- a/slavemode.sh
+++ b/slavemode.sh
@@ -121,8 +121,15 @@ function computeAndSetCurrentForChargePoint() {
 
 		if !(( CpIsCharging )); then
 			# if we're not charging, we always start off with minimalstromstaerke
-			llneu=${minimalstromstaerke}
-			$dbgWrite "$NowItIs: Slave Mode: Slow ramping: Not charging: Starting at minimal supported charge current ${llneu} A"
+		if (( `echo "$lldiff < 0" | bc` == 1 )); then
+				llneu=0
+
+				$dbgWrite "$NowItIs: Slave Mode: Slow ramping: Not charging: Too few current left to start"
+			else
+				llneu=${minimalstromstaerke}
+
+				$dbgWrite "$NowItIs: Slave Mode: Slow ramping: Not charging: Starting at minimal supported charge current ${llneu} A"
+			fi
 		else
 			llneu=$(( llalt + adjustment ))
 			$dbgWrite "$NowItIs: Slave Mode: Slow ramping: Limiting adjustment to ${llalt} + (${adjustment}) --> llneu = ${llneu} A"

--- a/slavemode.sh
+++ b/slavemode.sh
@@ -78,10 +78,6 @@ function computeAndSetCurrentForChargePoint() {
 		expectedChangeTimestamp=${expectedChangeArray[0]}
 		expectedCurrentPerPhase=${expectedChangeArray[1]}
 		local timeSinceAdjustment=$(( NowItIs - expectedChangeTimestamp ))
-		if (( `echo "(${expectedCurrentPerPhase} - ${ChargeCurrentOnPhase[1]}) > ${MaxCurrentOffset}" | bc` == 1 )); then
-			echo "$NowItIs: Slave Mode: Expecting current ${expectedCurrentPerPhase} A on max charging phase but found ${ChargeCurrentOnPhase[1]} A ${timeSinceAdjustment} seconds after adjustment. Not doing any further adjustment."
-			return 0
-		fi
 		if (( timeSinceAdjustment < MinimumAdjustmentInterval )); then
 			$dbgWrite "$NowItIs: Slave Mode: Time after adjustment ${timeSinceAdjustment} < ${MinimumAdjustmentInterval} seconds. Skipping control loop"
 			return 0


### PR DESCRIPTION
**In order to avoid osciallation and accomodate for EVs not immediately following allowed current within the first 10 seconds:**

1. a "slow mode" has been introduced which adjusts charge current by +1, -1 or -3 A steps (instead of the full computed difference to the possible value)
   This allows more smooth control of charge current but might cause slightyl longer time in which total system allowed current is exceeded (even though -3 A steps will be done if difference is < -3 A).
   Usage of this mode depends on the typical consumption of the overall system.

2. a "minimum adjustment interval" is checked: After every actual adjustment of charge current, no further adjustments will be done for at least this amount of time.
   This will allow the values to settle and get updated consistently and seven allow some averaging of values. Finally this avoids many osciallations resulting from total EVU current not immediately reflecting the adjustment. This can either be because the EV takes some time to actually consume more or less current or because of timing race between EVU polling and openWB control cycle.
   Typical values for the minimum interval is such that 1-2 openWB control cycles will be skipped (i.e. a value of ~12-28 seconds)

The settings are all adjustable via `openwb.conf` and can be configured via MQTT.