### PR TITLE
Persist plugin meter value accross restart

### DIFF
--- a/loadvars.sh
+++ b/loadvars.sh
@@ -1589,36 +1589,6 @@ loadvars(){
 			echo $arandomSleep > ramdisk/mqttRandomSleepValue
 	fi
 
-	for i in $(seq 1 8);
-	do
-		for f in \
-			"pluggedladunglp${i}startkwh:openWB/lp/${i}/plugStartkWh" \
-			"pluggedladungaktlp${i}:openWB/lp/${i}/pluggedladungakt"
-		do
-			IFS=':' read -r -a tuple <<< "$f"
-			local currentRamdiskFileVar="\"ramdisk/${tuple[0]}\""
-			local mqttRamdiskFileVar="\"ramdisk/mqtt${tuple[0]}\""
-			#echo "Working on currentRamdiskFile='$currentRamdiskFileVar', mqttRamdiskFile='$mqttRamdiskFileVar'"
-			eval currentRamdiskFile=\$$currentRamdiskFileVar
-			eval mqttRamdiskFile=\$$mqttRamdiskFileVar
-			if [ -r $currentRamdiskFile ]; then
-
-				aramdiskValue=$(<$currentRamdiskFile)
-				if [ -r $mqttRamdiskFile ]; then
-					oramdikValue=$(<$mqttRamdiskFile)
-				else
-					oramdikValue=0
-				fi
-
-				if [[ "$oramdikValue" != "$aramdiskValue" ]]; then
-					#echo "'$currentRamdiskFile' found changed: Fowarding value '$aramdiskValue' to MQTT topic '${tuple[1]}'"
-					tempPubList="${tempPubList}\n${tuple[1]}=${aramdiskValue}"
-					echo $aramdiskValue > $mqttRamdiskFile
-				fi
-			fi
-		done
-	done
-
 	declare -A mqttconfvar
 	mqttconfvar["config/get/pv/minFeedinPowerBeforeStart"]=mindestuberschuss
 	mqttconfvar["config/get/pv/maxPowerConsumptionBeforeStop"]=abschaltuberschuss

--- a/loadvars.sh
+++ b/loadvars.sh
@@ -1589,6 +1589,36 @@ loadvars(){
 			echo $arandomSleep > ramdisk/mqttRandomSleepValue
 	fi
 
+	for i in $(seq 1 8);
+	do
+		for f in \
+			"pluggedladunglp${i}startkwh:openWB/lp/${i}/plugStartkWh" \
+			"pluggedladungaktlp${i}:openWB/lp/${i}/pluggedladungakt"
+		do
+			IFS=':' read -r -a tuple <<< "$f"
+			local currentRamdiskFileVar="\"ramdisk/${tuple[0]}\""
+			local mqttRamdiskFileVar="\"ramdisk/mqtt${tuple[0]}\""
+			#echo "Working on currentRamdiskFile='$currentRamdiskFileVar', mqttRamdiskFile='$mqttRamdiskFileVar'"
+			eval currentRamdiskFile=\$$currentRamdiskFileVar
+			eval mqttRamdiskFile=\$$mqttRamdiskFileVar
+			if [ -r $currentRamdiskFile ]; then
+
+				aramdiskValue=$(<$currentRamdiskFile)
+				if [ -r $mqttRamdiskFile ]; then
+					oramdikValue=$(<$mqttRamdiskFile)
+				else
+					oramdikValue=0
+				fi
+
+				if [[ "$oramdikValue" != "$aramdiskValue" ]]; then
+					#echo "'$currentRamdiskFile' found changed: Fowarding value '$aramdiskValue' to MQTT topic '${tuple[1]}'"
+					tempPubList="${tempPubList}\n${tuple[1]}=${aramdiskValue}"
+					echo $aramdiskValue > $mqttRamdiskFile
+				fi
+			fi
+		done
+	done
+
 	declare -A mqttconfvar
 	mqttconfvar["config/get/pv/minFeedinPowerBeforeStart"]=mindestuberschuss
 	mqttconfvar["config/get/pv/maxPowerConsumptionBeforeStop"]=abschaltuberschuss

--- a/runs/atreboot.sh
+++ b/runs/atreboot.sh
@@ -138,11 +138,9 @@ echo 0 > /var/www/html/openWB/ramdisk/mqttrfidlasttag
 echo 0 > /var/www/html/openWB/ramdisk/ledstatus
 echo 1 > /var/www/html/openWB/ramdisk/execdisplay
 echo 0 > /var/www/html/openWB/ramdisk/pluggedladungaktlp1
-echo 0 > /var/www/html/openWB/ramdisk/pluggedladunglp1startkwh
 echo 0 > /var/www/html/openWB/ramdisk/pluggedladungbishergeladen
 echo 0 > /var/www/html/openWB/ramdisk/pluggedtimer1
 echo 0 > /var/www/html/openWB/ramdisk/pluggedladungaktlp2
-echo 0 > /var/www/html/openWB/ramdisk/pluggedladunglp2startkwh
 echo 0 > /var/www/html/openWB/ramdisk/pluggedladungbishergeladenlp2
 echo 0 > /var/www/html/openWB/ramdisk/pluggedtimer2
 echo 0 > /var/www/html/openWB/ramdisk/pluggedladungbishergeladenlp3
@@ -579,8 +577,25 @@ sudo chmod -R +x /var/www/html/openWB/modules/*
 sudo chmod -R 777 /var/www/html/openWB/modules/soc_i3
 sudo chmod -R 777 /var/www/html/openWB/modules/soc_i3s1
 
-
-
+for i in $(seq 1 8);
+do
+	for f in "pluggedladunglp${i}startkwh:openWB/lp/${i}/plugStartkWh" "pluggedladungaktlp${i}:openWB/lp/${i}/pluggedladungakt"
+	do
+		IFS=':' read -r -a tuple <<< "$f"
+		currentRamdiskFileVar="\"/var/www/html/openWB/ramdisk/${tuple[0]}\""
+		eval currentRamdiskFile=\$$currentRamdiskFileVar
+		if ! [ -f $currentRamdiskFile ]; then
+			mqttValue=$(timeout 1 mosquitto_sub -C 1 -t ${tuple[1]})
+			if [[ ! -z "$mqttValue" ]]; then
+				echo "'$currentRamdiskFile' missing: Setting from MQTT topic '${tuple[0]}' to value '$mqttValue'"
+				echo "$mqttValue" > $currentRamdiskFile
+			else
+				echo "'$currentRamdiskFile' missing: MQTT topic '${tuple[0]}' can also not provide any value: Setting to 0"
+				echo 0 > $currentRamdiskFile
+			fi
+		fi
+	done
+done
 
 ln -s /var/log/openWB.log /var/www/html/openWB/ramdisk/openWB.log
 mkdir -p /var/www/html/openWB/web/logging/data/daily

--- a/runs/atreboot.sh
+++ b/runs/atreboot.sh
@@ -137,10 +137,8 @@ echo 0 > /var/www/html/openWB/ramdisk/mqttrfidlasttag
 # echo 1 > /var/www/html/openWB/ramdisk/reloaddisplay
 echo 0 > /var/www/html/openWB/ramdisk/ledstatus
 echo 1 > /var/www/html/openWB/ramdisk/execdisplay
-echo 0 > /var/www/html/openWB/ramdisk/pluggedladungaktlp1
 echo 0 > /var/www/html/openWB/ramdisk/pluggedladungbishergeladen
 echo 0 > /var/www/html/openWB/ramdisk/pluggedtimer1
-echo 0 > /var/www/html/openWB/ramdisk/pluggedladungaktlp2
 echo 0 > /var/www/html/openWB/ramdisk/pluggedladungbishergeladenlp2
 echo 0 > /var/www/html/openWB/ramdisk/pluggedtimer2
 echo 0 > /var/www/html/openWB/ramdisk/pluggedladungbishergeladenlp3
@@ -579,7 +577,9 @@ sudo chmod -R 777 /var/www/html/openWB/modules/soc_i3s1
 
 for i in $(seq 1 8);
 do
-	for f in "pluggedladunglp${i}startkwh:openWB/lp/${i}/plugStartkWh" "pluggedladungaktlp${i}:openWB/lp/${i}/pluggedladungakt"
+	for f in \
+		"pluggedladunglp${i}startkwh:openWB/lp/${i}/plugStartkWh" \
+		"pluggedladungaktlp${i}:openWB/lp/${i}/pluggedladungakt"
 	do
 		IFS=':' read -r -a tuple <<< "$f"
 		currentRamdiskFileVar="\"/var/www/html/openWB/ramdisk/${tuple[0]}\""

--- a/runs/pubmqtt.sh
+++ b/runs/pubmqtt.sh
@@ -240,15 +240,24 @@ for mq in "${!mqttvar[@]}"; do
 	declare o${mqttvar[$mq]}
 	declare ${mqttvar[$mq]}
 	tempnewname=${mqttvar[$mq]}
-
 	tempoldname=o${mqttvar[$mq]}
-	tempoldname=$(<ramdisk/mqtt"${mqttvar[$mq]}")
-	tempnewname=$(<ramdisk/"${mqttvar[$mq]}")
-	if [[ "$tempoldname" != "$tempnewname" ]]; then
-		tempPubList="${tempPubList}\nopenWB/${mq}=${tempnewname}"
-		echo $tempnewname > ramdisk/mqtt${mqttvar[$mq]}
+
+	if [ -r ramdisk/"${mqttvar[$mq]}" ]; then
+
+		tempnewname=$(<ramdisk/"${mqttvar[$mq]}")
+
+		if [ -r ramdisk/mqtt"${mqttvar[$mq]}" ]; then
+			tempoldname=$(<ramdisk/mqtt"${mqttvar[$mq]}")
+		else
+			tempoldname=""
+		fi
+
+		if [[ "$tempoldname" != "$tempnewname" ]]; then
+			tempPubList="${tempPubList}\nopenWB/${mq}=${tempnewname}"
+			echo $tempnewname > ramdisk/mqtt${mqttvar[$mq]}
+		fi
+		#echo ${mqttvar[$mq]} $mq
 	fi
-	#echo ${mqttvar[$mq]} $mq
 done
 
 

--- a/runs/pubmqtt.sh
+++ b/runs/pubmqtt.sh
@@ -223,6 +223,18 @@ mqttvar["lp/6/TimeRemaining"]=restzeitlp6
 mqttvar["lp/7/TimeRemaining"]=restzeitlp7
 mqttvar["lp/8/TimeRemaining"]=restzeitlp8
 
+for i in $(seq 1 8);
+do
+	for f in \
+		"lp/${i}/plugStartkWh:pluggedladunglp${i}startkwh" \
+		"lp/${i}/pluggedladungakt:pluggedladungaktlp${i}"
+	do
+		IFS=':' read -r -a tuple <<< "$f"
+		#echo "Setting mqttvar[${tuple[0]}]=${tuple[1]}"
+		mqttvar["${tuple[0]}"]=${tuple[1]}
+	done
+done
+
 tempPubList=""
 for mq in "${!mqttvar[@]}"; do
 	declare o${mqttvar[$mq]}
@@ -236,7 +248,7 @@ for mq in "${!mqttvar[@]}"; do
 		tempPubList="${tempPubList}\nopenWB/${mq}=${tempnewname}"
 		echo $tempnewname > ramdisk/mqtt${mqttvar[$mq]}
 	fi
-	#echo ${mqttvar[$mq]} $mq 
+	#echo ${mqttvar[$mq]} $mq
 done
 
 


### PR DESCRIPTION
Avoid wrong values for "Geladen seit Einstecken" when openWB gets reboot (ramdisk loss).

Tested with reboot.
Could not yet test with SW-Update as that obviously overwrites the files until the changes are part of official repo.