### PR TITLE
fix layout on small devices

### DIFF
--- a/web/settings/misc.beta.php
+++ b/web/settings/misc.beta.php
@@ -725,7 +725,7 @@
 								</div>
 							</div>
 							<div class="form-row mt-2 mb-1">
-								<div class="col-4">
+								<div class="col-md-4">
 									<label for="cpunterbrechunglp1" class="col-form-label">Ladepunkt 1</label>
 								</div>
 								<div class="btn-group btn-group-toggle col" data-toggle="buttons">
@@ -738,7 +738,7 @@
 								</div>
 							</div>
 							<div class="form-row mt-2">
-								<div class="col-4">
+								<div class="col-md-4">
 									<label for="cpunterbrechunglp2" class="col-form-label">Ladepunkt 2</label>
 								</div>
 								<div class="btn-group btn-group-toggle col" data-toggle="buttons">
@@ -1852,7 +1852,7 @@
 								</div>
 							</div>
 							<div class="form-row mb-1">
-								<label for="livegraph" class="col-4 col-sm-4 col-form-label">Zeitintervall für den Live Graphen der Hauptseite</label>
+								<label for="livegraph" class="col-md-4 col-form-label">Zeitintervall für den Live Graphen der Hauptseite</label>
 								<div class="col-md-8">
 									<div class="form-row vaRow mb-1">
 										<label for="livegraph" class="col-2 col-form-label valueLabel" suffix="Min"><?php echo trim($livegraphold); ?> Min</label>

--- a/web/settings/pvconfig.beta.html
+++ b/web/settings/pvconfig.beta.html
@@ -189,7 +189,7 @@
 								</div>
 							</div>
 							<div class="form-row mb-1">
-								<label for="minCurrentLp1" class="col-4 col-md-4 col-form-label">Ladepunkt 1</label>
+								<label for="minCurrentLp1" class="col-md-4 col-form-label">Ladepunkt 1</label>
 								<div class="col-md-8">
 									<div class="form-row vaRow mb-1">
 										<label for="minCurrentLp1" class="col-2 col-form-label valueLabel" suffix="A"> A</label>
@@ -200,7 +200,7 @@
 								</div>
 							</div>
 							<div class="form-row mb-1 lp2options">
-								<label for="minCurrentLp2" class="col-4 col-md-4 col-form-label">Ladepunkt 2</label>
+								<label for="minCurrentLp2" class="col-md-4 col-form-label">Ladepunkt 2</label>
 								<div class="col-md-8">
 									<div class="form-row vaRow mb-1">
 										<label for="minCurrentLp2" class="col-2 col-form-label valueLabel" suffix="A"> A</label>
@@ -230,7 +230,7 @@
 								</div>
 							</div>
 							<div class="form-row mb-1">
-								<label for="adaptiveChargingFactor" class="col-4 col-md-4 col-form-label">adaptiver Regelfaktor</label>
+								<label for="adaptiveChargingFactor" class="col-md-4 col-form-label">adaptiver Regelfaktor</label>
 								<div class="col-md-8">
 									<div class="form-row vaRow mb-1">
 										<label for="adaptiveChargingFactor" class="col-2 col-form-label valueLabel" suffix=""> </label>
@@ -278,7 +278,7 @@
 					<div class="card-body">
 						<div class="form-group onlysoclp1options">
 							<div class="form-row mb-1">
-								<label for="minSocAlwaysToChargeToLp1" class="col-4 col-md-4 col-form-label">Mindest-SoC</label>
+								<label for="minSocAlwaysToChargeToLp1" class="col-md-4 col-form-label">Mindest-SoC</label>
 								<div class="col-md-8">
 									<div class="form-row vaRow mb-1">
 										<label for="minSocAlwaysToChargeToLp1" class="col-2 col-form-label valueLabel" suffix="%"> %</label>
@@ -290,7 +290,7 @@
 								</div>
 							</div>
 							<div class="form-row mb-1">
-								<label for="minSocAlwaysToChargeToCurrentLp1" class="col-4 col-md-4 col-form-label">Mindest-SoC-Stromstärke</label>
+								<label for="minSocAlwaysToChargeToCurrentLp1" class="col-md-4 col-form-label">Mindest-SoC-Stromstärke</label>
 								<div class="col-md-8">
 									<div class="form-row vaRow mb-1">
 										<label for="minSocAlwaysToChargeToCurrentLp1" class="col-2 col-form-label valueLabel" suffix="A"> A</label>
@@ -302,7 +302,7 @@
 								</div>
 							</div>
 							<div class="form-row mb-1">
-								<label for="maxSocToChargeToLp1" class="col-4 col-md-4 col-form-label">Maximal-SoC</label>
+								<label for="maxSocToChargeToLp1" class="col-md-4 col-form-label">Maximal-SoC</label>
 								<div class="col-md-8">
 									<div class="form-row vaRow mb-1">
 										<label for="maxSocToChargeToLp1" class="col-2 col-form-label valueLabel" suffix="%"> %</label>
@@ -437,7 +437,7 @@
 								</div>
 							</div>
 							<div class="form-row mb-1">
-								<label for="minBatteryDischargeSocAtBattPriority" class="col-4 col-md-4 col-form-label">minimaler Entlade-SoC</label>
+								<label for="minBatteryDischargeSocAtBattPriority" class="col-md-4 col-form-label">minimaler Entlade-SoC</label>
 								<div class="col-md-8">
 									<div class="form-row vaRow mb-1">
 										<label for="minBatteryDischargeSocAtBattPriority" class="col-2 col-form-label valueLabel" suffix="%"> %</label>
@@ -461,7 +461,7 @@
 					<div class="card-body">
 						<div class="form-group">
 							<div class="form-row mb-1">
-								<label for="minCurrentMinPv" class="col-4 col-md-4 col-form-label">Mindeststromstärke</label>
+								<label for="minCurrentMinPv" class="col-md-4 col-form-label">Mindeststromstärke</label>
 								<div class="col-md-8">
 									<div class="form-row vaRow mb-1">
 										<label for="minCurrentMinPv" class="col-2 col-form-label valueLabel" suffix="A"> A</label>
@@ -486,7 +486,7 @@
 						</div>
 						<div class="form-group housebatteryoptions">
 							<div class="form-row mb-1">
-								<label for="socStartChargeAtMinPv" class="col-4 col-md-4 col-form-label">Einschalt-SoC</label>
+								<label for="socStartChargeAtMinPv" class="col-md-4 col-form-label">Einschalt-SoC</label>
 								<div class="col-md-8">
 									<div class="form-row vaRow mb-1">
 										<label for="socStartChargeAtMinPv" class="col-2 col-form-label valueLabel" suffix="%"> %</label>
@@ -498,7 +498,7 @@
 								</div>
 							</div>
 							<div class="form-row mb-1">
-								<label for="socStopChargeAtMinPv" class="col-4 col-md-4 col-form-label">Ausschalt-SoC</label>
+								<label for="socStopChargeAtMinPv" class="col-md-4 col-form-label">Ausschalt-SoC</label>
 								<div class="col-md-8">
 									<div class="form-row vaRow mb-1">
 										<label for="socStopChargeAtMinPv" class="col-2 col-form-label valueLabel" suffix="%"> %</label>

--- a/web/settings/settings.beta.php
+++ b/web/settings/settings.beta.php
@@ -827,7 +827,7 @@
 									</div>
 								</div>
 								<div class="form-row mb-1">
-									<label for="zielladenalp1" class="col-4 col-md-4 col-form-label">Stromstärke</label>
+									<label for="zielladenalp1" class="col-md-4 col-form-label">Stromstärke</label>
 									<div class="col-md-8">
 										<div class="form-row vaRow mb-1">
 											<label for="zielladenalp1" class="col-2 col-form-label valueLabel" suffix="A"><?php echo trim($zielladenalp1old); ?> A</label>
@@ -903,7 +903,7 @@
 									</div>
 								</div>
 								<div class="form-row mb-1">
-									<label for="zielladenmaxalp1" class="col-4 col-md-4 col-form-label">maximale Stromstärke</label>
+									<label for="zielladenmaxalp1" class="col-md-4 col-form-label">maximale Stromstärke</label>
 									<div class="col-md-8">
 										<div class="form-row vaRow mb-1">
 											<label for="zielladenmaxalp1" class="col-2 col-form-label valueLabel" suffix="A"><?php echo trim($zielladenmaxalp1old); ?> A</label>
@@ -1168,7 +1168,7 @@
 									</div>
 								</div>
 								<div class="form-row mb-1">
-									<label for="nachtll" class="col-4 col-sm-4 col-form-label">Stromstärke in A</label>
+									<label for="nachtll" class="col-md-4 col-form-label">Stromstärke in A</label>
 									<div class="col-md-8">
 										<div class="form-row vaRow mb-1">
 											<label for="nachtll" class="col-2 col-form-label valueLabel" suffix="A"><?php echo trim($nachtllold); ?> A</label>
@@ -1229,7 +1229,7 @@
 									</div>
 								</div>
 								<div class="form-row mb-1">
-									<label for="nachtsoc" class="col-4 col-sm-4 col-form-label">SoC Sonntag bis Donnerstag</label>
+									<label for="nachtsoc" class="col-md-4 col-form-label">SoC Sonntag bis Donnerstag</label>
 									<div class="col-md-8">
 										<div class="form-row vaRow mb-1">
 											<label for="nachtsoc" class="col-2 col-form-label valueLabel" suffix="%"><?php echo trim($nachtsocold); ?> %</label>
@@ -1241,7 +1241,7 @@
 									</div>
 								</div>
 								<div class="form-row mb-1">
-									<label for="nachtsoc1" class="col-4 col-sm-4 col-form-label">SoC Freitag bis Sonntag</label>
+									<label for="nachtsoc1" class="col-md-4 col-form-label">SoC Freitag bis Sonntag</label>
 									<div class="col-md-8">
 										<div class="form-row vaRow mb-1">
 											<label for="nachtsoc1" class="col-2 col-form-label valueLabel" suffix="%"><?php echo trim($nachtsoc1old); ?> %</label>
@@ -1264,7 +1264,7 @@
 									</div>
 								</div>
 								<div class="form-row mb-1">
-									<label for="mollp1moll" class="col-4 col-sm-4 col-form-label">Stromstärke in A</label>
+									<label for="mollp1moll" class="col-md-4 col-form-label">Stromstärke in A</label>
 									<div class="col-md-8">
 										<div class="form-row vaRow mb-1">
 											<label for="mollp1moll" class="col-2 col-form-label valueLabel" suffix="A"><?php echo trim($mollp1mollold); ?> A</label>
@@ -1377,7 +1377,7 @@
 									</div>
 								</div>
 								<div class="form-row mb-1">
-									<label for="mollp1dill" class="col-4 col-sm-4 col-form-label">Stromstärke in A</label>
+									<label for="mollp1dill" class="col-md-4 col-form-label">Stromstärke in A</label>
 									<div class="col-md-8">
 										<div class="form-row vaRow mb-1">
 											<label for="mollp1dill" class="col-2 col-form-label valueLabel" suffix="A"><?php echo trim($mollp1dillold); ?> A</label>
@@ -1490,7 +1490,7 @@
 									</div>
 								</div>
 								<div class="form-row mb-1">
-									<label for="mollp1mill" class="col-4 col-sm-4 col-form-label">Stromstärke in A</label>
+									<label for="mollp1mill" class="col-md-4 col-form-label">Stromstärke in A</label>
 									<div class="col-md-8">
 										<div class="form-row vaRow mb-1">
 											<label for="mollp1mill" class="col-2 col-form-label valueLabel" suffix="A"><?php echo trim($mollp1millold); ?> A</label>
@@ -1603,7 +1603,7 @@
 									</div>
 								</div>
 								<div class="form-row mb-1">
-									<label for="mollp1doll" class="col-4 col-sm-4 col-form-label">Stromstärke in A</label>
+									<label for="mollp1doll" class="col-md-4 col-form-label">Stromstärke in A</label>
 									<div class="col-md-8">
 										<div class="form-row vaRow mb-1">
 											<label for="mollp1doll" class="col-2 col-form-label valueLabel" suffix="A"><?php echo trim($mollp1dollold); ?> A</label>
@@ -1716,7 +1716,7 @@
 									</div>
 								</div>
 								<div class="form-row mb-1">
-									<label for="mollp1frll" class="col-4 col-sm-4 col-form-label">Stromstärke in A</label>
+									<label for="mollp1frll" class="col-md-4 col-form-label">Stromstärke in A</label>
 									<div class="col-md-8">
 										<div class="form-row vaRow mb-1">
 											<label for="mollp1frll" class="col-2 col-form-label valueLabel" suffix="A"><?php echo trim($mollp1frllold); ?> A</label>
@@ -1829,7 +1829,7 @@
 									</div>
 								</div>
 								<div class="form-row mb-1">
-									<label for="mollp1sall" class="col-4 col-sm-4 col-form-label">Stromstärke in A</label>
+									<label for="mollp1sall" class="col-md-4 col-form-label">Stromstärke in A</label>
 									<div class="col-md-8">
 										<div class="form-row vaRow mb-1">
 											<label for="mollp1sall" class="col-2 col-form-label valueLabel" suffix="A"><?php echo trim($mollp1sallold); ?> A</label>
@@ -1942,7 +1942,7 @@
 									</div>
 								</div>
 								<div class="form-row mb-1">
-									<label for="mollp1soll" class="col-4 col-sm-4 col-form-label">Stromstärke in A</label>
+									<label for="mollp1soll" class="col-md-4 col-form-label">Stromstärke in A</label>
 									<div class="col-md-8">
 										<div class="form-row vaRow mb-1">
 											<label for="mollp1soll" class="col-2 col-form-label valueLabel" suffix="A"><?php echo trim($mollp1sollold); ?> A</label>
@@ -2074,7 +2074,7 @@
 											</div>
 										</div>
 										<div class="form-row mb-1">
-											<label for="nachtlls1" class="col-4 col-sm-4 col-form-label">Stromstärke in A</label>
+											<label for="nachtlls1" class="col-md-4 col-form-label">Stromstärke in A</label>
 											<div class="col-md-8">
 												<div class="form-row vaRow mb-1">
 													<label for="nachtlls1" class="col-2 col-form-label valueLabel" suffix="A"><?php echo trim($nachtlls1old); ?> A</label>
@@ -2135,7 +2135,7 @@
 											</div>
 										</div>
 										<div class="form-row mb-1">
-											<label for="nachtsocs1" class="col-4 col-sm-4 col-form-label">SoC Sonntag bis Donnerstag</label>
+											<label for="nachtsocs1" class="col-md-4 col-form-label">SoC Sonntag bis Donnerstag</label>
 											<div class="col-md-8">
 												<div class="form-row vaRow mb-1">
 													<label for="nachtsocs1" class="col-2 col-form-label valueLabel" suffix="%"><?php echo trim($nachtsocs1old); ?> %</label>
@@ -2147,7 +2147,7 @@
 											</div>
 										</div>
 										<div class="form-row mb-1">
-											<label for="nachtsoc1s1" class="col-4 col-sm-4 col-form-label">SoC Freitag bis Sonntag</label>
+											<label for="nachtsoc1s1" class="col-md-4 col-form-label">SoC Freitag bis Sonntag</label>
 											<div class="col-md-8">
 												<div class="form-row vaRow mb-1">
 													<label for="nachtsoc1s1" class="col-2 col-form-label valueLabel" suffix="%"><?php echo trim($nachtsoc1s1old); ?> %</label>
@@ -2165,7 +2165,7 @@
 											</div>
 										</div>
 										<div class="form-row mb-1">
-											<label for="nacht2lls1" class="col-4 col-sm-4 col-form-label">Stromstärke in A</label>
+											<label for="nacht2lls1" class="col-md-4 col-form-label">Stromstärke in A</label>
 											<div class="col-md-8">
 												<div class="form-row vaRow mb-1">
 													<label for="nacht2lls1" class="col-2 col-form-label valueLabel" suffix="A"><?php echo trim($nacht2lls1old); ?> A</label>


### PR DESCRIPTION
Einige Labels wurden umgebrochen, da die Breite falsch angegeben war. Jetzt wird die komplette Zeile genutzt.