### PR TITLE
fix: typo bei Ladepunkt 1

### DIFF
--- a/web/display2/display.html
+++ b/web/display2/display.html
@@ -146,7 +146,7 @@
             <!-- Ladepunkt 1 -->
             <div class="row" data-lp="1">
                 <div class="card col-xs-12">
-                    <div class="card-header bg-primary nameLp">
+                    <div class="card-header bg-primary">
                         <div class="row pr-3">
                             <div class="col cursor-pointer nameLp enableLp lpDisabledStyle">
                                 Ladepunkt 1


### PR DESCRIPTION
Wenn ein Name für den ersten Ladepunkt gesetzt ist, wurde der falsche DIV-Tag aktualisiert.