### PR TITLE
Handling of load imbalance and Duo in slave mode

### DIFF
--- a/rfidtag.sh
+++ b/rfidtag.sh
@@ -202,7 +202,7 @@ setLpPlugChangeState() {
 			echo "$NowItIs: LP 2 un-plugged"
 			unpluggedLps[2]=1
 		else
-			echo "$NowItIs: LP 2 unkown plug state '${plugstats1}'"
+			echo "$NowItIs: LP 2 unkown plug state '${lpsPlugStat[2]}'"
 		fi
 
 		echo ${lpsPlugStat[2]} > "ramdisk/accPlugstatChangeDetectLp2"
@@ -220,7 +220,7 @@ setLpPlugChangeState() {
 			echo "$NowItIs: LP 1 un-plugged"
 			unpluggedLps[1]=1
 		else
-			echo "$NowItIs: LP 1 unkown plug state '${plugstat}'"
+			echo "$NowItIs: LP 1 unkown plug state '${lpsPlugStat[1]}'"
 		fi
 
 		echo ${lpsPlugStat[1]} > "ramdisk/accPlugstatChangeDetectLp1"

--- a/runs/mqttsub.py
+++ b/runs/mqttsub.py
@@ -73,7 +73,7 @@ def on_connect(client, userdata, flags, rc):
     client.subscribe("openWB/config/set/#", 2)
 # handle each set topic
 def on_message(client, userdata, msg):
- 
+
     if (( "openWB/set/lp" in msg.topic) and ("ChargePointEnabled" in msg.topic)):
         devicenumb=re.sub('\D', '', msg.topic)
         if ( 1 <= int(devicenumb) <= 8 and 0 <= int(msg.payload) <= 1):
@@ -229,7 +229,7 @@ def on_message(client, userdata, msg):
                 f = open('/var/www/html/openWB/ramdisk/gelrlp'+str(devicenumb), 'w')
                 f.write("0")
                 f.close()
-            client.publish("openWB/config/set/sofort/lp/"+str(devicenumb)+"/resetEnergyToCharge", "", qos=0, retain=True) 
+            client.publish("openWB/config/set/sofort/lp/"+str(devicenumb)+"/resetEnergyToCharge", "", qos=0, retain=True)
     if (( "openWB/config/set/sofort/lp" in msg.topic) and ("socToChargeTo" in msg.topic)):
         devicenumb=re.sub('\D', '', msg.topic)
         if ( 1 <= int(devicenumb) <= 2 and 0 <= int(msg.payload) <= 100):
@@ -254,7 +254,7 @@ def on_message(client, userdata, msg):
 
             client.publish("openWB/config/get/sofort/lp/"+str(devicenumb)+"/chargeLimitation", msg.payload.decode("utf-8"), qos=0, retain=True)
             client.publish("openWB/config/set/sofort/lp/"+str(devicenumb)+"/chargeLimitation", "", qos=0, retain=True)
- 
+
 
     if (msg.topic == "openWB/config/set/pv/minFeedinPowerBeforeStart"):
         if (int(msg.payload) >= -100000 and int(msg.payload) <= 100000):
@@ -484,6 +484,11 @@ def on_message(client, userdata, msg):
     if (msg.topic == "openWB/set/configure/FixedChargeCurrentCp2"):
         if (int(msg.payload) >= -1 and int(msg.payload) <=32):
             f = open('/var/www/html/openWB/ramdisk/FixedChargeCurrentCp2', 'w')
+            f.write(msg.payload.decode("utf-8"))
+            f.close()
+    if (msg.topic == "openWB/set/configure/SlaveModeAllowedLoadImbalance"):
+        if (float(msg.payload) >= 0 and float(msg.payload) <=200):
+            f = open('/var/www/html/openWB/ramdisk/SlaveModeAllowedLoadImbalance', 'w')
             f.write(msg.payload.decode("utf-8"))
             f.close()
     if (msg.topic == "openWB/set/configure/AllowedRfidsForLp1"):
@@ -890,7 +895,7 @@ def on_message(client, userdata, msg):
             f.write(msg.payload.decode("utf-8"))
             f.close()
 
-    if (len(msg.payload) >= 1): 
+    if (len(msg.payload) >= 1):
         theTime = datetime.now()
         timestamp = theTime.strftime(format = "%Y-%m-%d %H:%M:%S")
         file = open('/var/www/html/openWB/ramdisk/mqtt.log', 'a')

--- a/slavemode.sh
+++ b/slavemode.sh
@@ -164,7 +164,12 @@ function computeAndSetCurrentForChargePoint() {
 			# newly calculated imbalance allows more than 1 A more current
 			imbalDiff=$(echo "scale=0; ($lastImbalance + $imbalDiff - 0.9999)/1" | bc)
 
-			$dbgWrite "$NowItIs: Slave Mode: Load Imbalance: Can increase current even with imbalance compensation to imbalDiff=${imbalDiff} A"
+			if (( imbalDiff > 0 )); then
+				$dbgWrite "$NowItIs: Slave Mode: Load Imbalance: No more limit contribution. Setting imbalDiff from ${imbalDiff} A to 0 A"
+				imbalDiff=0
+			else
+				$dbgWrite "$NowItIs: Slave Mode: Load Imbalance: Can increase current even with imbalance compensation to imbalDiff=${imbalDiff} A"
+			fi
 		else
 
 			# else we keep on using the previous imbalance


### PR DESCRIPTION
**Includes the following changes:**
* **Bugfix:** for handling CP2 of openWB Duo in Slave mode.
* **New feature:** Allow load imbalance limit in slave mode.

**Details:**
Default imbalance limit is set to 20 A.

Can be adjusted via the optional MQTT topic `SlaveModeAllowedLoadImbalance`.

To disable load imbalance limit, set the MQTT value of `SlaveModeAllowedLoadImbalance` >= the value of topic `AllowedTotalCurrentPerPhase`

Minor debug printout correction in `rfidtag.sh` included.