### PR TITLE
Create ramdisk/mqttpvvorhanden at reboot

### DIFF
--- a/runs/atreboot.sh
+++ b/runs/atreboot.sh
@@ -159,6 +159,7 @@ echo 0 > /var/www/html/openWB/ramdisk/mqttlastchargestat
 echo 0 > /var/www/html/openWB/ramdisk/mqttlastchargestats1
 echo 0 > /var/www/html/openWB/ramdisk/mqttlastplugstats1
 echo 2 > /var/www/html/openWB/ramdisk/mqttspeichervorhanden
+echo 0 > /var/www/html/openWB/ramdisk/mqttpvvorhanden
 echo 3 > /var/www/html/openWB/ramdisk/mqttspeichersoc
 echo 2 > /var/www/html/openWB/ramdisk/mqttspeicherleistung
 echo 0 > /var/www/html/openWB/ramdisk/mqttladeleistungs1


### PR DESCRIPTION
Currently `openWB.log` is filling up with lines
```
loadvars.sh: Zeile 1386: ramdisk/mqttpvvorhanden: Datei oder Verzeichnis nicht gefunden
```
for every single control loop (i.e. one line every 10s).

As that will not really help extending sd-card life this PR will create the missing file with a value of 0 in `atreboot.sh`.

Please double-check if 0 is a reasonable default and correct if necessary.