### PR TITLE
docs: improve docs for configuration of SolarView

### DIFF
--- a/web/settings/modulconfig.php
+++ b/web/settings/modulconfig.php
@@ -4250,18 +4250,18 @@
 					</div>
 					<div id="pvsolarview">
 						<div class="row" style="background-color:#febebe">
-							<b><label for="solarview_hostname">IP Adresse des Solarview</label></b>
+							<b><label for="solarview_hostname">Hostname des SolarView TCP-Servers</label></b>
 							<input type="text" name="solarview_hostname" id="solarview_hostname" value="<?php echo htmlspecialchars($solarview_hostnameold) ?>">
 						</div>
 						<div class="row" style="background-color:#febebe">
-							Gültige Werte IP.
+							Gültige Werte Hostname oder IP-Adresse.
 						</div>
 						<div class="row" style="background-color:#febebe">
-							<b><label for="solarview_port">Port des Solarview</label></b>
+							<b><label for="solarview_port">Port des Solarview TCP-Servers</label></b>
 							<input type="text" name="solarview_port" id="solarview_port" value="<?php echo htmlspecialchars($solarview_portold) ?>">
 						</div>
 						<div class="row" style="background-color:#febebe">
-							Gültige Werte Port, z.B. 80.
+							Gültige Werte Port, z.B. 15000.
 						</div>
 					</div>
 					<div id="pvpowerwall">


### PR DESCRIPTION
Bei der Anbindung von SolarView ist aufgefallen, dass die Beschreibung der Weboberfläche noch etwas missverständlich formuliert ist. Eine Stolperfalle ist, dass der angebundene TCP-Server Default-mäßig auf Port 15000 läuft, die openwb-Doku aber Port 80 als Beispiel angibt. In diesem Pull Request wird die Doku deshalb präzisiert.

Gibt es die Möglichkeit darauf hinzuweisen, dass der TCP-Server in SolarView eingeschaltet werden muss?