### PR TITLE
Bugfix: Actually do what debug printout says ...

### DIFF
--- a/slavemode.sh
+++ b/slavemode.sh
@@ -190,6 +190,7 @@ function computeAndSetCurrentForChargePoint() {
 
 			if (( $llneu > $PreviousExpectedChargeCurrent )); then
 				$dbgWrite "$NowItIs: Slave Mode: Fast ramping: EV seems to consume less than allowed (llneu=$llneu > AllowedTotalCurrentPerPhase=$AllowedTotalCurrentPerPhase && llneu > PreviousExpectedChargeCurrent=$PreviousExpectedChargeCurrent): Not changing allowed current."
+				llneu=$PreviousExpectedChargeCurrent
 			else
 				$dbgWrite "$NowItIs: Slave Mode: Fast ramping: EV seems to consume less than allowed (llneu=$llneu > AllowedTotalCurrentPerPhase=$AllowedTotalCurrentPerPhase && llneu <= PreviousExpectedChargeCurrent=$PreviousExpectedChargeCurrent): Limiting allowed current to $AllowedTotalCurrentPerPhase A."
 				llneu=$AllowedTotalCurrentPerPhase


### PR DESCRIPTION
If EV is not consuming the allowed power, algorithms might
calculate an allowed value that exceeds allowed system total current.
This is handled by  checks which work correct and print correct
debug messages. But they missed to do what the printout says.

In consquence, in some special cases, there could be osciallations of
allowed current in every control loop.. But as this only happened when
EV was anyway consuming by far less, it didn't affect the charge operation
at all. Still, it should be fixed.