### PR TITLE
[soc-tesla] enable logging

### DIFF
--- a/modules/soc_tesla/main.sh
+++ b/modules/soc_tesla/main.sh
@@ -12,7 +12,7 @@ CHARGEPOINT=$1
 
 socTeslaDebug=$debug
 # for developement only
-#socTeslaDebug=1
+socTeslaDebug=1
 
 case $CHARGEPOINT in
 	2)
@@ -29,6 +29,8 @@ case $CHARGEPOINT in
 		;;
 	*)
 		# defaults to first charge point for backward compatibility
+		# set CHARGEPOINT in case it is empty (needed for logging)
+		CHARGEPOINT=1
 		socintervallladen=$(( soc_tesla_intervallladen * 6 ))
 		socintervall=$(( soc_tesla_intervall * 6 ))
 		ladeleistung=$(<$RAMDISKDIR/llaktuell)
@@ -48,6 +50,8 @@ socTeslaLog(){
 		timestamp=`date --rfc-3339=seconds`
 		echo "$timestamp: Lp$CHARGEPOINT: $@" >> $LOGFILE
 	fi
+	# limit logfile to 500 lines
+	mv $LOGFILE $LOGFILE.old; tail -n 500 $LOGFILE.old > $LOGFILE; rm $LOGFILE.old
 }
 
 getAndWriteSoc(){
@@ -113,6 +117,7 @@ checkToken(){
 				setTokenPassword
 			else
 				socTeslaLog "ERROR: Auth with user/pass failed!"
+				echo "Fehler: Anmeldung bei Tesla gescheitert!" > $RAMDISKDIR/lastregelungaktiv
 			fi
 			;;
 	esac


### PR DESCRIPTION
Enables logging to ramdisk and limits size of logfile to 500 lines.
User is noticed if auth with tesla api failed.
fix: show number for chargepoint 1 in logfile