### PR TITLE
http Geräte im smarthomehandler Unterstützung

### DIFF
--- a/modules/smarthome/http/off.py
+++ b/modules/smarthome/http/off.py
@@ -1,0 +1,27 @@
+#!/usr/bin/python3
+import sys
+import os
+import time
+import json
+import getopt
+import socket
+import struct
+import codecs
+import binascii
+import urllib.request
+from urllib.parse import urlparse
+named_tuple = time.localtime() # getstruct_time
+time_string = time.strftime("%m/%d/%Y, %H:%M:%S http off.py", named_tuple)
+devicenumber=str(sys.argv[1])
+uberschuss=int(sys.argv[3])
+url=str(sys.argv[4])
+if not urlparse(url).scheme:
+   url = 'http://' + url
+file_string= '/var/www/html/openWB/ramdisk/smarthome_device_' + str(devicenumber) + '_http.log'
+if os.path.isfile(file_string):
+   f = open( file_string , 'a')
+else:
+   f = open( file_string , 'w')
+print ('%s devicenr %s url %s)' % (time_string,devicenumber,url),file=f)
+f.close()
+urllib.request.urlopen(url, timeout=5)

--- a/modules/smarthome/http/on.py
+++ b/modules/smarthome/http/on.py
@@ -1,0 +1,27 @@
+#!/usr/bin/python3
+import sys
+import os
+import time
+import json
+import getopt
+import socket
+import struct
+import codecs
+import binascii
+import urllib.request
+from urllib.parse import urlparse
+named_tuple = time.localtime() # getstruct_time
+time_string = time.strftime("%m/%d/%Y, %H:%M:%S http on.py", named_tuple)
+devicenumber=str(sys.argv[1])
+uberschuss=int(sys.argv[3])
+url=str(sys.argv[4])
+if not urlparse(url).scheme:
+   url = 'http://' + url
+file_string= '/var/www/html/openWB/ramdisk/smarthome_device_' + str(devicenumber) + '_http.log'
+if os.path.isfile(file_string):
+   f = open( file_string , 'a')
+else:
+   f = open( file_string , 'w')
+print ('%s devicenr %s url %s)' % (time_string,devicenumber,url),file=f)
+f.close()
+urllib.request.urlopen(url, timeout=5)

--- a/modules/smarthome/http/watt.py
+++ b/modules/smarthome/http/watt.py
@@ -1,0 +1,39 @@
+#!/usr/bin/python3
+import sys
+import os
+import time
+import json
+import getopt
+import socket
+import struct
+import codecs
+import binascii
+import urllib.request
+from urllib.parse import urlparse
+named_tuple = time.localtime() # getstruct_time
+time_string = time.strftime("%m/%d/%Y, %H:%M:%S http watty.py", named_tuple)
+devicenumber=str(sys.argv[1])
+uberschuss=int(sys.argv[3])
+url=str(sys.argv[4])
+if not urlparse(url).scheme:
+   url = 'http://' + url
+if uberschuss < 0:
+   uberschuss = 0
+urlrep= url.replace("<openwb-ueberschuss>", str(uberschuss))
+file_string= '/var/www/html/openWB/ramdisk/smarthome_device_' + str(devicenumber) + '_http.log'
+if os.path.isfile(file_string):
+   f = open( file_string , 'a')
+else:
+   f = open( file_string , 'w')
+print ('%s devicenr %s orig url %s replaced url %s' % (time_string,devicenumber,url,urlrep),file=f)
+f.close()
+aktpower = int(urllib.request.urlopen(urlrep, timeout=5).read().decode("utf-8"))
+if aktpower > 50:
+    relais = 1
+else:
+    relais = 0
+powerc = 0
+answer = '{"power":' + str(aktpower) + ',"powerc":' + str(powerc) + ',"on":' + str(relais) + '} '
+f1 = open('/var/www/html/openWB/ramdisk/smarthome_device_ret' + str(devicenumber), 'w')
+json.dump(answer,f1)
+f1.close() 

--- a/modules/smarthome/sdm630/sdm630.py
+++ b/modules/smarthome/sdm630/sdm630.py
@@ -27,6 +27,6 @@ watti = struct.unpack('>f',struct.pack('>HH',*resp.registers))
 watt = int(watti[0])
 
 answer = '{"power":' + str(watt) + ',"powerc":' + str(vwh3) + '} '
-f1 = open('/var/www/html/openWB/ramdisk/smarthome_device_rets' + str(devicenumber), 'w')
+f1 = open('/var/www/html/openWB/ramdisk/smarthome_device_ret' + str(devicenumber), 'w')
 json.dump(answer,f1)
 f1.close()

--- a/modules/smarthome/shelly/watt.py
+++ b/modules/smarthome/shelly/watt.py
@@ -15,7 +15,10 @@ devicenumber=str(sys.argv[1])
 ipadr=str(sys.argv[2])
 uberschuss=int(sys.argv[3])
 answer = json.loads(str(urllib.request.urlopen("http://"+str(ipadr)+"/status", timeout=3).read().decode("utf-8")))
-aktpower = int(answer['meters'][0]['power'])
+try:
+    aktpower = int(answer['meters'][0]['power'])  # Abfrage shelly 
+except:
+    aktpower = int(answer['emeters'][0]['power']) # Abfrage shellyEM
 relais = int(answer['relays'][0]['ison'])
 powerc = 0
 answer = '{"power":' + str(aktpower) + ',"powerc":' + str(powerc) + ',"on":' + str(relais) + '} '


### PR DESCRIPTION
Der Geräte typ http  wird unterstützt

Die urls werden in folgenden Variablen erwartet:
device_type = http
device_einschalturl
device_ausschalturl
device_leistungurl

device_measuretype = http
device_measureurl

Wenn in der device_leistungurl oder der  device_measureurl
der Platzhalter "<openwb-ueberschuss> übergeben wird, wird diese String zur Laufzeit mit dem aktuellen Überschuss (0 oder positiver Wert) ersetzt.

Beispiel init FIle:
device_einschalturl2 = 127.0.0.1//cust/on.php
device_ausschalturl2 = 127.0.0.1/cust/off.php
device_leistungurl2 = 127.0.0.1/cust/wattd.php?meinParameter=<openwb-ueberschuss>
device_measuretype_3= http
device_measureurl3 = http://127.0.0.1/cust/wattd.php

Zusätzlich wird Leistungsabfrage Shell EM unterstützt