### PR TITLE
Perform random sleep before loop

### DIFF
--- a/loadvars.sh
+++ b/loadvars.sh
@@ -59,6 +59,7 @@ lp5enabled=$(<ramdisk/lp5enabled)
 lp6enabled=$(<ramdisk/lp6enabled)
 lp7enabled=$(<ramdisk/lp7enabled)
 lp8enabled=$(<ramdisk/lp8enabled)
+
 version=$(<web/version)
 # EVSE DIN Plug State
 declare -r IsNumberRegex='^[0-9]+$'
@@ -1563,8 +1564,15 @@ fi
 ouiplast=$(<ramdisk/mqttupdateinprogress)
 auiplast=$(<ramdisk/updateinprogress)
 if [[ "$ouiplast" != "$auiplast" ]]; then
-	tempPubList="${tempPubList}\nopenWB/system/updateInProgress=${auiplast}"
-	echo $arfidlast > ramdisk/mqttupdateinprogress
+		tempPubList="${tempPubList}\nopenWB/system/updateInProgress=${auiplast}"
+		echo $auiplast > ramdisk/mqttupdateinprogress
+fi
+
+arandomSleep=$(<ramdisk/randomSleepValue)
+orandomSleepValue=$(<ramdisk/mqttRandomSleepValue)
+if [[ "$orandomSleepValue" != "$arandomSleep" ]]; then
+		tempPubList="${tempPubList}\nopenWB/system/randomSleep=${arandomSleep}"
+		echo $arandomSleep > ramdisk/mqttRandomSleepValue
 fi
 
 declare -A mqttconfvar

--- a/regel.sh
+++ b/regel.sh
@@ -31,14 +31,16 @@ cd /var/www/html/openWB/
 
 declare -r IsFloatingNumberRegex='^-?[0-9.]+$'
 
-randomSleep=$(<ramdisk/randomSleepValue)
-if [[ -z $randomSleep ]] || ! [[ "${randomSleep}" =~ $IsFloatingNumberRegex ]]; then
-    randomSleep=`shuf --random-source=/dev/urandom -i 0-8 -n 1`.`shuf --random-source=/dev/urandom -i 0-9 -n 1`
-    echo $(date +%s): ramdisk/randomSleepValue missing - creating new one containing $randomSleep
-    echo $randomSleep > ramdisk/randomSleepValue
-fi
+if (( slavemode == 1)); then
+	randomSleep=$(<ramdisk/randomSleepValue)
+	if [[ -z $randomSleep ]] || ! [[ "${randomSleep}" =~ $IsFloatingNumberRegex ]]; then
+		randomSleep=`shuf --random-source=/dev/urandom -i 0-8 -n 1`.`shuf --random-source=/dev/urandom -i 0-9 -n 1`
+		echo $(date +%s): ramdisk/randomSleepValue missing - creating new one containing $randomSleep
+		echo $randomSleep > ramdisk/randomSleepValue
+	fi
 
-sleep $randomSleep
+	sleep $randomSleep
+fi
 
 source minundpv.sh
 source nurpv.sh

--- a/regel.sh
+++ b/regel.sh
@@ -28,6 +28,18 @@ set -o pipefail
 cd /var/www/html/openWB/
 #config file einlesen
 . /var/www/html/openWB/loadconfig.sh
+
+declare -r IsFloatingNumberRegex='^-?[0-9.]+$'
+
+randomSleep=$(<ramdisk/randomSleepValue)
+if [[ -z $randomSleep ]] || ! [[ "${randomSleep}" =~ $IsFloatingNumberRegex ]]; then
+    randomSleep=`shuf --random-source=/dev/urandom -i 0-8 -n 1`.`shuf --random-source=/dev/urandom -i 0-9 -n 1`
+    echo $(date +%s): ramdisk/randomSleepValue missing - creating new one containing $randomSleep
+    echo $randomSleep > ramdisk/randomSleepValue
+fi
+
+sleep $randomSleep
+
 source minundpv.sh
 source nurpv.sh
 source auslademodus.sh
@@ -49,6 +61,7 @@ re='^-?[0-9]+$'
 if [[ $isss == "1" ]]; then
        exit 0
 fi
+
 #doppelte Ausfuehrungsgeschwindigkeit
 if [[ $dspeed == "1" ]]; then
 	if [ -e ramdisk/5sec ]; then

--- a/runs/cronnightly.sh
+++ b/runs/cronnightly.sh
@@ -91,3 +91,10 @@ curl -s https://raw.githubusercontent.com/snaptec/openWB/master/web/version > /v
 curl -s https://raw.githubusercontent.com/snaptec/openWB/beta/web/version > /var/www/html/openWB/ramdisk/vbeta
 curl -s https://raw.githubusercontent.com/snaptec/openWB/stable/web/version > /var/www/html/openWB/ramdisk/vstable
 
+randomSleep=$(<ramdisk/randomSleepValue)
+if [[ ! -z $randomSleep ]] && (( `echo "$randomSleep != 0" | bc` == 1 )); then
+    echo $(date +%s): Deleting ramdisk/randomSleepValue to force new randomization
+    rm /var/www/html/openWB/ramdisk/randomSleepValue
+else
+    echo "Not deleting randomSleepValue"
+fi


### PR DESCRIPTION
In order to avoid that multiple, time-synced openWBs execute their control loop in almost the same millisecond, this PR introduces a random sleep in range 0.0 - 8.9 seconds before the control loop.
Hence the loop doesn't run a 0, 10, 20, 30, 40 and 50 seconds but 0+random, 10+random, ...

The random value is re-computed once every night such that no openWB will have continuous disadvantages over other boxes e.g. because it's always "the last" one.

Randomness is disabled if not in slave mode or by writing `0` into `ramdisk/randomSleepValue`. In that case even the re-randomize at night will be skipped. The default, however, is to randomize.

Also fixes a little copy-and-paste bug causing `openWB/system/updateInProgress` being sent in each and every loop.

I'm filing this as a draft for discussion.

But I guess it would be beneficial for all setups running >1 independent openWBs if one wallbox has the chance to "see" the adjustments that another box has made (e.g. when reading EVU / Solar meters). This will avoid spikes in if both boxes start doing the same control step at the same time without knowing of each other.  
For single openWBs it has no impact at all whether loop is executed at integer 10 seconds each minute or at any other time. So no special handling seems required.