### PR TITLE
Generelle Bearbeitung .log Dateien durch cron5min.sh

### DIFF
--- a/runs/cleanup.sh
+++ b/runs/cleanup.sh
@@ -1,0 +1,4 @@
+#!/bin/bash
+
+find /var/www/html/openWB/ramdisk/* -name *.log -type f -exec /var/www/html/openWB/runs/cleanupf.sh {} \;
+

--- a/runs/cleanupf.sh
+++ b/runs/cleanupf.sh
@@ -1,0 +1,4 @@
+#!/bin/bash
+#echo "tail $1"
+ls $1 -l
+echo "$(tail -1000 $1)" > $1

--- a/runs/cron5min.sh
+++ b/runs/cron5min.sh
@@ -197,11 +197,11 @@ echo $hausdailyyield > /var/www/html/openWB/ramdisk/daily_hausverbrauchkwh
 ip route get 1 | awk '{print $NF;exit}' > /var/www/html/openWB/ramdisk/ipaddress
 
 
-echo "$(tail -500 /var/www/html/openWB/ramdisk/smarthome.log)" > /var/www/html/openWB/ramdisk/smarthome.log
-echo "$(tail -500 /var/www/html/openWB/ramdisk/mqtt.log)" > /var/www/html/openWB/ramdisk/mqtt.log
-echo "$(tail -500 /var/www/html/openWB/ramdisk/nurpv.log)" > /var/www/html/openWB/ramdisk/nurpv.log
-echo "$(tail -5000 /var/www/html/openWB/ramdisk/nurpv.log)" > /var/www/html/openWB/ramdisk/isss.log
-echo "$(tail -5000 /var/www/html/openWB/ramdisk/nurpv.log)" > /var/www/html/openWB/ramdisk/rfid.log
+#echo "$(tail -500 /var/www/html/openWB/ramdisk/smarthome.log)" > /var/www/html/openWB/ramdisk/smarthome.log
+#echo "$(tail -500 /var/www/html/openWB/ramdisk/mqtt.log)" > /var/www/html/openWB/ramdisk/mqtt.log
+#echo "$(tail -500 /var/www/html/openWB/ramdisk/nurpv.log)" > /var/www/html/openWB/ramdisk/nurpv.log
+#echo "$(tail -5000 /var/www/html/openWB/ramdisk/nurpv.log)" > /var/www/html/openWB/ramdisk/isss.log
+#echo "$(tail -5000 /var/www/html/openWB/ramdisk/nurpv.log)" > /var/www/html/openWB/ramdisk/rfid.log
 
 
 if ps ax |grep -v grep |grep "python3 /var/www/html/openWB/runs/mqttsub.py" > /dev/null
@@ -214,7 +214,7 @@ if ps ax |grep -v grep |grep "python3 /var/www/html/openWB/runs/smarthomehandler
 then
 	echo "test" > /dev/null
 else
-	python3 /var/www/html/openWB/runs/smarthomehandler.py &
+	python3 /var/www/html/openWB/runs/smarthomehandler.py  >> /var/www/html/openWB/ramdisk/smarthomehandler.log 2>&1 &
 fi
 
 if (( isss == 1 )); then
@@ -264,3 +264,4 @@ then
 else
        sudo python3 /var/www/html/openWB/runs/modbusserver/modbusserver.py &
 fi
+	/var/www/html/openWB/runs/cleanup.sh >> /var/www/html/openWB/ramdisk/cleanup.log 2>&1


### PR DESCRIPTION
Neu werden alle *.Log Dateien auf der Ramdisk  gleichartig durch cron5min bearbeited (tail 1000) . openWB.Log ist ausgenommen, da nur link auf der Ramdisk.
Cleanup.sh sind Suchparameter. Cleanupsf.sh ist das Tailkommando welches für jede Datei durchlaufen wird,
Ebenso wird der Output vom Smarthomehandler.py neu in eine separates *.log geschrieben