### PR TITLE
Smarthome ausschalten beim Laden

### DIFF
--- a/modules/smart_elwa/watt.py
+++ b/modules/smart_elwa/watt.py
@@ -64,7 +64,7 @@ if count5==0:
       faktor = 1.2
    else:
       faktor = 1
-      modbuswrite = 0
+   modbuswrite = 0
    # weiche Anpassung bei negativem ueberschuss
    if uberschuss < 0:
       neupower = aktpower + uberschuss


### PR DESCRIPTION
Wenn "Auschalten beim Laden " im smarthomedevice gesetzt ist, werden smarthomedevices beim Starten vom Ladevorgang ausgeschaltet respektive nicht eingeschaltet. Funktioniert bei min+pv. für nur pv muss noch nurpv.sh angepasst werden. Die aktuelle Leistungsaufnahme der aktuellen Devices die (jetzt) abgeschaltet werden können werden in /ramdisk/devicetotal_watt geschrieben. (Mindeseinschaltdauer wird berücksichtigt)
Elwa Einrückung korrigiert