### PR TITLE
Bugfix MQTT updateInProgress

### DIFF
--- a/runs/atreboot.sh
+++ b/runs/atreboot.sh
@@ -2729,5 +2729,6 @@ chmod 777 /var/www/html/openWB/ramdisk/smarthome.log
 chmod 777 /var/www/html/openWB/ramdisk/smarthomehandlerloglevel
 echo 0 > /var/www/html/openWB/ramdisk/bootinprogress
 echo 0 > /var/www/html/openWB/ramdisk/updateinprogress
+mosquitto_pub -t openWB/system/updateInProgress -r -m "0"
 sudo /bin/su -c "echo 'upload_max_filesize = 300M' > /etc/php/7.0/apache2/conf.d/20-uploadlimit.ini"
 


### PR DESCRIPTION
This problem could only be detected after previous MR had been included:
The `loadvars.sh` approach seems not to work reliably for `updateInProgress`.
Fixed by additionally explicitly publishing at end of `atreboot.sh`.