### PR TITLE
Kill old readrfid.py before launching a new one

### DIFF
--- a/runs/atreboot.sh
+++ b/runs/atreboot.sh
@@ -626,6 +626,8 @@ if (( rseenabled == 1 )); then
 	fi
 fi
 if (( rfidakt == 1 )); then
+	sudo kill $(ps aux |grep '[r]eadrfid.py' | awk '{print $2}')
+
 	(sleep 10; sudo python /var/www/html/openWB/runs/readrfid.py $displayaktiv) &
 	(sleep 10; sudo python /var/www/html/openWB/runs/readrfid2.py $displayaktiv) &
 fi


### PR DESCRIPTION
I think that's the way to prevent `atreboot.sh` launching a more and more readrfid.py for every update.

Otherwise, please comment back.