### PR TITLE
Fronius SM - Support for Meter with ID=1

### DIFF
--- a/modules/bezug_fronius_sm/main.sh
+++ b/modules/bezug_fronius_sm/main.sh
@@ -7,7 +7,7 @@
 
 
 # Fordere die Werte vom SmartMeter an.
-response_sm=$(curl --connect-timeout 5 -s "$wrfroniusip/solar_api/v1/GetMeterRealtimeData.cgi?Scope=Device&DeviceID=0")
+response_sm=$(curl --connect-timeout 5 -s "$wrfroniusip/solar_api/v1/GetMeterRealtimeData.cgi?Scope=Device&DeviceID=$froniuserzeugung")
 
 # Überprüfe den Einbauort des SmartMeters.
 meter_location=$(echo $response_sm | jq '.Body.Data.Meter_Location_Current')

--- a/runs/atreboot.sh
+++ b/runs/atreboot.sh
@@ -1833,6 +1833,10 @@ if ! grep -Fq "kostalplenticorebatt=" /var/www/html/openWB/openwb.conf
 then
 	  echo "kostalplenticorebatt=0" >> /var/www/html/openWB/openwb.conf
 fi
+if ! grep -Fq "froniuserzeugung=" /var/www/html/openWB/openwb.conf
+then
+	  echo "froniuserzeugung=0" >> /var/www/html/openWB/openwb.conf
+  fi
 if ! grep -Fq "froniusprimo=" /var/www/html/openWB/openwb.conf
 then
 	  echo "froniusprimo=0" >> /var/www/html/openWB/openwb.conf

--- a/web/settings/modulconfig.php
+++ b/web/settings/modulconfig.php
@@ -3887,7 +3887,7 @@
 						</div>
 						<input type='hidden' value='0' name='froniuserzeugung'>
 						<input id="froniuserzeugung" name="froniuserzeugung" value="1" type="checkbox" <?php if ( $froniuserzeugungold == 1){ echo "checked"; } ?> >
-						<label for="froniuserzeugung">Erzeugungszähler statt Bezugszähler</label><br />
+						<label for="froniuserzeugung"> Meter mit ID 1 statt 0</label><br />
 						<input type='hidden' value='0' name='froniusprimo'>
 						<input id="froniusprimo" name="froniusprimo" value="1" type="checkbox" <?php if ( $froniusprimoold == 1){ echo "checked"; } ?> >
 						<label for="froniusprimo"> Kompatibilitätsmodus für die Primo Reihe</label>

--- a/web/settings/modulconfig.php
+++ b/web/settings/modulconfig.php
@@ -1111,6 +1111,9 @@
 				if(strpos($line, "kostalplenticorebatt=") !== false) {
 					list(, $kostalplenticorebattold) = explode("=", $line);
 				}
+				if(strpos($line, "froniuserzeugung=") !== false) {
+					list(, $froniuserzeugungold) = explode("=", $line);
+				}
 				if(strpos($line, "froniusprimo=") !== false) {
 					list(, $froniusprimoold) = explode("=", $line);
 				}
@@ -3880,12 +3883,14 @@
 						</div>
 					</div>
 					<div id="wattbezugfronius">
-						<div class="row" style="background-color:#febebe">
-							Die IP des Wechselrichters wird im dazugehörigen Fronius PV-Modul eingestellt.
+						<div class="row" style="background-color:#febebe"> Die IP des Wechselrichters wird im dazugehörigen Fronius PV-Modul eingestellt.
 						</div>
+						<input type='hidden' value='0' name='froniuserzeugung'>
+						<input id="froniuserzeugung" name="froniuserzeugung" value="1" type="checkbox" <?php if ( $froniuserzeugungold == 1){ echo "checked"; } ?> >
+						<label for="froniuserzeugung">Erzeugungszähler statt Bezugszähler</label><br />
 						<input type='hidden' value='0' name='froniusprimo'>
 						<input id="froniusprimo" name="froniusprimo" value="1" type="checkbox" <?php if ( $froniusprimoold == 1){ echo "checked"; } ?> >
-						<label for="froniusprimo">Kompatibilitätsmodus für die Primo Reihe</label>
+						<label for="froniusprimo"> Kompatibilitätsmodus für die Primo Reihe</label>
 					</div>
 					<div id="wattbezugjson">
 						<div class="row" style="background-color:#febebe">

--- a/web/tools/savemodul.php
+++ b/web/tools/savemodul.php
@@ -1276,6 +1276,10 @@ if(isset($_POST['evsecon'])) {
 			$result .= 'evuglaettungakt='.$_POST['evuglaettungakt']."\n";
 			$writeit = '1';
 		}
+		if(strpos($line, "froniuserzeugung=") !== false) {
+			$result .= 'froniuserzeugung='.$_POST['froniuserzeugung']."\n";
+			$writeit = '1';
+		}
 		if(strpos($line, "froniusprimo=") !== false) {
 			$result .= 'froniusprimo='.$_POST['froniusprimo']."\n";
 			$writeit = '1';


### PR DESCRIPTION
Seit Wochen passe ich nach jedem Update das Modul von Hand wieder an. Es wird also Zeit das ganze mal vernünftig einzupflegen:

Die aktuellen Fronius SmartMeter kommen ab Werk mit der Modbus Adresse 1 und werden auch über die DeviceID=1 in der JSON API angesprochen. OpenWB fragt derzeit allerdings immer DeviceID=0 als Smartmeter ab, vermutlich aus historischen Gründen. Hier antwortet mir der WR allerdings nur, dass es kein SmartMeter mit ID=0 gibt.

(Auszug aus der Anleitung des aktuellen Fronius 63A SmartMeters)
<img width="789" alt="Bildschirmfoto 2020-07-09 um 23 09 01" src="https://user-images.githubusercontent.com/16595697/87091407-e2aaf300-c239-11ea-8fab-296fdb6762aa.png">

Nur in dieser Konfiguration funktioniert OpenWB bei mir ordentlich (neuste Software auf dem Fronius). Die bisherigen Programmierungen im Modul sind sicherlich nicht ohne Grund gemacht worden, daher habe ich einen Schalter hinzugefügt, der bei Bedarf die ID von 0 auf 1 schaltet. Andere Konfigurationen machen mMn keinen Sinn bei der derzeitigen Gestaltung seitens Fronius.
