### PR TITLE
Flicker-Fix

### DIFF
--- a/web/themes/dark/processAllMqttMsg.js
+++ b/web/themes/dark/processAllMqttMsg.js
@@ -47,13 +47,12 @@ function handlevar(mqttmsg, mqttpayload) {
 	else if ( mqttmsg.match( /^openwb\/config\/get\/SmartHome\/Devices\//i) ) { processSmartHomeDevicesConfigMessages(mqttmsg, mqttpayload); }
 	else if ( mqttmsg.match( /^openwb\/config\/get\/sofort\/lp\//i) ) { processSofortConfigMessages(mqttmsg, mqttpayload); }
 	else if ( mqttmsg.match( /^openwb\/config\/get\/pv\//i) ) { processPvConfigMessages(mqttmsg, mqttpayload); }
-
 }  // end handlevar
 
 
 
 function processPvConfigMessages(mqttmsg, mqttpayload) {
-
+	processPreloader(mqttmsg);
 	if ( mqttmsg == 'openWB/config/get/pv/priorityModeEVBattery' ) {
 		// sets button color in charge mode modal and sets icon in mode select button
 		switch (mqttpayload) {
@@ -806,7 +805,7 @@ function processSmartHomeDevicesMessages(mqttmsg, mqttpayload) {
 	// called by handlevar
 	processPreloader(mqttmsg);
 	if ( mqttmsg.match( /^openwb\/SmartHome\/Devices\/[1-9][0-9]*\/Watt$/i ) ) {
-		
+
 		var index = getIndex(mqttmsg);  // extract number between two / /
 		var parent = $('[data-dev="' + index + '"]');  // get parent row element for SH Device
 		var element = parent.find('.actualPowerDevice');  // now get parents respective child element

--- a/web/themes/dark/style.css
+++ b/web/themes/dark/style.css
@@ -27,20 +27,6 @@ body > .container {
 	    padding: 55px 15px 0;
     }
 
-.loader {
-    position: fixed;
-    z-index: 999999;
-    top: 0;
-    left: 0;
-    width: 100%;
-    height: 100%;
-    background: #fff;
-}
-.loader-container {
-	margin-top: 150px;
-	text-align: center;
-}
-
 @keyframes alertPulsation {
   0%   { opacity:1; }
   50%  { opacity:0; }

--- a/web/themes/dark/theme.html
+++ b/web/themes/dark/theme.html
@@ -68,20 +68,21 @@
 		}
 		var themeCookie = getCookie('openWBTheme');
 		// include special Theme style
-		$('head').append('<link rel="stylesheet" type="text/css" href="themes/' + themeCookie + '/style.css">');
+		$('head').append('<link rel="stylesheet" href="themes/' + themeCookie + '/style.css">');
 	</script>
 </head>
 
 <body>
 	<!-- Preloader with Progress Bar -->
-	<div class="loader bg-white">
-		<div class="loader-container regularTextSize">
-		  	<div class="row text-black">
+	<!-- style instead of css due to async loading of theme css -->
+	<div id="preloader" style="background-color:white; position:fixed; top:0px; left:0px; width:100%; height:100%; z-index:999999;">
+		<div style="margin-top: 150px; text-align: center;">
+		  	<div class="row" style="color:black;">
 			  	<div class="mx-auto d-block justify-content-center">
 					<img src="img/favicons/preloader-image.png" style="max-width: 300px" alt="openWB">
 			  	</div>
 			</div>
-			<div class="row text-grey justify-content-center mt-2">
+			<div class="row justify-content-center mt-2" style="color:grey;">
 				<div class="col-10 col-sm-6">
 					Bitte warten, während die Seite aufgebaut wird.
 				</div>
@@ -1107,7 +1108,7 @@
 					landingpageShown = true;
 					setTimeout(function (){
 						// delay a little bit
-						$(".loader").fadeOut(1000);
+						$("#preloader").fadeOut(1000);
 					}, 500);
 				}
 			}


### PR DESCRIPTION
Das Laden des Theme-CSS mittels .append erfolgt je nach Browser asynchron, so dass das css des Preloaders noch nicht geladen ist, während er schon angezeigt wird. Style des Preloaders fest hinzugefügt: verhindert Flickern beim Laden.