### PR TITLE
initial support for dark-mode in settings

### DIFF
--- a/web/settings/settings_style.css
+++ b/web/settings/settings_style.css
@@ -134,3 +134,28 @@ body > .container {
 .input {
     vertical-align: midle;
 }
+
+@media (prefers-color-scheme: dark) {
+    body {
+        background-color: #212529;
+        color: #ffffff;
+    }
+
+    .card {
+        background-color: #212529;
+        border-color: rgba(255, 255, 255, 0.5);
+    }
+
+    .bg-warning {
+        color: #212529;
+    }
+
+    .form-control {
+        background-color: #6c757d;
+        color: #ffffff;
+    }
+
+    .btn-outline-secondary {
+        color: #ffffff;
+    }
+}


### PR DESCRIPTION
Auf aktuellen Geräten (Android, Mac, Win10) kann zwischen einem dunklen und hellen Design gewählt werden. Als Vorschlag habe ich das CSS für die neuen Einstellungen entsprechend erweitert. Da ein @media Query genutzt wird, hat es ansonsten keinen Einfluss auf die Darstellung.