### PR TITLE
Reliably activate randomization in slave mode after reboot

### DIFF
--- a/regel.sh
+++ b/regel.sh
@@ -33,9 +33,9 @@ declare -r IsFloatingNumberRegex='^-?[0-9.]+$'
 
 if (( slavemode == 1)); then
 	randomSleep=$(<ramdisk/randomSleepValue)
-	if [[ -z $randomSleep ]] || ! [[ "${randomSleep}" =~ $IsFloatingNumberRegex ]]; then
+	if [[ -z $randomSleep ]] || [[ "${randomSleep}" == "0" ]] || ! [[ "${randomSleep}" =~ $IsFloatingNumberRegex ]]; then
 		randomSleep=`shuf --random-source=/dev/urandom -i 0-8 -n 1`.`shuf --random-source=/dev/urandom -i 0-9 -n 1`
-		echo $(date +%s): ramdisk/randomSleepValue missing - creating new one containing $randomSleep
+		echo "$(date +%s): slavemode=$slavemode: ramdisk/randomSleepValue missing or 0 - creating new one containing $randomSleep"
 		echo $randomSleep > ramdisk/randomSleepValue
 	fi
 


### PR DESCRIPTION
`atreboot.sh` unconditionally creates randomization value of 0.  
It causes `regel.sh` to not create a random value any more. Similarly `cronnightly.sh` will not delete the file containing 0.  
In other words: The implementation didn't consider reboot where ramdisk gets lost.  

Since randomization is happening in slave mode only, implementation has been changed such that a value of 0 now also triggers creation of new random value.

**Important:** With the new implementation randomization will always be active in slave mode. If that's not acceptable we need a persistent setting in `openwb.conf` (feel free to coment in that case).