### PR TITLE
Update loadvars.sh

### DIFF
--- a/loadvars.sh
+++ b/loadvars.sh
@@ -853,6 +853,11 @@ else
 	wattbezugint=$((-uberschuss))
 	wattbezug=$wattbezugint
 fi
+# Abschaltbare Smartdevices zum Ueberschuss rechnen
+echo $uberschuss > /var/www/html/openWB/ramdisk/ueberschuss_org
+wattabs=$(cat /var/www/html/openWB/ramdisk/devicetotal_watt)
+uberschuss=$((uberschuss + wattabs))
+echo $uberschuss > /var/www/html/openWB/ramdisk/ueberschuss_mitsmart
 
 #Soc ermitteln
 if [[ $socmodul != "none" ]]; then


### PR DESCRIPTION
Neu wird in die Überschussberechnung das Total aller jetzt abschaltbaren Smarthomedevices eingerechnet (devicetotalwatt positve Zahl, entspricht der aktuellen Leistungsaufnahme ller jetzt abschaltbaren Smarthomedevices  unter Berücksichtigung der Mindestlaufzeit) . Somit wird bei pv min Betrieb unter Umständen eine Autoladung gestartet. Und dann reagiert der smarthomehandler auf die gestartete Autoladung und schaltet diese Smarthomedevices aus. Das ganze wurde von Bastian getestet (siehe Forum)