### PR TITLE
Support for ABB-B23 Verbraucher

### DIFF
--- a/hook.sh
+++ b/hook.sh
@@ -194,6 +194,11 @@ if (( verbraucher1_aktiv == "1")); then
 			verbraucher1_watt=$(cat /var/www/html/openWB/ramdisk/verbraucher1_watt)
 		fi
 	fi
+	if [[ $verbraucher1_typ == "abb-b23" ]]; then
+			python modules/verbraucher/abb-b23remote.py 1 $verbraucher1_source $verbraucher1_id &
+			verbraucher1_watt=$(cat /var/www/html/openWB/ramdisk/verbraucher1_watt)
+			sleep .3
+	fi
 	if [[ $verbraucher1_typ == "tasmota" ]]; then
 		verbraucher1_out=$(curl --connect-timeout 3 -s $verbraucher1_ip/cm?cmnd=Status%208 )
 		verbraucher1_watt=$(echo $verbraucher1_out | jq '.StatusSNS.ENERGY.Power')
@@ -238,7 +243,6 @@ if (( verbraucher2_aktiv == "1")); then
 			verbraucher2_watt=$(cat /var/www/html/openWB/ramdisk/verbraucher2_watt)
 		fi
 	fi
-
 	if [[ $verbraucher2_typ == "sdm120" ]]; then
 		if [[ $verbraucher2_source == *"dev"* ]]; then
 			sudo python modules/verbraucher/sdm120local.py 2 $verbraucher2_source $verbraucher2_id &
@@ -247,6 +251,11 @@ if (( verbraucher2_aktiv == "1")); then
 			sudo python modules/verbraucher/sdm120remote.py 2 $verbraucher2_source $verbraucher2_id &
 			verbraucher2_watt=$(cat /var/www/html/openWB/ramdisk/verbraucher2_watt)
 		fi
+	fi
+	if [[ $verbraucher2_typ == "abb-b23" ]]; then
+			python modules/verbraucher/abb-b23remote.py 2 $verbraucher2_source $verbraucher2_id &
+			verbraucher2_watt=$(cat /var/www/html/openWB/ramdisk/verbraucher2_watt)
+			sleep .3
 	fi
 	if [[ $verbraucher2_typ == "tasmota" ]]; then
 		verbraucher2_out=$(curl --connect-timeout 3 -s $verbraucher2_ip/cm?cmnd=Status%208 )

--- a/modules/verbraucher/abb-b23remote.py
+++ b/modules/verbraucher/abb-b23remote.py
@@ -1,0 +1,94 @@
+#!/usr/bin/python
+import sys
+import os
+import time
+import getopt
+import socket
+import ConfigParser
+import struct
+import binascii
+import ctypes
+
+#Args in var schreiben
+verbrauchernr = str(sys.argv[1])
+seradd = str(sys.argv[2])
+ABBid = int(sys.argv[3])
+
+from pymodbus.client.sync import ModbusTcpClient as ModbusClient
+from pymodbus.transaction import ModbusRtuFramer
+client = ModbusClient(seradd, port=502, framer=ModbusRtuFramer)
+
+response = client.read_holding_registers(address=0x5B00, count=28, unit=ABBid)
+
+#Phase 1 A
+al1 = ((response.registers[12] << 16) | response.registers[13]) / 10
+al1string = "/var/www/html/openWB/ramdisk/verbraucher%s_a1" % (verbrauchernr)
+f = open(al1string, 'w')
+f.write(str(al1))
+f.close()
+
+#Phase 2 A
+al2 = ((response.registers[14] << 16) | response.registers[15]) / 10
+al2string = "/var/www/html/openWB/ramdisk/verbraucher%s_a2" % (verbrauchernr)
+f = open(al2string, 'w')
+f.write(str(al2))
+f.close()
+
+#Phase 3 A
+al3 = ((response.registers[16] << 16) | response.registers[17]) / 10
+al3string = "/var/www/html/openWB/ramdisk/verbraucher%s_a3" % (verbrauchernr)
+f = open(al3string, 'w')
+f.write(str(al3))
+f.close()
+
+#Phase 1 V
+vl1 = ((response.registers[0] << 16) | response.registers[1]) / 10
+vl1string = "/var/www/html/openWB/ramdisk/verbraucher%s_v1" % (verbrauchernr)
+f = open(vl1string, 'w')
+f.write(str(vl1))
+f.close()
+
+#Phase 2 V
+vl2 = ((response.registers[2] << 16) | response.registers[3]) / 10
+vl2string = "/var/www/html/openWB/ramdisk/verbraucher%s_v2" % (verbrauchernr)
+f = open(vl2string, 'w')
+f.write(str(vl2))
+f.close()
+
+#Phase 3 V
+vl3 = ((response.registers[4] << 16) | response.registers[5]) / 10
+vl3string = "/var/www/html/openWB/ramdisk/verbraucher%s_v3" % (verbrauchernr)
+f = open(vl3string, 'w')
+f.write(str(vl3))
+f.close()
+
+#KWH Total Export
+# Not supported on ABB Steel Series Meters, broze and upwards may support export values
+#Totoal Export
+#response = client.read_holding_registers(address=0x5004, count=4, unit=ABBid)
+whe = 0.0
+# uncomment this line if you have a bronze or higher ABB meter
+#whe = ((response.registers[0] << 32)|(response.registers[1] << 24)|(response.registers[2] << 16)|response.registers[3]) * 10.0
+vwhestring = "/var/www/html/openWB/ramdisk/verbraucher%s_whe" % (verbrauchernr)
+f = open(vwhestring, 'w')
+f.write(str(whe))
+f.close()
+
+#Aktueller Verbrauch
+#response = client.read_holding_registers(0x5B14,2, unit=ABBid)
+watt = ((response.registers[20] << 16)| response.registers[21])
+watt = ctypes.c_int32(watt).value / 100
+wattstring = "/var/www/html/openWB/ramdisk/verbraucher%s_watt" % (verbrauchernr)
+f = open(wattstring, 'w')
+f.write(str(watt))
+f.close()
+
+#KWH Total Import
+response = client.read_holding_registers(address=0x5000, count=4, unit=ABBid)
+vwh = ((response.registers[0] << 32)|(response.registers[1] << 24)|(response.registers[2] << 16)|response.registers[3]) * 10.0
+vwhstring = "/var/www/html/openWB/ramdisk/verbraucher%s_wh" % (verbrauchernr)
+f = open(vwhstring, 'w')
+f.write(str(vwh))
+f.close()
+
+client.close()

--- a/web/settings/smarthome.php
+++ b/web/settings/smarthome.php
@@ -497,6 +497,7 @@
 								<option <?php if($verbraucher1_typold == "mpm3pm\n") echo "selected" ?> value="mpm3pm">MPM3PM</option>
 								<option <?php if($verbraucher1_typold == "sdm120\n") echo "selected" ?> value="sdm120">SDM120</option>
 								<option <?php if($verbraucher1_typold == "sdm630\n") echo "selected" ?> value="sdm630">SDM630</option>
+								<option <?php if($verbraucher1_typold == "abb-b23\n") echo "selected" ?> value="abb-b23">ABB-B23</option>
 								<option <?php if($verbraucher1_typold == "tasmota\n") echo "selected" ?> value="tasmota">Sonoff mit Tasmota FW</option>
 								<option <?php if($verbraucher1_typold == "shelly\n") echo "selected" ?> value="shelly">Shelly 1PM</option>
 							</select>
@@ -568,6 +569,9 @@
 							if($('#verbraucher1_typ').val() == 'sdm120') {
 								$('#v1modbus').show();
 							}
+							if($('#verbraucher1_typ').val() == 'abb-b23') {
+								$('#v1modbus').show();
+							}
 							if($('#verbraucher1_typ').val() == 'tasmota') {
 								$('#v1tasmota').show();
 							}
@@ -625,6 +629,7 @@
 								<option <?php if($verbraucher2_typold == "mpm3pm\n") echo "selected" ?> value="mpm3pm">MPM3PM</option>
 								<option <?php if($verbraucher2_typold == "sdm120\n") echo "selected" ?> value="sdm120">SDM120</option>
 								<option <?php if($verbraucher2_typold == "sdm630\n") echo "selected" ?> value="sdm630">SDM630</option>
+								<option <?php if($verbraucher2_typold == "abb-b23\n") echo "selected" ?> value="abb-b23">ABB-B23</option>
 								<option <?php if($verbraucher2_typold == "tasmota\n") echo "selected" ?> value="tasmota">Sonoff mit Tasmota FW</option>
 							</select>
 						</div>
@@ -693,6 +698,9 @@
 								$('#v2modbus').show();
 							}
 							if($('#verbraucher2_typ').val() == 'sdm120') {
+								$('#v2modbus').show();
+							}
+							if($('#verbraucher2_typ').val() == 'abb-b23') {
 								$('#v2modbus').show();
 							}
 							if($('#verbraucher2_typ').val() == 'tasmota') {


### PR DESCRIPTION
Initiales Python Skript für die Kommunikation mit ABB-B23 Zählern. Beim Anschluss bitte aufpassen, A und B sind ggü. der Beschriftung am Zähler sowie Anleitung vertauscht. Meine Zähler funktionieren nur, wenn ich A am Zähler an B eines anderen Geräts anschließe (und B an A). Dies ist analog zur Anleitung von LG für den Anschluss an den LG PCS, auch hier wird der Anschluss derart empfohlen.

Das ganze ist getestet und funktioniert auf bei mir mit 3 ABB Zählern und einem USR einwandfrei.