### PR TITLE
Add support for shelly3EM

### DIFF
--- a/modules/smarthome/shelly/watt.py
+++ b/modules/smarthome/shelly/watt.py
@@ -9,19 +9,28 @@ import struct
 import codecs
 import binascii
 import urllib.request
+
+def totalPowerFromShellyJson(json):
+    if 'meters' in answer:
+        meters = answer['meters'] # shelly
+    else:
+        meters = answer['emeters'] # shellyEM & shelly3EM
+    total = 0
+    # shellyEM has one meter, shelly3EM has three meters:
+    for meter in meters:
+        total = total + meter['power']
+    return int(total)
+
 named_tuple = time.localtime() # getstruct_time
 time_string = time.strftime("%m/%d/%Y, %H:%M:%S shelly watty.py", named_tuple)
 devicenumber=str(sys.argv[1])
 ipadr=str(sys.argv[2])
 uberschuss=int(sys.argv[3])
 answer = json.loads(str(urllib.request.urlopen("http://"+str(ipadr)+"/status", timeout=3).read().decode("utf-8")))
-try:
-    aktpower = int(answer['meters'][0]['power'])  # Abfrage shelly 
-except:
-    aktpower = int(answer['emeters'][0]['power']) # Abfrage shellyEM
+aktpower = totalPowerFromShellyJson(answer)
 relais = int(answer['relays'][0]['ison'])
 powerc = 0
 answer = '{"power":' + str(aktpower) + ',"powerc":' + str(powerc) + ',"on":' + str(relais) + '} '
 f1 = open('/var/www/html/openWB/ramdisk/smarthome_device_ret' + str(devicenumber), 'w')
 json.dump(answer,f1)
-f1.close() 
+f1.close()


### PR DESCRIPTION
It is possible to add a shelly3EM as a SmartHome-device, but the home page only shows the power consumption of phase 1. This PR fixes that.

I am missing some automated tests... Should there be some tests somewhere?