### PR TITLE
wizzard fix: dark themes

### DIFF
--- a/web/themes/Gauges/settings.css
+++ b/web/themes/Gauges/settings.css
@@ -19,7 +19,7 @@ body {
 	background-attachment: fixed;
 }
 
-.bg-warning, .bg-info, .bg-success {
+.bg-warning, .bg-info, .bg-success, .bg-light {
 	color: #212529;
 }
 

--- a/web/themes/dark/settings.css
+++ b/web/themes/dark/settings.css
@@ -19,7 +19,7 @@ body {
 	background-attachment: fixed;
 }
 
-.bg-warning, .bg-info, .bg-success {
+.bg-warning, .bg-info, .bg-success, .bg-light {
 	color: #212529;
 }
 


### PR DESCRIPTION
fix white text on light background in dark themes