### PR TITLE
Slavemode: Fix div/0 in rare cases at low charge currents

### DIFF
--- a/slavemode.sh
+++ b/slavemode.sh
@@ -454,11 +454,11 @@ function aggregateDataForChargePoint() {
 			NumberOfChargingPhases=$previousNumberOfChargingPhases
 			$dbgWrite "$NowItIs: CP${chargePoint}: Previously charging phase #${ChargingPhaseWithMaximumTotalCurrent} has highest current and will be used for load management"
 		fi
+	fi
 
-		# if we have no charging vehicles at all, assume ourself as charging (and avoid dev/0 error)
-		if (( ChargingVehiclesAdjustedForThisCp == 0 )); then
-			ChargingVehiclesAdjustedForThisCp=1
-		fi
+	# if we have no charging vehicles at all, assume ourself as charging (and avoid dev/0 error)
+	if (( ChargingVehiclesAdjustedForThisCp == 0 )); then
+		ChargingVehiclesAdjustedForThisCp=1
 	fi
 
 	# we must make sure that we don't leave NumberOfChargingPhases at 0 if we couldn't count it up to here


### PR DESCRIPTION
In rare occasions at low charge power it could happen that the if-clause at the end of which the `ChargingVehiclesAdjustedForThisCp` is changed from 0 to 1 (assuming the own box always charges) is not executed.

Hence `ChargingVehiclesAdjustedForThisCp` stays at 0 causing a div/0 error in algorithm which again causes charge current to be set to 0.

Once the EV stops charging, another control flow is taken which is finally re-granting charge. End of the story is a nasty oscillation.

The  `ChargingVehiclesAdjustedForThisCp` = 0 compensation has simply been moved out of the critical if statement.