### PR TITLE
disable buttons if data usage is declined

### DIFF
--- a/web/settings/cloudconfig.php
+++ b/web/settings/cloudconfig.php
@@ -68,6 +68,9 @@
 				if(strpos($line, "cloudpw=") !== false) {
 					list(, $cloudpwold) = explode("=", $line, 2);
 				}
+				if(strpos($line, "datenschutzack=") !== false) {
+					list(, $datenschutzackold) = explode("=", $line, 2);
+				}
 			}
 			$files = glob('/etc/mosquitto/conf.d/99-bridge-*.conf*');
 			if (count($files) == 0) {
@@ -96,7 +99,12 @@
 
 		<div role="main" class="container" style="margin-top:20px">
 			<h1>Einstellungen zur openWB Cloud</h1>
-			<?php if (( $connectionName == "cloud") && ( $bridgeEnabled == "1")) { ?>
+			<?php if ( $datenschutzackold != 1 ) { ?>
+				<div class="alert alert-danger">
+					Sie müssen der <a href="tools/datenschutz.html">Datenschutzerklärung</a> zustimmen, um die Cloudanbindung nutzen zu können.
+				</div>
+			<?php }
+			if (( $connectionName == "cloud") && ( $bridgeEnabled == "1")) { ?>
 				<div class="card border-secondary">
 					<div class="card-header bg-secondary">
 						Cloud Anmeldedaten
@@ -162,7 +170,7 @@
 							</div>
 						</div>
 						<div class="card-footer text-center">
-							<button type="submit" class="btn btn-success">Mit Account anmelden</button>
+							<button type="submit" class="btn btn-success"<?php if( $datenschutzackold != 1 ) echo ' disabled="disabled"'; ?>>Mit Account anmelden</button>
 						</div>
 					</form>
 				</div> <!-- card 1 -->
@@ -203,7 +211,7 @@
 							</div>
 						</div>
 						<div class="card-footer text-center">
-							<button type="submit" class="btn btn-success">Neuen Account erstellen und einrichten</button>
+							<button type="submit" class="btn btn-success"<?php if( $datenschutzackold != 1 ) echo ' disabled="disabled"'; ?>>Neuen Account erstellen und einrichten</button>
 						</div>
 					</form>
 				</div> <!-- card 2 -->
@@ -231,7 +239,7 @@
 		<script>
 
 			$.get(
-				{ url: "settings/navbar.html", cache: false},
+				{ url: "settings/navbar.html", cache: false },
 				function(data){
 					$("#nav").replaceWith(data);
 					// disable navbar entry for current page

--- a/web/settings/debugging.php
+++ b/web/settings/debugging.php
@@ -65,6 +65,9 @@
 				if(strpos($line, "debug=") !== false) {
 					list(, $debugmode) = explode("=", $line);
 				}
+				if(strpos($line, "datenschutzack=") !== false) {
+					list(, $datenschutzackold) = explode("=", $line, 2);
+				}
 			}
 			$debugmode = trim($debugmode);
 			if ( $debugmode == "" ) {
@@ -118,6 +121,11 @@
 						Remote Support
 					</div>
 					<div class="card-body">
+						<?php if ( $datenschutzackold != 1 ) { ?>
+						<div class="alert alert-danger">
+							Sie müssen der <a href="tools/datenschutz.html">Datenschutzerklärung</a> zustimmen, um den Online-Support nutzen zu können.
+						</div>
+						<?php } ?>
 						<div class="form-group mb-0">
 							<span id="textHelpBlock" class="form-text">Durch Angabe des Tokens und mit Klick auf "Tunnel herstellen" wird eine Verbindung von der lokalen openWB zum openWB Support hergestellt. openWB erhält damit Vollzugriff auf diese Installation. Diese Schnittstelle nur nach Aufforderung mit dem entsprechenden Token aktivieren.</span>
 							<div class="input-group">
@@ -131,7 +139,7 @@
 						</div>
 					</div>
 					<div class="card-footer text-center">
-						<button type="submit" class="btn btn-success">Tunnel herstellen</button>
+						<button type="submit" class="btn btn-success"<?php if( $datenschutzackold != 1 ) echo ' disabled="disabled"'; ?>>Tunnel herstellen</button>
 					</div>
 				</form>
 			</div>
@@ -147,7 +155,7 @@
 		<script>
 
 			$.get(
-				{ url: "settings/navbar.html", cache: false},
+				{ url: "settings/navbar.html", cache: false },
 				function(data){
 					$("#nav").replaceWith(data);
 					// disable navbar entry for current page

--- a/web/settings/fehlerbericht.php
+++ b/web/settings/fehlerbericht.php
@@ -62,14 +62,9 @@
 			// read selected debug mode from config file
 			$lines = file('/var/www/html/openWB/openwb.conf');
 			foreach($lines as $line) {
-				if(strpos($line, "debug=") !== false) {
-					list(, $debugmode) = explode("=", $line);
+				if(strpos($line, "datenschutzack=") !== false) {
+					list(, $datenschutzackold) = explode("=", $line, 2);
 				}
-			}
-			$debugmode = trim($debugmode);
-			if ( $debugmode == "" ) {
-				// if no debug mode set, set 0 = off
-				$debugmode="0";
 			}
 
 		?>
@@ -78,6 +73,12 @@
 
 		<div role="main" class="container" style="margin-top:20px">
 			<h1>Fehlermeldungen</h1>
+
+			<?php if ( $datenschutzackold != 1 ) { ?>
+			<div class="alert alert-danger">
+				Sie müssen der <a href="tools/datenschutz.html">Datenschutzerklärung</a> zustimmen, um eine Fehlermeldung senden zu können.
+			</div>
+			<?php } ?>
 
 			<div class="card border-secondary">
 				<form class="form" id="sendDebugMessageForm" action="./tools/senddebug.php" method="POST">
@@ -102,7 +103,7 @@
 						</div>
 					</div>
 					<div class="card-footer text-center">
-						<button type="submit" class="btn btn-success">Absenden</button>
+						<button type="submit" class="btn btn-success"<?php if( $datenschutzackold != 1 ) echo ' disabled="disabled"'; ?>>Absenden</button>
 					</div>
 				</form>
 			</div>
@@ -118,7 +119,7 @@
 		<script>
 
 			$.get(
-				{ url: "settings/navbar.html", cache: false},
+				{ url: "settings/navbar.html", cache: false },
 				function(data){
 					$("#nav").replaceWith(data);
 					// disable navbar entry for current page


### PR DESCRIPTION
Aktionen, die eine Einwilligung in die Datenschutzerklärung benötigen, sind deaktiviert, falls die Einwilligung nicht gegeben wurde. Eine Warnmeldung erklärt, warum die Buttons deaktiviert sind und verlinkt auf die Datenschutzerklärung, um nachträglich einzuwilligen.