### PR TITLE
several smarthome fixes

### DIFF
--- a/runs/atreboot.sh
+++ b/runs/atreboot.sh
@@ -62,7 +62,6 @@ echo 0 > /var/www/html/openWB/ramdisk/device6_wh
 echo 0 > /var/www/html/openWB/ramdisk/device7_wh
 echo 0 > /var/www/html/openWB/ramdisk/device8_wh
 echo 0 > /var/www/html/openWB/ramdisk/device9_wh
-echo 0 > /var/www/html/openWB/ramdisk/device10_wh
 echo 0 > /var/www/html/openWB/ramdisk/device1_temp0
 echo 0 > /var/www/html/openWB/ramdisk/device1_temp1
 echo 0 > /var/www/html/openWB/ramdisk/device1_temp2
@@ -209,7 +208,6 @@ echo 0 > /var/www/html/openWB/ramdisk/smarthome_device_manual_6
 echo 0 > /var/www/html/openWB/ramdisk/smarthome_device_manual_7
 echo 0 > /var/www/html/openWB/ramdisk/smarthome_device_manual_8
 echo 0 > /var/www/html/openWB/ramdisk/smarthome_device_manual_9
-echo 0 > /var/www/html/openWB/ramdisk/smarthome_device_manual_10
 echo 0 > /var/www/html/openWB/ramdisk/devicetotal_watt
 touch /var/www/html/openWB/ramdisk/wattbezug
 echo 10 > /var/www/html/openWB/ramdisk/lp1sofortll

--- a/runs/cron5min.sh
+++ b/runs/cron5min.sh
@@ -57,7 +57,7 @@ d6=$(</var/www/html/openWB/ramdisk/device6_wh)
 d7=$(</var/www/html/openWB/ramdisk/device7_wh)
 d8=$(</var/www/html/openWB/ramdisk/device8_wh)
 d9=$(</var/www/html/openWB/ramdisk/device9_wh)
-d10=$(</var/www/html/openWB/ramdisk/device10_wh)
+d10="0"
 
 
 

--- a/runs/cronnightly.sh
+++ b/runs/cronnightly.sh
@@ -44,7 +44,7 @@ d6=$(</var/www/html/openWB/ramdisk/device6_wh)
 d7=$(</var/www/html/openWB/ramdisk/device7_wh)
 d8=$(</var/www/html/openWB/ramdisk/device8_wh)
 d9=$(</var/www/html/openWB/ramdisk/device9_wh)
-d10=$(</var/www/html/openWB/ramdisk/device10_wh)
+d10="0"
 
 ll1=$(echo "$ll1 * 1000" | bc)
 ll2=$(echo "$ll2 * 1000" | bc)

--- a/runs/mqttsub.py
+++ b/runs/mqttsub.py
@@ -13,8 +13,9 @@ inaction=0
 config = configparser.ConfigParser()
 shconfigfile='/var/www/html/openWB/smarthome.ini'
 config.read(shconfigfile)
+numberOfSupportedDevices=9 # limit number of smarthome devices
 
-for i in range(1,11):
+for i in range(1,(numberOfSupportedDevices+1)):
     try:
         confvar = config.get('smarthomedevices', 'device_configured_' + str(i))
     except:
@@ -76,8 +77,10 @@ def on_connect(client, userdata, flags, rc):
 
 # handle each set topic
 def on_message(client, userdata, msg):
+    global numberOfSupportedDevices
     # log all messages before any error forces this process to die
     if (len(msg.payload.decode("utf-8")) >= 1):
+        setTopicCleared = False
         theTime = datetime.now()
         timestamp = theTime.strftime(format = "%Y-%m-%d %H:%M:%S")
         file = open('/var/www/html/openWB/ramdisk/mqtt.log', 'a')
@@ -91,7 +94,6 @@ def on_message(client, userdata, msg):
                 f.write(msg.payload.decode("utf-8"))
                 f.close()
                 client.publish("openWB/lp/"+str(devicenumb)+"/ChargePointEnabled", msg.payload.decode("utf-8"), qos=0, retain=True)
-                client.publish("openWB/set/lp/"+str(devicenumb)+"/ChargePointEnabled", "", qos=0, retain=True)
         if (( "openWB/set/lp" in msg.topic) and ("ForceSoCUpdate" in msg.topic)):
             devicenumb=re.sub(r'\D', '', msg.topic)
             if ( 1 <= int(devicenumb) <= 2 and int(msg.payload) == 1):
@@ -102,48 +104,40 @@ def on_message(client, userdata, msg):
                 f = open(soctimerfile, 'w')
                 f.write("20000")
                 f.close()
-                client.publish(msg.topic, "", qos=0, retain=True)
-
         if (( "openWB/config/set/SmartHome/Device" in msg.topic) and ("device_configured" in msg.topic)):
             devicenumb=re.sub(r'\D', '', msg.topic)
-            if ( 1 <= int(devicenumb) <= 10 and 0 <= int(msg.payload) <= 1):
+            if ( 1 <= int(devicenumb) <= numberOfSupportedDevices and 0 <= int(msg.payload) <= 1):
                 writetoconfig(shconfigfile,'smarthomedevices','device_configured_'+str(devicenumb),msg.payload.decode("utf-8"))
                 client.publish("openWB/config/get/SmartHome/Devices/"+str(devicenumb)+"/device_configured", msg.payload.decode("utf-8"), qos=0, retain=True)
-                client.publish("openWB/config/set/SmartHome/Devices/"+str(devicenumb)+"/device_configured", "", qos=0, retain=True)
         if (( "openWB/config/set/SmartHome/Device" in msg.topic) and ("device_canSwitch" in msg.topic)):
             devicenumb=re.sub(r'\D', '', msg.topic)
-            if ( 1 <= int(devicenumb) <= 10 and 0 <= int(msg.payload) <= 1):
+            if ( 1 <= int(devicenumb) <= numberOfSupportedDevices and 0 <= int(msg.payload) <= 1):
                 writetoconfig(shconfigfile,'smarthomedevices','device_canSwitch_'+str(devicenumb),msg.payload.decode("utf-8"))
                 client.publish("openWB/config/get/SmartHome/Devices/"+str(devicenumb)+"/device_canSwitch", msg.payload.decode("utf-8"), qos=0, retain=True)
-                client.publish("openWB/config/set/SmartHome/Devices/"+str(devicenumb)+"/device_canSwitch", "", qos=0, retain=True)
         if (( "openWB/config/set/SmartHome/Device" in msg.topic) and ("device_differentMeasurement" in msg.topic)):
             devicenumb=re.sub(r'\D', '', msg.topic)
-            if ( 1 <= int(devicenumb) <= 10 and 0 <= int(msg.payload) <= 1):
+            if ( 1 <= int(devicenumb) <= numberOfSupportedDevices and 0 <= int(msg.payload) <= 1):
                 writetoconfig(shconfigfile,'smarthomedevices','device_differentMeasurement_'+str(devicenumb),msg.payload.decode("utf-8"))
                 client.publish("openWB/config/get/SmartHome/Devices/"+str(devicenumb)+"/device_differentMeasurement", msg.payload.decode("utf-8"), qos=0, retain=True)
-                client.publish("openWB/config/set/SmartHome/Devices/"+str(devicenumb)+"/device_differentMeasurement", "", qos=0, retain=True)
         if (( "openWB/config/set/SmartHome/Device" in msg.topic) and ("device_ip" in msg.topic)):
             devicenumb=re.sub(r'\D', '', msg.topic)
-            if ( 1 <= int(devicenumb) <= 10 and len(str(msg.payload.decode("utf-8"))) > 6 and bool(re.match(ipallowed, msg.payload.decode("utf-8")))):
+            if ( 1 <= int(devicenumb) <= numberOfSupportedDevices and len(str(msg.payload.decode("utf-8"))) > 6 and bool(re.match(ipallowed, msg.payload.decode("utf-8")))):
                 writetoconfig(shconfigfile,'smarthomedevices','device_ip_'+str(devicenumb), msg.payload.decode("utf-8"))
                 client.publish("openWB/config/get/SmartHome/Devices/"+str(devicenumb)+"/device_ip", msg.payload.decode("utf-8"), qos=0, retain=True)
-                client.publish("openWB/config/set/SmartHome/Devices/"+str(devicenumb)+"/device_ip", "", qos=0, retain=True)
         if (( "openWB/config/set/SmartHome/Device" in msg.topic) and ("device_measureip" in msg.topic)):
             devicenumb=re.sub(r'\D', '', msg.topic)
-            if ( 1 <= int(devicenumb) <= 10 and len(str(msg.payload.decode("utf-8"))) > 6 and bool(re.match(ipallowed, msg.payload.decode("utf-8")))):
+            if ( 1 <= int(devicenumb) <= numberOfSupportedDevices and len(str(msg.payload.decode("utf-8"))) > 6 and bool(re.match(ipallowed, msg.payload.decode("utf-8")))):
                 writetoconfig(shconfigfile,'smarthomedevices','device_measureip_'+str(devicenumb), msg.payload.decode("utf-8"))
                 client.publish("openWB/config/get/SmartHome/Devices/"+str(devicenumb)+"/device_measureip", msg.payload.decode("utf-8"), qos=0, retain=True)
-                client.publish("openWB/config/set/SmartHome/Devices/"+str(devicenumb)+"/device_measureip", "", qos=0, retain=True)
         if (( "openWB/config/set/SmartHome/Device" in msg.topic) and ("device_name" in msg.topic)):
             devicenumb=re.sub(r'\D', '', msg.topic)
-            if ( 1 <= int(devicenumb) <= 10 and  3 <= len(str(msg.payload.decode("utf8"))) <= 12 and bool(re.match(nameallowed, msg.payload.decode("utf-8")))):
+            if ( 1 <= int(devicenumb) <= numberOfSupportedDevices and  3 <= len(str(msg.payload.decode("utf8"))) <= 12 and bool(re.match(nameallowed, msg.payload.decode("utf-8")))):
                 writetoconfig(shconfigfile,'smarthomedevices','device_name_'+str(devicenumb), msg.payload.decode("utf-8"))
                 client.publish("openWB/config/get/SmartHome/Devices/"+str(devicenumb)+"/device_name", msg.payload.decode("utf-8"), qos=0, retain=True)
-                client.publish("openWB/config/set/SmartHome/Devices/"+str(devicenumb)+"/device_name", "", qos=0, retain=True)
         if (( "openWB/config/set/SmartHome/Device" in msg.topic) and ("device_type" in msg.topic)):
             devicenumb=re.sub(r'\D', '', msg.topic)
             validDeviceTypes = ['shelly','tasmota','acthor','elwa','idm','stiebel','pyt'] # 'pyt' is deprecated and will be removed!
-            if ( 1 <= int(devicenumb) <= 10 and len(str(msg.payload.decode("utf-8"))) > 2):
+            if ( 1 <= int(devicenumb) <= numberOfSupportedDevices and len(str(msg.payload.decode("utf-8"))) > 2):
                 try:
                     # just check vor payload in list, deviceTypeIndex is not used
                     deviceTypeIndex = validDeviceTypes.index(msg.payload.decode("utf-8"))
@@ -152,133 +146,111 @@ def on_message(client, userdata, msg):
                 else:
                     writetoconfig(shconfigfile,'smarthomedevices','device_type_'+str(devicenumb), msg.payload.decode("utf-8"))
                     client.publish("openWB/config/get/SmartHome/Devices/"+str(devicenumb)+"/device_type", msg.payload.decode("utf-8"), qos=0, retain=True)
-            # always clear set message
-            client.publish(msg.topic, "", qos=0, retain=True)
         if (( "openWB/config/set/SmartHome/Device" in msg.topic) and ("device_measureType" in msg.topic)):
             devicenumb=re.sub(r'\D', '', msg.topic)
-            if ( 1 <= int(devicenumb) <= 10 and len(str(msg.payload.decode("utf-8"))) > 2):
+            if ( 1 <= int(devicenumb) <= numberOfSupportedDevices and len(str(msg.payload.decode("utf-8"))) > 2):
                 if ( msg.payload.decode("utf-8") == "http" or msg.payload.decode("utf-8") == "shelly" or msg.payload.decode("utf-8") == "sdm630"):
                     writetoconfig(shconfigfile,'smarthomedevices','device_measureType_'+str(devicenumb), msg.payload.decode("utf-8"))
                     client.publish("openWB/config/get/SmartHome/Devices/"+str(devicenumb)+"/device_measureType", msg.payload.decode("utf-8"), qos=0, retain=True)
-                    client.publish("openWB/config/set/SmartHome/Devices/"+str(devicenumb)+"/device_measureType", "", qos=0, retain=True)
         if (( "openWB/config/set/SmartHome/Device" in msg.topic) and ("device_temperatur_configured" in msg.topic)):
             devicenumb=re.sub(r'\D', '', msg.topic)
-            if ( 1 <= int(devicenumb) <= 10 and 0 <= int(msg.payload) <= 3):
+            if ( 1 <= int(devicenumb) <= numberOfSupportedDevices and 0 <= int(msg.payload) <= 3):
                 writetoconfig(shconfigfile,'smarthomedevices','device_temperatur_configured_'+str(devicenumb), msg.payload.decode("utf-8"))
                 client.publish("openWB/config/get/SmartHome/Devices/"+str(devicenumb)+"/device_temperatur_configured", msg.payload.decode("utf-8"), qos=0, retain=True)
-                client.publish("openWB/config/set/SmartHome/Devices/"+str(devicenumb)+"/device_temperatur_configured", "", qos=0, retain=True)
         if (( "openWB/config/set/SmartHome/Device" in msg.topic) and ("device_einschaltschwelle" in msg.topic)):
             devicenumb=re.sub(r'\D', '', msg.topic)
-            if ( 1 <= int(devicenumb) <= 10 and -100000 <= int(msg.payload) <= 100000):
+            if ( 1 <= int(devicenumb) <= numberOfSupportedDevices and -100000 <= int(msg.payload) <= 100000):
                 writetoconfig(shconfigfile,'smarthomedevices','device_einschaltschwelle_'+str(devicenumb), msg.payload.decode("utf-8"))
                 client.publish("openWB/config/get/SmartHome/Devices/"+str(devicenumb)+"/device_einschaltschwelle", msg.payload.decode("utf-8"), qos=0, retain=True)
-                client.publish("openWB/config/set/SmartHome/Devices/"+str(devicenumb)+"/device_einschaltschwelle", "", qos=0, retain=True)
         if (( "openWB/config/set/SmartHome/Device" in msg.topic) and ("device_deactivateWhileEvCharging" in msg.topic)):
             devicenumb=re.sub(r'\D', '', msg.topic)
-            if ( 1 <= int(devicenumb) <= 10 and 0 <= int(msg.payload) <= 1):
+            if ( 1 <= int(devicenumb) <= numberOfSupportedDevices and 0 <= int(msg.payload) <= 1):
                 writetoconfig(shconfigfile,'smarthomedevices','device_deactivateWhileEvCharging_'+str(devicenumb), msg.payload.decode("utf-8"))
                 client.publish("openWB/config/get/SmartHome/Devices/"+str(devicenumb)+"/device_deactivateWhileEvCharging", msg.payload.decode("utf-8"), qos=0, retain=True)
-                client.publish("openWB/config/set/SmartHome/Devices/"+str(devicenumb)+"/device_deactivateWhileEvCharging", "", qos=0, retain=True)
         if (( "openWB/config/set/SmartHome/Device" in msg.topic) and ("device_ausschaltschwelle" in msg.topic)):
             devicenumb=re.sub(r'\D', '', msg.topic)
-            if ( 1 <= int(devicenumb) <= 10 and -100000 <= int(msg.payload) <= 100000):
+            if ( 1 <= int(devicenumb) <= numberOfSupportedDevices and -100000 <= int(msg.payload) <= 100000):
                 writetoconfig(shconfigfile,'smarthomedevices','device_ausschaltschwelle_'+str(devicenumb), msg.payload.decode("utf-8"))
                 client.publish("openWB/config/get/SmartHome/Devices/"+str(devicenumb)+"/device_ausschaltschwelle", msg.payload.decode("utf-8"), qos=0, retain=True)
-                client.publish("openWB/config/set/SmartHome/Devices/"+str(devicenumb)+"/device_ausschaltschwelle", "", qos=0, retain=True)
         if (( "openWB/config/set/SmartHome/Device" in msg.topic) and ("device_ausschaltverzoegerung" in msg.topic)):
             devicenumb=re.sub(r'\D', '', msg.topic)
-            if ( 1 <= int(devicenumb) <= 10 and 0 <= int(msg.payload) <= 10000):
+            if ( 1 <= int(devicenumb) <= numberOfSupportedDevices and 0 <= int(msg.payload) <= 10000):
                 writetoconfig(shconfigfile,'smarthomedevices','device_ausschaltverzoegerung_'+str(devicenumb), msg.payload.decode("utf-8"))
                 client.publish("openWB/config/get/SmartHome/Devices/"+str(devicenumb)+"/device_ausschaltverzoegerung", msg.payload.decode("utf-8"), qos=0, retain=True)
-                client.publish("openWB/config/set/SmartHome/Devices/"+str(devicenumb)+"/device_ausschaltverzoegerung", "", qos=0, retain=True)
         if (( "openWB/config/set/SmartHome/Device" in msg.topic) and ("device_einschaltverzoegerung" in msg.topic)):
             devicenumb=re.sub(r'\D', '', msg.topic)
-            if ( 1 <= int(devicenumb) <= 10 and 0 <= int(msg.payload) <= 100000):
+            if ( 1 <= int(devicenumb) <= numberOfSupportedDevices and 0 <= int(msg.payload) <= 100000):
                 writetoconfig(shconfigfile,'smarthomedevices','device_einschaltverzoegerung_'+str(devicenumb), msg.payload.decode("utf-8"))
                 client.publish("openWB/config/get/SmartHome/Devices/"+str(devicenumb)+"/device_einschaltverzoegerung", msg.payload.decode("utf-8"), qos=0, retain=True)
-                client.publish("openWB/config/set/SmartHome/Devices/"+str(devicenumb)+"/device_einschaltverzoegerung", "", qos=0, retain=True)
         if (( "openWB/config/set/SmartHome/Device" in msg.topic) and ("device_measureid" in msg.topic)):
             devicenumb=re.sub(r'\D', '', msg.topic)
-            if ( 1 <= int(devicenumb) <= 10 and 1 <= int(msg.payload) <= 255):
+            if ( 1 <= int(devicenumb) <= numberOfSupportedDevices and 1 <= int(msg.payload) <= 255):
                 writetoconfig(shconfigfile,'smarthomedevices','device_measureid_'+str(devicenumb), msg.payload.decode("utf-8"))
                 client.publish("openWB/config/get/SmartHome/Devices/"+str(devicenumb)+"/device_measureid", msg.payload.decode("utf-8"), qos=0, retain=True)
-                client.publish("openWB/config/set/SmartHome/Devices/"+str(devicenumb)+"/device_measureid", "", qos=0, retain=True)
         if (( "openWB/config/set/SmartHome/Device" in msg.topic) and ("device_speichersocbeforestart" in msg.topic)):
             devicenumb=re.sub(r'\D', '', msg.topic)
-            if ( 1 <= int(devicenumb) <= 10 and 0 <= int(msg.payload) <= 100):
+            if ( 1 <= int(devicenumb) <= numberOfSupportedDevices and 0 <= int(msg.payload) <= 100):
                 writetoconfig(shconfigfile,'smarthomedevices','device_speichersocbeforestart_'+str(devicenumb), msg.payload.decode("utf-8"))
                 client.publish("openWB/config/get/SmartHome/Devices/"+str(devicenumb)+"/device_speichersocbeforestart", msg.payload.decode("utf-8"), qos=0, retain=True)
-                client.publish("openWB/config/set/SmartHome/Devices/"+str(devicenumb)+"/device_speichersocbeforestart", "", qos=0, retain=True)
         if (( "openWB/config/set/SmartHome/Device" in msg.topic) and ("device_speichersocbeforestop" in msg.topic)):
             devicenumb=re.sub(r'\D', '', msg.topic)
-            if ( 1 <= int(devicenumb) <= 10 and 0 <= int(msg.payload) <= 100):
+            if ( 1 <= int(devicenumb) <= numberOfSupportedDevices and 0 <= int(msg.payload) <= 100):
                 writetoconfig(shconfigfile,'smarthomedevices','device_speichersocbeforestop_'+str(devicenumb), msg.payload.decode("utf-8"))
                 client.publish("openWB/config/get/SmartHome/Devices/"+str(devicenumb)+"/device_speichersocbeforestop", msg.payload.decode("utf-8"), qos=0, retain=True)
-                client.publish("openWB/config/set/SmartHome/Devices/"+str(devicenumb)+"/device_speichersocbeforestop", "", qos=0, retain=True)
         if (( "openWB/config/set/SmartHome/Device" in msg.topic) and ("device_maxeinschaltdauer" in msg.topic)):
             devicenumb=re.sub(r'\D', '', msg.topic)
-            if ( 1 <= int(devicenumb) <= 10 and 0 <= int(msg.payload) <= 100000):
+            if ( 1 <= int(devicenumb) <= numberOfSupportedDevices and 0 <= int(msg.payload) <= 100000):
                 writetoconfig(shconfigfile,'smarthomedevices','device_maxeinschaltdauer_'+str(devicenumb), msg.payload.decode("utf-8"))
                 client.publish("openWB/config/get/SmartHome/Devices/"+str(devicenumb)+"/device_maxeinschaltdauer", msg.payload.decode("utf-8"), qos=0, retain=True)
-                client.publish("openWB/config/set/SmartHome/Devices/"+str(devicenumb)+"/device_maxeinschaltdauer", "", qos=0, retain=True)
         if (( "openWB/config/set/SmartHome/Device" in msg.topic) and ("device_mineinschaltdauer" in msg.topic)):
             devicenumb=re.sub(r'\D', '', msg.topic)
-            if ( 1 <= int(devicenumb) <= 10 and 0 <= int(msg.payload) <= 100000):
+            if ( 1 <= int(devicenumb) <= numberOfSupportedDevices and 0 <= int(msg.payload) <= 100000):
                 writetoconfig(shconfigfile,'smarthomedevices','device_mineinschaltdauer_'+str(devicenumb), msg.payload.decode("utf-8"))
                 client.publish("openWB/config/get/SmartHome/Devices/"+str(devicenumb)+"/device_mineinschaltdauer", msg.payload.decode("utf-8"), qos=0, retain=True)
-                client.publish("openWB/config/set/SmartHome/Devices/"+str(devicenumb)+"/device_mineinschaltdauer", "", qos=0, retain=True)
         if (( "openWB/config/set/SmartHome/Device" in msg.topic) and ("device_manual_control" in msg.topic)):
             devicenumb=re.sub(r'\D', '', msg.topic)
-            if ( 1 <= int(devicenumb) <= 10 and 0 <= int(msg.payload) <= 1):
+            if ( 1 <= int(devicenumb) <= numberOfSupportedDevices and 0 <= int(msg.payload) <= 1):
                 client.publish("openWB/config/get/SmartHome/Devices/"+str(devicenumb)+"/device_manual_control", msg.payload.decode("utf-8"), qos=0, retain=True)
-                client.publish("openWB/config/set/SmartHome/Devices/"+str(devicenumb)+"/device_manual_control", "", qos=0, retain=True)
                 f = open('/var/www/html/openWB/ramdisk/smarthome_device_manual_control_'+str(devicenumb), 'w')
                 f.write(msg.payload.decode("utf-8"))
                 f.close()
         if (( "openWB/config/set/SmartHome/Device" in msg.topic) and ("mode" in msg.topic)):
             devicenumb=re.sub(r'\D', '', msg.topic)
-            if ( 1 <= int(devicenumb) <= 10 and 0 <= int(msg.payload) <= 1):
+            if ( 1 <= int(devicenumb) <= numberOfSupportedDevices and 0 <= int(msg.payload) <= 1):
                 client.publish("openWB/config/get/SmartHome/Devices/"+str(devicenumb)+"/mode", msg.payload.decode("utf-8"), qos=0, retain=True)
-                client.publish("openWB/config/set/SmartHome/Devices/"+str(devicenumb)+"/mode", "", qos=0, retain=True)
                 f = open('/var/www/html/openWB/ramdisk/smarthome_device_manual_'+str(devicenumb), 'w')
                 f.write(msg.payload.decode("utf-8"))
                 f.close()
         if (( "openWB/config/set/SmartHome/Device" in msg.topic) and ("device_einschalturl" in msg.topic)):
             devicenumb=re.sub(r'\D', '', msg.topic)
-            if ( 1 <= int(devicenumb) <= 10 ):
-                writetoconfig(shconfigfile,'smarthomedevices','device_einschalturl'+str(devicenumb), msg.payload.decode("utf-8"))
+            if ( 1 <= int(devicenumb) <= numberOfSupportedDevices ):
+                writetoconfig(shconfigfile,'smarthomedevices','device_einschalturl_'+str(devicenumb), msg.payload.decode("utf-8"))
                 client.publish("openWB/config/get/SmartHome/Devices/"+str(devicenumb)+"/device_einschalturl", msg.payload.decode("utf-8"), qos=0, retain=True)
-                client.publish("openWB/config/set/SmartHome/Devices/"+str(devicenumb)+"/device_einschalturl", "", qos=0, retain=True)
         if (( "openWB/config/set/SmartHome/Device" in msg.topic) and ("device_ausschalturl" in msg.topic)):
             devicenumb=re.sub(r'\D', '', msg.topic)
-            if ( 1 <= int(devicenumb) <= 10 ):
-                writetoconfig(shconfigfile,'smarthomedevices','device_ausschalturl'+str(devicenumb), msg.payload.decode("utf-8"))
+            if ( 1 <= int(devicenumb) <= numberOfSupportedDevices ):
+                writetoconfig(shconfigfile,'smarthomedevices','device_ausschalturl_'+str(devicenumb), msg.payload.decode("utf-8"))
                 client.publish("openWB/config/get/SmartHome/Devices/"+str(devicenumb)+"/device_ausschalturl", msg.payload.decode("utf-8"), qos=0, retain=True)
-                client.publish("openWB/config/set/SmartHome/Devices/"+str(devicenumb)+"/device_ausschalturl", "", qos=0, retain=True)
         if (( "openWB/config/set/SmartHome/Device" in msg.topic) and ("device_leistungurl" in msg.topic)):
             devicenumb=re.sub(r'\D', '', msg.topic)
-            if ( 1 <= int(devicenumb) <= 10 ):
-                writetoconfig(shconfigfile,'smarthomedevices','device_leistungurl'+str(devicenumb), msg.payload.decode("utf-8"))
+            if ( 1 <= int(devicenumb) <= numberOfSupportedDevices ):
+                writetoconfig(shconfigfile,'smarthomedevices','device_leistungurl_'+str(devicenumb), msg.payload.decode("utf-8"))
                 client.publish("openWB/config/get/SmartHome/Devices/"+str(devicenumb)+"/device_leistungurl", msg.payload.decode("utf-8"), qos=0, retain=True)
-                client.publish("openWB/config/set/SmartHome/Devices/"+str(devicenumb)+"/device_leistungurl", "", qos=0, retain=True)
         if (( "openWB/config/set/SmartHome/Device" in msg.topic) and ("device_measureurl" in msg.topic)):
             devicenumb=re.sub(r'\D', '', msg.topic)
-            if ( 1 <= int(devicenumb) <= 10 ):
-                writetoconfig(shconfigfile,'smarthomedevices','device_measureurl'+str(devicenumb), msg.payload.decode("utf-8"))
+            if ( 1 <= int(devicenumb) <= numberOfSupportedDevices ):
+                writetoconfig(shconfigfile,'smarthomedevices','device_measureurl_'+str(devicenumb), msg.payload.decode("utf-8"))
                 client.publish("openWB/config/get/SmartHome/Devices/"+str(devicenumb)+"/device_measureurl", msg.payload.decode("utf-8"), qos=0, retain=True)
-                client.publish("openWB/config/set/SmartHome/Devices/"+str(devicenumb)+"/device_measureurl", "", qos=0, retain=True)
         if (msg.topic == "openWB/config/set/SmartHome/logLevel"):
             if (int(msg.payload) >= 0 and int(msg.payload) <= 2):
                 f = open('/var/www/html/openWB/ramdisk/smarthomehandlerloglevel', 'w')
                 f.write(msg.payload.decode("utf-8"))
                 f.close()
                 client.publish("openWB/config/get/SmartHome/logLevel", msg.payload.decode("utf-8"), qos=0, retain=True)
-                client.publish("openWB/config/set/SmartHome/logLevel", "", qos=0, retain=True)
         if (( "openWB/config/set/sofort/lp" in msg.topic) and ("current" in msg.topic)):
             devicenumb=re.sub(r'\D', '', msg.topic)
             if ( 1 <= int(devicenumb) <= 8 and 6 <= int(msg.payload) <= 32):
                 client.publish("openWB/config/get/sofort/lp/"+str(devicenumb)+"/current", msg.payload.decode("utf-8"), qos=0, retain=True)
-                client.publish("openWB/config/set/sofort/lp/"+str(devicenumb)+"/current", "", qos=0, retain=True)
                 f = open('/var/www/html/openWB/ramdisk/lp'+str(devicenumb)+'sofortll', 'w')
                 f.write(msg.payload.decode("utf-8"))
                 f.close()
@@ -286,7 +258,6 @@ def on_message(client, userdata, msg):
             devicenumb=re.sub(r'\D', '', msg.topic)
             if ( 1 <= int(devicenumb) <= 8 and 0 <= int(msg.payload) <= 100):
                 client.publish("openWB/config/get/lp/"+str(devicenumb)+"/manualSoc", msg.payload.decode("utf-8"), qos=0, retain=True)
-                client.publish("openWB/config/set/lp/"+str(devicenumb)+"/manualSoc", "", qos=0, retain=True)
                 f = open('/var/www/html/openWB/ramdisk/lp'+str(devicenumb)+'_manual_soc', 'w')
                 f.write(msg.payload.decode("utf-8"))
                 f.close()
@@ -294,7 +265,6 @@ def on_message(client, userdata, msg):
                 f = open('/var/www/html/openWB/ramdisk/soc', 'w')
                 f.write(msg.payload.decode("utf-8"))
                 f.close()
-
         if (( "openWB/config/set/sofort/lp" in msg.topic) and ("energyToCharge" in msg.topic)):
             devicenumb=re.sub(r'\D', '', msg.topic)
             if ( 1 <= int(devicenumb) <= 8 and 0 <= int(msg.payload) <= 100):
@@ -310,9 +280,7 @@ def on_message(client, userdata, msg):
                 if (int(devicenumb) >= 4):
                     sendcommand = ["/var/www/html/openWB/runs/replaceinconfig.sh", "lademkwhlp"+str(devicenumb)+"=", msg.payload.decode("utf-8")]
                     subprocess.Popen(sendcommand)
-
                 client.publish("openWB/config/get/sofort/lp/"+str(devicenumb)+"/energyToCharge", msg.payload.decode("utf-8"), qos=0, retain=True)
-                client.publish("openWB/config/set/sofort/lp/"+str(devicenumb)+"/energyToCharge", "", qos=0, retain=True)
         if (( "openWB/config/set/sofort/lp" in msg.topic) and ("resetEnergyToCharge" in msg.topic)):
             devicenumb=re.sub(r'\D', '', msg.topic)
             if ( 1 <= int(devicenumb) <= 8 and int(msg.payload) == 1):
@@ -344,14 +312,12 @@ def on_message(client, userdata, msg):
                     f = open('/var/www/html/openWB/ramdisk/gelrlp'+str(devicenumb), 'w')
                     f.write("0")
                     f.close()
-                client.publish("openWB/config/set/sofort/lp/"+str(devicenumb)+"/resetEnergyToCharge", "", qos=0, retain=True)
         if (( "openWB/config/set/sofort/lp" in msg.topic) and ("socToChargeTo" in msg.topic)):
             devicenumb=re.sub(r'\D', '', msg.topic)
             if ( 1 <= int(devicenumb) <= 2 and 0 <= int(msg.payload) <= 100):
                 client.publish("openWB/config/get/sofort/lp/"+str(devicenumb)+"/socToChargeTo", msg.payload.decode("utf-8"), qos=0, retain=True)
                 sendcommand = ["/var/www/html/openWB/runs/replaceinconfig.sh", "sofortsoclp"+str(devicenumb)+"=", msg.payload.decode("utf-8")]
                 subprocess.Popen(sendcommand)
-                client.publish("openWB/config/set/sofort/lp/"+str(devicenumb)+"/socToChargeTo", "", qos=0, retain=True)
         if (( "openWB/config/set/sofort/lp" in msg.topic) and ("chargeLimitation" in msg.topic)):
             devicenumb=re.sub(r'\D', '', msg.topic)
             if ( 3 <= int(devicenumb) <= 8 and 0 <= int(msg.payload) <= 1):
@@ -366,235 +332,187 @@ def on_message(client, userdata, msg):
                     sendcommand = ["/var/www/html/openWB/runs/replaceinconfig.sh", "lademstatlp"+str(devicenumb)+"=", "0"]
                     subprocess.Popen(sendcommand)
                     client.publish("openWB/lp/5/boolDirectModeChargekWh", "0", qos=0, retain=True)
-
                 client.publish("openWB/config/get/sofort/lp/"+str(devicenumb)+"/chargeLimitation", msg.payload.decode("utf-8"), qos=0, retain=True)
-                client.publish("openWB/config/set/sofort/lp/"+str(devicenumb)+"/chargeLimitation", "", qos=0, retain=True)
-
-
         if (msg.topic == "openWB/config/set/pv/minFeedinPowerBeforeStart"):
             if (int(msg.payload) >= -100000 and int(msg.payload) <= 100000):
                 sendcommand = ["/var/www/html/openWB/runs/replaceinconfig.sh", "mindestuberschuss=", msg.payload.decode("utf-8")]
                 subprocess.Popen(sendcommand)
                 client.publish("openWB/config/get/pv/minFeedinPowerBeforeStart", msg.payload.decode("utf-8"), qos=0, retain=True)
-                client.publish("openWB/config/set/pv/minFeedinPowerBeforeStart", "", qos=0, retain=True)
         if (msg.topic == "openWB/config/set/pv/maxPowerConsumptionBeforeStop"):
             if (int(msg.payload) >= -100000 and int(msg.payload) <= 100000):
                 sendcommand = ["/var/www/html/openWB/runs/replaceinconfig.sh", "abschaltuberschuss=", msg.payload.decode("utf-8")]
                 subprocess.Popen(sendcommand)
                 client.publish("openWB/config/get/pv/maxPowerConsumptionBeforeStop", msg.payload.decode("utf-8"), qos=0, retain=True)
-                client.publish("openWB/config/set/pv/maxPowerConsumptionBeforeStop", "", qos=0, retain=True)
         if (msg.topic == "openWB/config/set/pv/stopDelay"):
             if (int(msg.payload) >= 0 and int(msg.payload) <= 10000):
                 sendcommand = ["/var/www/html/openWB/runs/replaceinconfig.sh", "abschaltverzoegerung=", msg.payload.decode("utf-8")]
                 subprocess.Popen(sendcommand)
                 client.publish("openWB/config/get/pv/stopDelay", msg.payload.decode("utf-8"), qos=0, retain=True)
-                client.publish("openWB/config/set/pv/stopDelay", "", qos=0, retain=True)
         if (msg.topic == "openWB/config/set/pv/startDelay"):
             if (int(msg.payload) >= 0 and int(msg.payload) <= 100000):
                 sendcommand = ["/var/www/html/openWB/runs/replaceinconfig.sh", "einschaltverzoegerung=", msg.payload.decode("utf-8")]
                 subprocess.Popen(sendcommand)
                 client.publish("openWB/config/get/pv/startDelay", msg.payload.decode("utf-8"), qos=0, retain=True)
-                client.publish("openWB/config/set/pv/startDelay", "", qos=0, retain=True)
         if (msg.topic == "openWB/config/set/pv/minCurrentMinPv"):
             if (int(msg.payload) >= 6 and int(msg.payload) <= 16):
                 sendcommand = ["/var/www/html/openWB/runs/replaceinconfig.sh", "minimalampv=", msg.payload.decode("utf-8")]
                 subprocess.Popen(sendcommand)
                 client.publish("openWB/config/get/pv/minCurrentMinPv", msg.payload.decode("utf-8"), qos=0, retain=True)
-                client.publish("openWB/config/set/pv/minCurrentMinPv", "", qos=0, retain=True)
         if (msg.topic == "openWB/config/set/pv/lp/1/maxSoc"):
             if (int(msg.payload) >= 0 and int(msg.payload) <= 100):
                 sendcommand = ["/var/www/html/openWB/runs/replaceinconfig.sh", "stopchargepvpercentagelp1=", msg.payload.decode("utf-8")]
                 subprocess.Popen(sendcommand)
                 client.publish("openWB/config/get/pv/lp/1/maxSoc", msg.payload.decode("utf-8"), qos=0, retain=True)
-                client.publish("openWB/config/set/pv/lp/1/maxSoc", "", qos=0, retain=True)
         if (msg.topic == "openWB/config/set/pv/lp/2/maxSoc"):
             if (int(msg.payload) >= 0 and int(msg.payload) <= 100):
                 sendcommand = ["/var/www/html/openWB/runs/replaceinconfig.sh", "stopchargepvpercentagelp2=", msg.payload.decode("utf-8")]
                 subprocess.Popen(sendcommand)
                 client.publish("openWB/config/get/pv/lp/2/maxSoc", msg.payload.decode("utf-8"), qos=0, retain=True)
-                client.publish("openWB/config/set/pv/lp/2/maxSoc", "", qos=0, retain=True)
         if (msg.topic == "openWB/config/set/pv/lp/1/socLimitation"):
             if (int(msg.payload) >= 0 and int(msg.payload) <= 1):
                 sendcommand = ["/var/www/html/openWB/runs/replaceinconfig.sh", "stopchargepvatpercentlp1=", msg.payload.decode("utf-8")]
                 subprocess.Popen(sendcommand)
                 client.publish("openWB/config/get/pv/lp/1/socLimitation", msg.payload.decode("utf-8"), qos=0, retain=True)
-                client.publish("openWB/config/set/pv/lp/1/socLimitation", "", qos=0, retain=True)
         if (msg.topic == "openWB/config/set/pv/lp/2/socLimitation"):
             if (int(msg.payload) >= 0 and int(msg.payload) <= 1):
                 sendcommand = ["/var/www/html/openWB/runs/replaceinconfig.sh", "stopchargepvatpercentlp2=", msg.payload.decode("utf-8")]
                 subprocess.Popen(sendcommand)
                 client.publish("openWB/config/get/pv/lp/2/socLimitation", msg.payload.decode("utf-8"), qos=0, retain=True)
-                client.publish("openWB/config/set/pv/lp/2/socLimitation", "", qos=0, retain=True)
-
         if (msg.topic == "openWB/config/set/pv/lp/1/minCurrent"):
             if (int(msg.payload) >= 6 and int(msg.payload) <= 16):
                 sendcommand = ["/var/www/html/openWB/runs/replaceinconfig.sh", "minimalapv=", msg.payload.decode("utf-8")]
                 subprocess.Popen(sendcommand)
                 client.publish("openWB/config/get/pv/lp/1/minCurrent", msg.payload.decode("utf-8"), qos=0, retain=True)
-                client.publish("openWB/config/set/pv/lp/1/minCurrent", "", qos=0, retain=True)
         if (msg.topic == "openWB/config/set/pv/lp/2/minCurrent"):
             if (int(msg.payload) >= 6 and int(msg.payload) <= 16):
                 sendcommand = ["/var/www/html/openWB/runs/replaceinconfig.sh", "minimalalp2mpv=", msg.payload.decode("utf-8")]
                 subprocess.Popen(sendcommand)
                 client.publish("openWB/config/get/pv/lp/2/minCurrent", msg.payload.decode("utf-8"), qos=0, retain=True)
-                client.publish("openWB/config/set/pv/lp/2/minCurrent", "", qos=0, retain=True)
         if (msg.topic == "openWB/config/set/u1p3p/standbyPhases"):
             if (int(msg.payload) >= 1 and int(msg.payload) <= 3):
                 sendcommand = ["/var/www/html/openWB/runs/replaceinconfig.sh", "u1p3pstandby=", msg.payload.decode("utf-8")]
                 subprocess.Popen(sendcommand)
                 client.publish("openWB/config/get/u1p3p/standbyPhases", msg.payload.decode("utf-8"), qos=0, retain=True)
-                client.publish("openWB/config/set/u1p3p/standbyPhases", "", qos=0, retain=True)
         if (msg.topic == "openWB/config/set/u1p3p/sofortPhases"):
             if (int(msg.payload) >= 1 and int(msg.payload) <= 3):
                 sendcommand = ["/var/www/html/openWB/runs/replaceinconfig.sh", "u1p3psofort=", msg.payload.decode("utf-8")]
                 subprocess.Popen(sendcommand)
                 client.publish("openWB/config/get/u1p3p/sofortPhases", msg.payload.decode("utf-8"), qos=0, retain=True)
-                client.publish("openWB/config/set/u1p3p/sofortPhases", "", qos=0, retain=True)
         if (msg.topic == "openWB/config/set/u1p3p/nachtPhases"):
             if (int(msg.payload) >= 1 and int(msg.payload) <= 3):
                 sendcommand = ["/var/www/html/openWB/runs/replaceinconfig.sh", "u1p3pnl=", msg.payload.decode("utf-8")]
                 subprocess.Popen(sendcommand)
                 client.publish("openWB/config/get/u1p3p/nachtPhases", msg.payload.decode("utf-8"), qos=0, retain=True)
-                client.publish("openWB/config/set/u1p3p/nachtPhases", "", qos=0, retain=True)
         if (msg.topic == "openWB/config/set/u1p3p/minundpvPhases"):
             if (int(msg.payload) >= 1 and int(msg.payload) <= 3):
                 sendcommand = ["/var/www/html/openWB/runs/replaceinconfig.sh", "u1p3pminundpv=", msg.payload.decode("utf-8")]
                 subprocess.Popen(sendcommand)
                 client.publish("openWB/config/get/u1p3p/minundpvPhases", msg.payload.decode("utf-8"), qos=0, retain=True)
-                client.publish("openWB/config/set/u1p3p/minundpvPhases", "", qos=0, retain=True)
         if (msg.topic == "openWB/config/set/u1p3p/nurpvPhases"):
             if (int(msg.payload) >= 1 and int(msg.payload) <= 3):
                 sendcommand = ["/var/www/html/openWB/runs/replaceinconfig.sh", "u1p3pnurpv=", msg.payload.decode("utf-8")]
                 subprocess.Popen(sendcommand)
                 client.publish("openWB/config/get/u1p3p/nurpvPhases", msg.payload.decode("utf-8"), qos=0, retain=True)
-                client.publish("openWB/config/set/u1p3p/nurpvPhases", "", qos=0, retain=True)
         if (msg.topic == "openWB/config/set/u1p3p/isConfigured"):
             if (int(msg.payload) >= 0 and int(msg.payload) <= 1):
                 sendcommand = ["/var/www/html/openWB/runs/replaceinconfig.sh", "u1p3paktiv=", msg.payload.decode("utf-8")]
                 subprocess.Popen(sendcommand)
                 client.publish("openWB/config/get/u1p3p/isConfigured", msg.payload.decode("utf-8"), qos=0, retain=True)
-                client.publish("openWB/config/set/u1p3p/isConfigured", "", qos=0, retain=True)
         if (msg.topic == "openWB/config/set/global/minEVSECurrentAllowed"):
             if (int(msg.payload) >= 6 and int(msg.payload) <= 32):
                 sendcommand = ["/var/www/html/openWB/runs/replaceinconfig.sh", "minimalstromstaerke=", msg.payload.decode("utf-8")]
                 subprocess.Popen(sendcommand)
                 client.publish("openWB/config/get/global/minEVSECurrentAllowed", msg.payload.decode("utf-8"), qos=0, retain=True)
-                client.publish("openWB/config/set/global/minEVSECurrentAllowed", "", qos=0, retain=True)
         if (msg.topic == "openWB/config/set/global/maxEVSECurrentAllowed"):
             if (int(msg.payload) >= 6 and int(msg.payload) <= 32):
                 sendcommand = ["/var/www/html/openWB/runs/replaceinconfig.sh", "maximalstromstaerke=", msg.payload.decode("utf-8")]
                 subprocess.Popen(sendcommand)
                 client.publish("openWB/config/get/global/maxEVSECurrentAllowed", msg.payload.decode("utf-8"), qos=0, retain=True)
-                client.publish("openWB/config/set/global/maxEVSECurrentAllowed", "", qos=0, retain=True)
         if (msg.topic == "openWB/config/set/global/dataProtectionAcknoledged"):
             if (int(msg.payload) >= 0 and int(msg.payload) <= 2):
                 sendcommand = ["/var/www/html/openWB/runs/replaceinconfig.sh", "datenschutzack=", msg.payload.decode("utf-8")]
                 subprocess.Popen(sendcommand)
                 client.publish("openWB/config/get/global/dataProtectionAcknoledged", msg.payload.decode("utf-8"), qos=0, retain=True)
-                client.publish("openWB/config/set/global/dataProtectionAcknoledged", "", qos=0, retain=True)
         if (msg.topic == "openWB/config/set/pv/lp/1/minSocAlwaysToChargeTo"):
             if (int(msg.payload) >= 0 and int(msg.payload) <= 80):
                 sendcommand = ["/var/www/html/openWB/runs/replaceinconfig.sh", "minnurpvsoclp1=", msg.payload.decode("utf-8")]
                 subprocess.Popen(sendcommand)
                 client.publish("openWB/config/get/pv/lp/1/minSocAlwaysToChargeTo", msg.payload.decode("utf-8"), qos=0, retain=True)
-                client.publish("openWB/config/set/pv/lp/1/minSocAlwaysToChargeTo", "", qos=0, retain=True)
         if (msg.topic == "openWB/config/set/pv/lp/1/maxSocToChargeTo"):
             if (int(msg.payload) >= 0 and int(msg.payload) <= 101):
                 sendcommand = ["/var/www/html/openWB/runs/replaceinconfig.sh", "maxnurpvsoclp1=", msg.payload.decode("utf-8")]
                 subprocess.Popen(sendcommand)
                 client.publish("openWB/config/get/pv/lp/1/maxSocToChargeTo", msg.payload.decode("utf-8"), qos=0, retain=True)
-                client.publish("openWB/config/set/pv/lp/1/maxSocToChargeTo", "", qos=0, retain=True)
         if (msg.topic == "openWB/config/set/pv/lp/1/minSocAlwaysToChargeToCurrent"):
             if (int(msg.payload) >= 6 and int(msg.payload) <= 32):
                 sendcommand = ["/var/www/html/openWB/runs/replaceinconfig.sh", "minnurpvsocll=", msg.payload.decode("utf-8")]
                 subprocess.Popen(sendcommand)
                 client.publish("openWB/config/get/pv/lp/1/minSocAlwaysToChargeToCurrent", msg.payload.decode("utf-8"), qos=0, retain=True)
-                client.publish("openWB/config/set/pv/lp/1/minSocAlwaysToChargeToCurrent", "", qos=0, retain=True)
         if (msg.topic == "openWB/config/set/pv/chargeSubmode"):
             if (int(msg.payload) >= 0 and int(msg.payload) <= 2):
                 sendcommand = ["/var/www/html/openWB/runs/replaceinconfig.sh", "pvbezugeinspeisung=", msg.payload.decode("utf-8")]
                 subprocess.Popen(sendcommand)
                 client.publish("openWB/config/get/pv/chargeSubmode", msg.payload.decode("utf-8"), qos=0, retain=True)
-                client.publish("openWB/config/set/pv/chargeSubmode", "", qos=0, retain=True)
         if (msg.topic == "openWB/config/set/pv/regulationPoint"):
             if (int(msg.payload) >= -300000 and int(msg.payload) <= 300000):
                 sendcommand = ["/var/www/html/openWB/runs/replaceinconfig.sh", "offsetpv=", msg.payload.decode("utf-8")]
                 subprocess.Popen(sendcommand)
                 client.publish("openWB/config/get/pv/regulationPoint", msg.payload.decode("utf-8"), qos=0, retain=True)
-                client.publish("openWB/config/set/pv/regulationPoint", "", qos=0, retain=True)
         if (msg.topic == "openWB/config/set/pv/boolShowPriorityIconInTheme"):
             if (int(msg.payload) >= 0 and int(msg.payload) <= 1):
                 sendcommand = ["/var/www/html/openWB/runs/replaceinconfig.sh", "speicherpvui=", msg.payload.decode("utf-8")]
                 subprocess.Popen(sendcommand)
                 client.publish("openWB/config/get/pv/boolShowPriorityIconInTheme", msg.payload.decode("utf-8"), qos=0, retain=True)
-                client.publish("openWB/config/set/pv/boolShowPriorityIconInTheme", "", qos=0, retain=True)
         if (msg.topic == "openWB/config/set/pv/minBatteryChargePowerAtEvPriority"):
             if (int(msg.payload) >= 0 and int(msg.payload) <= 90000):
                 sendcommand = ["/var/www/html/openWB/runs/replaceinconfig.sh", "speichermaxwatt=", msg.payload.decode("utf-8")]
                 subprocess.Popen(sendcommand)
                 client.publish("openWB/config/get/pv/minBatteryChargePowerAtEvPriority", msg.payload.decode("utf-8"), qos=0, retain=True)
-                client.publish("openWB/config/set/pv/minBatteryChargePowerAtEvPriority", "", qos=0, retain=True)
         if (msg.topic == "openWB/config/set/pv/minBatteryDischargeSocAtBattPriority"):
             if (int(msg.payload) >= 0 and int(msg.payload) <= 101):
                 sendcommand = ["/var/www/html/openWB/runs/replaceinconfig.sh", "speichersocnurpv=", msg.payload.decode("utf-8")]
                 subprocess.Popen(sendcommand)
                 client.publish("openWB/config/get/pv/minBatteryDischargeSocAtBattPriority", msg.payload.decode("utf-8"), qos=0, retain=True)
-                client.publish("openWB/config/set/pv/minBatteryDischargeSocAtBattPriority", "", qos=0, retain=True)
         if (msg.topic == "openWB/config/set/pv/batteryDischargePowerAtBattPriority"):
             if (int(msg.payload) >= 0 and int(msg.payload) <= 90000):
                 sendcommand = ["/var/www/html/openWB/runs/replaceinconfig.sh", "speicherwattnurpv=", msg.payload.decode("utf-8")]
                 subprocess.Popen(sendcommand)
                 client.publish("openWB/config/get/pv/batteryDischargePowerAtBattPriority", msg.payload.decode("utf-8"), qos=0, retain=True)
-                client.publish("openWB/config/set/pv/batteryDischargePowerAtBattPriority", "", qos=0, retain=True)
         if (msg.topic == "openWB/config/set/pv/socStartChargeAtMinPv"):
             if (int(msg.payload) >= 0 and int(msg.payload) <= 101):
                 sendcommand = ["/var/www/html/openWB/runs/replaceinconfig.sh", "speichersocminpv=", msg.payload.decode("utf-8")]
                 subprocess.Popen(sendcommand)
                 client.publish("openWB/config/get/pv/socStartChargeAtMinPv", msg.payload.decode("utf-8"), qos=0, retain=True)
-                client.publish("openWB/config/set/pv/socStartChargeAtMinPv", "", qos=0, retain=True)
         if (msg.topic == "openWB/config/set/pv/socStopChargeAtMinPv"):
             if (int(msg.payload) >= 0 and int(msg.payload) <= 101):
                 sendcommand = ["/var/www/html/openWB/runs/replaceinconfig.sh", "speichersochystminpv=", msg.payload.decode("utf-8")]
                 subprocess.Popen(sendcommand)
                 client.publish("openWB/config/get/pv/socStopChargeAtMinPv", msg.payload.decode("utf-8"), qos=0, retain=True)
-                client.publish("openWB/config/set/pv/socStopChargeAtMinPv", "", qos=0, retain=True)
         if (msg.topic == "openWB/config/set/pv/boolAdaptiveCharging"):
             if (int(msg.payload) >= 0 and int(msg.payload) <= 1):
                 sendcommand = ["/var/www/html/openWB/runs/replaceinconfig.sh", "adaptpv=", msg.payload.decode("utf-8")]
                 subprocess.Popen(sendcommand)
                 client.publish("openWB/config/get/pv/boolAdaptiveCharging", msg.payload.decode("utf-8"), qos=0, retain=True)
-                client.publish("openWB/config/set/pv/boolAdaptiveCharging", "", qos=0, retain=True)
         if (msg.topic == "openWB/config/set/pv/adaptiveChargingFactor"):
             if (int(msg.payload) >= 0 and int(msg.payload) <= 100):
                 sendcommand = ["/var/www/html/openWB/runs/replaceinconfig.sh", "adaptfaktor=", msg.payload.decode("utf-8")]
                 subprocess.Popen(sendcommand)
                 client.publish("openWB/config/get/pv/adaptiveChargingFactor", msg.payload.decode("utf-8"), qos=0, retain=True)
-                client.publish("openWB/config/set/pv/adaptiveChargingFactor", "", qos=0, retain=True)
         if (msg.topic == "openWB/config/set/pv/nurpv70dynact"):
             if (int(msg.payload) >= 0 and int(msg.payload) <= 1):
                 sendcommand = ["/var/www/html/openWB/runs/replaceinconfig.sh", "nurpv70dynact=", msg.payload.decode("utf-8")]
                 subprocess.Popen(sendcommand)
                 client.publish("openWB/config/get/pv/nurpv70dynact", msg.payload.decode("utf-8"), qos=0, retain=True)
-                client.publish("openWB/config/set/pv/nurpv70dynact", "", qos=0, retain=True)
         if (msg.topic == "openWB/config/set/pv/nurpv70dynw"):
             if (int(msg.payload) >= 2000 and int(msg.payload) <= 50000):
                 sendcommand = ["/var/www/html/openWB/runs/replaceinconfig.sh", "nurpv70dynw=", msg.payload.decode("utf-8")]
                 subprocess.Popen(sendcommand)
                 client.publish("openWB/config/get/pv/nurpv70dynw", msg.payload.decode("utf-8"), qos=0, retain=True)
-                client.publish("openWB/config/set/pv/nurpv70dynw", "", qos=0, retain=True)
-
-
-
-
-        if (msg.topic == "openWB/set/system/topicSender"):
-            if ( 3 <= len(msg.payload.decode("utf-8")) <=100 ):
-                client.publish("openWB/set/system/topicSender", "", qos=0, retain=True)
         if (msg.topic == "openWB/set/system/GetRemoteSupport"):
             if ( 5 <= len(msg.payload.decode("utf-8")) <=50 ):
                 token=msg.payload.decode("utf-8")
                 getsupport = ["/var/www/html/openWB/runs/startremotesupport.sh", token]
                 subprocess.Popen(getsupport)
-                client.publish("openWB/set/system/GetRemoteSupport", "", qos=0, retain=True)
         if (msg.topic == "openWB/set/hook/HookControl"):
             if (int(msg.payload) >= 0 and int(msg.payload) <=30):
                 hookmsg=msg.payload.decode("utf-8")
@@ -602,12 +520,7 @@ def on_message(client, userdata, msg):
                 hookact=hookmsg[0:1]
                 sendhook = ["/var/www/html/openWB/runs/hookcontrol.sh", hookmsg]
                 subprocess.Popen(sendhook)
-                client.publish("openWB/set/hook/HookControl", "", qos=0, retain=True)
                 client.publish("openWB/hook/"+hooknmb+"/BoolHookStatus", hookact, qos=0, retain=True)
-
-
-
-
         if (msg.topic == "openWB/config/set/slave/MinimumAdjustmentInterval"):
             if (int(msg.payload) >= 10 and int(msg.payload) <= 300):
                 sendcommand = ["/var/www/html/openWB/runs/replaceinconfig.sh", "slaveModeMinimumAdjustmentInterval=", msg.payload.decode("utf-8")]
@@ -695,45 +608,37 @@ def on_message(client, userdata, msg):
                 f = open('/var/www/html/openWB/ramdisk/ChargingVehiclesOnL3', 'w')
                 f.write(msg.payload.decode("utf-8"))
                 f.close()
-
-
-
         if (msg.topic == "openWB/config/set/global/lp/1/cpInterrupt"):
             if (int(msg.payload) >= 0 and int(msg.payload) <=1):
                 einbeziehen=msg.payload.decode("utf-8")
                 sendcommand = ["/var/www/html/openWB/runs/replaceinconfig.sh", "cpunterbrechunglp1=", einbeziehen]
                 subprocess.Popen(sendcommand)
                 client.publish("openWB/config/get/global/lp/1/cpInterrupt", einbeziehen, qos=0, retain=True)
-                client.publish("openWB/config/set/global/lp/1/cpInterrupt", "", qos=0, retain=True)
         if (msg.topic == "openWB/config/set/global/lp/2/cpInterrupt"):
             if (int(msg.payload) >= 0 and int(msg.payload) <=1):
                 einbeziehen=msg.payload.decode("utf-8")
                 sendcommand = ["/var/www/html/openWB/runs/replaceinconfig.sh", "cpunterbrechunglp2=", einbeziehen]
                 subprocess.Popen(sendcommand)
                 client.publish("openWB/config/get/global/lp/2/cpInterrupt", einbeziehen, qos=0, retain=True)
-                client.publish("openWB/config/set/global/lp/2/cpInterrupt", "", qos=0, retain=True)
-
         if (msg.topic == "openWB/config/set/pv/priorityModeEVBattery"):
             if (int(msg.payload) >= 0 and int(msg.payload) <=1):
                 einbeziehen=msg.payload.decode("utf-8")
                 sendcommand = ["/var/www/html/openWB/runs/replaceinconfig.sh", "speicherpveinbeziehen=", einbeziehen]
                 subprocess.Popen(sendcommand)
                 client.publish("openWB/config/get/pv/priorityModeEVBattery", einbeziehen, qos=0, retain=True)
-                client.publish("openWB/config/set/pv/priorityModeEVBattery", "", qos=0, retain=True)
         if (msg.topic == "openWB/set/graph/LiveGraphDuration"):
             if (int(msg.payload) >= 20 and int(msg.payload) <=120):
                 sendcommand = ["/var/www/html/openWB/runs/replaceinconfig.sh", "livegraph=", msg.payload.decode("utf-8")]
                 subprocess.Popen(sendcommand)
-                client.publish("openWB/set/graph/LiveGraphDuration", "", qos=0, retain=True)
         if (msg.topic == "openWB/set/system/SimulateRFID"):
             if len(str(msg.payload.decode("utf-8"))) >= 1 and bool(re.match(namenumballowed, msg.payload.decode("utf-8"))):
                 f = open('/var/www/html/openWB/ramdisk/readtag', 'w')
                 f.write(msg.payload.decode("utf-8"))
                 f.close()
-                client.publish("openWB/set/system/SimulateRFID", "", qos=0, retain=True)
         if (msg.topic == "openWB/set/system/PerformUpdate"):
             if (int(msg.payload) == 1):
                 client.publish("openWB/set/system/PerformUpdate", "0", qos=0, retain=True)
+                setTopicCleared = True
                 subprocess.Popen("/var/www/html/openWB/runs/update.sh")
         if (msg.topic == "openWB/set/system/SendDebug"):
             if ( 20 <= len(msg.payload.decode("utf-8")) <=1000 ):
@@ -741,21 +646,21 @@ def on_message(client, userdata, msg):
                 f.write(msg.payload.decode("utf-8"))
                 f.close()
                 client.publish("openWB/set/system/SendDebug", "0", qos=0, retain=True)
+                setTopicCleared = True
                 subprocess.Popen("/var/www/html/openWB/runs/senddebuginit.sh")
         if (msg.topic == "openWB/set/system/reloadDisplay"):
             if (int(msg.payload) >= 0 and int(msg.payload) <= 1):
                 client.publish("openWB/system/reloadDisplay", msg.payload.decode("utf-8"), qos=0, retain=True)
-                client.publish("openWB/set/system/reloadDisplay", "", qos=0, retain=True)
         if (msg.topic == "openWB/config/set/releaseTrain"):
             if ( msg.payload.decode("utf-8") == "stable17" or msg.payload.decode("utf-8") == "master" or msg.payload.decode("utf-8") == "beta" or msg.payload.decode("utf-8").startswith("yc/")):
                 sendcommand = ["/var/www/html/openWB/runs/replaceinconfig.sh", "releasetrain=", msg.payload.decode("utf-8")]
                 subprocess.Popen(sendcommand)
-                client.publish("openWB/config/set/releaseTrain", "", qos=0, retain=True)
         if (msg.topic == "openWB/set/graph/RequestLiveGraph"):
             if (int(msg.payload) == 1):
                 subprocess.Popen("/var/www/html/openWB/runs/sendlivegraphdata.sh")
             else:
                 client.publish("openWB/system/LiveGraphData", "empty", qos=0, retain=True)
+            setTopicCleared = True
         if (msg.topic == "openWB/set/graph/RequestLLiveGraph"):
             if (int(msg.payload) == 1):
                 subprocess.Popen("/var/www/html/openWB/runs/sendllivegraphdata.sh")
@@ -776,7 +681,7 @@ def on_message(client, userdata, msg):
                 client.publish("openWB/system/14alllivevalues", "empty", qos=0, retain=True)
                 client.publish("openWB/system/15alllivevalues", "empty", qos=0, retain=True)
                 client.publish("openWB/system/16alllivevalues", "empty", qos=0, retain=True)
-
+            setTopicCleared = True
         if (msg.topic == "openWB/set/graph/RequestDayGraph"):
             if (int(msg.payload) >= 1 and int(msg.payload) <= 20501231):
                 sendcommand = ["/var/www/html/openWB/runs/senddaygraphdata.sh", msg.payload]
@@ -794,6 +699,7 @@ def on_message(client, userdata, msg):
                 client.publish("openWB/system/DayGraphData10", "empty", qos=0, retain=True)
                 client.publish("openWB/system/DayGraphData11", "empty", qos=0, retain=True)
                 client.publish("openWB/system/DayGraphData12", "empty", qos=0, retain=True)
+            setTopicCleared = True
         if (msg.topic == "openWB/set/graph/RequestMonthGraph"):
             if (int(msg.payload) >= 1 and int(msg.payload) <= 205012):
                 sendcommand = ["/var/www/html/openWB/runs/sendmonthgraphdata.sh", msg.payload]
@@ -811,10 +717,12 @@ def on_message(client, userdata, msg):
                 client.publish("openWB/system/MonthGraphData10", "empty", qos=0, retain=True)
                 client.publish("openWB/system/MonthGraphData11", "empty", qos=0, retain=True)
                 client.publish("openWB/system/MonthGraphData12", "empty", qos=0, retain=True)
+            setTopicCleared = True
         if (msg.topic == "openWB/set/system/debug/RequestDebugInfo"):
             if (int(msg.payload) == 1):
                 sendcommand = ["/var/www/html/openWB/runs/sendmqttdebug.sh"]
                 subprocess.Popen(sendcommand)
+            setTopicCleared = True
         if (msg.topic == "openWB/set/graph/RequestMonthLadelog"):
             if (int(msg.payload) >= 1 and int(msg.payload) <= 205012):
                 sendcommand = ["/var/www/html/openWB/runs/sendladelog.sh", msg.payload]
@@ -832,18 +740,17 @@ def on_message(client, userdata, msg):
                 client.publish("openWB/system/MonthLadelogData10", "empty", qos=0, retain=True)
                 client.publish("openWB/system/MonthLadelogData11", "empty", qos=0, retain=True)
                 client.publish("openWB/system/MonthLadelogData12", "empty", qos=0, retain=True)
+            setTopicCleared = True
         if (msg.topic == "openWB/set/pv/NurPV70Status"):
             if (int(msg.payload) >= 0 and int(msg.payload) <= 1):
                 client.publish("openWB/pv/bool70PVDynStatus", msg.payload.decode("utf-8"), qos=0, retain=True)
                 f = open('/var/www/html/openWB/ramdisk/nurpv70dynstatus', 'w')
                 f.write(msg.payload.decode("utf-8"))
                 f.close()
-                client.publish("openWB/set/pv/NurPV70Status", "", qos=0, retain=True)
         if (msg.topic == "openWB/set/RenewMQTT"):
             if (int(msg.payload) == 1):
                 client.publish("openWB/set/RenewMQTT", "0", qos=0, retain=True)
-                #time.sleep(0.5)
-                #subprocess.Popen("/var/www/html/openWB/runs/renewmqtt.sh")
+                setTopicCleared = True
                 f = open('/var/www/html/openWB/ramdisk/renewmqtt', 'w')
                 f.write("1")
                 f.close()
@@ -853,7 +760,6 @@ def on_message(client, userdata, msg):
                 f.write(msg.payload.decode("utf-8"))
                 f.close()
                 client.publish("openWB/global/ChargeMode", msg.payload.decode("utf-8"), qos=0, retain=True)
-                client.publish("openWB/set/ChargeMode", "", qos=0, retain=True)
         if (msg.topic == "openWB/config/set/sofort/lp/1/chargeLimitation"):
             if (int(msg.payload) >= 0 and int(msg.payload) <=2):
                 sendcommand = ["/var/www/html/openWB/runs/replaceinconfig.sh", "msmoduslp1=", msg.payload.decode("utf-8")]
@@ -866,7 +772,6 @@ def on_message(client, userdata, msg):
                     client.publish("openWB/lp/1/boolDirectChargeModeSoc", "1", qos=0, retain=True)
                 else:
                     client.publish("openWB/lp/1/boolDirectChargeModeSoc", "0", qos=0, retain=True)
-                client.publish("openWB/config/set/sofort/lp/1/chargeLimitation", "", qos=0, retain=True)
                 client.publish("openWB/config/get/sofort/lp/1/chargeLimitation", msg.payload.decode("utf-8"), qos=0, retain=True)
         if (msg.topic == "openWB/config/set/sofort/lp/2/chargeLimitation"):
             if (int(msg.payload) >= 0 and int(msg.payload) <=2):
@@ -880,7 +785,6 @@ def on_message(client, userdata, msg):
                     client.publish("openWB/lp/2/boolDirectChargeModeSoc", "1", qos=0, retain=True)
                 else:
                     client.publish("openWB/lp/2/boolDirectChargeModeSoc", "0", qos=0, retain=True)
-                client.publish("openWB/config/set/sofort/lp/2/chargeLimitation", "", qos=0, retain=True)
                 client.publish("openWB/config/get/sofort/lp/2/chargeLimitation", msg.payload.decode("utf-8"), qos=0, retain=True)
         if (msg.topic == "openWB/set/lp/1/DirectChargeSubMode"):
             if (int(msg.payload) == 0):
@@ -937,40 +841,33 @@ def on_message(client, userdata, msg):
                 replaceAll("lademstatlp8=",msg.payload.decode("utf-8"))
             if (int(msg.payload) == 1):
                 replaceAll("lademstatlp8=",msg.payload.decode("utf-8"))
-
         if (msg.topic == "openWB/set/isss/ClearRfid"):
             if (int(msg.payload) > 0 and int(msg.payload) <=1):
                 f = open('/var/www/html/openWB/ramdisk/readtag', 'w')
                 f.write("0")
                 f.close()
-                client.publish("openWB/set/isss/ClearRfid", "", qos=0, retain=True)
         if (msg.topic == "openWB/set/isss/Current"):
             if (int(msg.payload) >= 0 and int(msg.payload) <=32):
                 f = open('/var/www/html/openWB/ramdisk/llsoll', 'w')
                 f.write(msg.payload.decode("utf-8"))
                 f.close()
-                client.publish("openWB/set/isss/Current", "", qos=0, retain=True)
         if (msg.topic == "openWB/set/isss/Lp2Current"):
             if (int(msg.payload) >= 0 and int(msg.payload) <=32):
                 f = open('/var/www/html/openWB/ramdisk/llsolls1', 'w')
                 f.write(msg.payload.decode("utf-8"))
                 f.close()
-                client.publish("openWB/set/isss/Lp2Current", "", qos=0, retain=True)
         if (msg.topic == "openWB/set/isss/U1p3p"):
             if (int(msg.payload) >= 0 and int(msg.payload) <=5):
                 f = open('/var/www/html/openWB/ramdisk/u1p3pstat', 'w')
                 f.write(msg.payload.decode("utf-8"))
                 f.close()
-                client.publish("openWB/set/isss/U1p3p", "", qos=0, retain=True)
         if (msg.topic == "openWB/set/isss/Cpulp1"):
             if (int(msg.payload) >= 0 and int(msg.payload) <=5):
                 f = open('/var/www/html/openWB/ramdisk/extcpulp1', 'w')
                 f.write(msg.payload.decode("utf-8"))
                 f.close()
-            client.publish("openWB/set/isss/Cpulp1", "", qos=0, retain=True)
         if (msg.topic == "openWB/set/isss/parentWB"):
             client.publish("openWB/system/parentWB", msg.payload.decode("utf-8"), qos=0, retain=True)
-            client.publish("openWB/set/isss/parentWB", "", qos=0, retain=True)
         if (msg.topic == "openWB/set/awattar/MaxPriceForCharging"):
             if (float(msg.payload) >= -50 and float(msg.payload) <=50):
                 f = open('/var/www/html/openWB/ramdisk/awattarmaxprice', 'w')
@@ -1122,6 +1019,9 @@ def on_message(client, userdata, msg):
                 f = open('/var/www/html/openWB/ramdisk/llkwh', 'w')
                 f.write(msg.payload.decode("utf-8"))
                 f.close()
+        # clear all set topics if not already done
+        if ( not(setTopicCleared) ):
+            client.publish(msg.topic, "", qos=0, retain=True)
 
 client.on_connect = on_connect
 client.on_message = on_message

--- a/runs/smarthomehandler.py
+++ b/runs/smarthomehandler.py
@@ -16,10 +16,12 @@ config = configparser.ConfigParser()
 config.read(shconfigfile)
 prefixpy = basePath+'/modules/smarthome/'
 loglevel=2
+numberOfSupportedDevices=9 # limit number of smarthome devices
 DeviceValues = { }
 DeviceTempValues = { }
 DeviceCounters = { }
-for i in range(1, 11):
+
+for i in range(1, (numberOfSupportedDevices+1)):
     DeviceTempValues.update({'oldw'+str(i) : '2'})
     DeviceTempValues.update({'oldwh'+str(i) : '2'})
     DeviceTempValues.update({'oldtemp'+str(i) : '2'})
@@ -98,7 +100,7 @@ def sepwatt(oldwatt,oldwattk,nummer):
        try:
           pyname = prefixpy + 'http/watt.py'
           try:
-             device_measureurl = str(config.get('smarthomedevices', 'device_measureurl'+str(nummer))) 
+             device_measureurl = str(config.get('smarthomedevices', 'device_measureurl_'+str(nummer))) 
           except:
              device_measureurl = "undef"
           proc=subprocess.Popen( ['python3',pyname,str(nummer),config.get('smarthomedevices', 'device_measureip_'+str(nummer)),str(uberschuss),device_measureurl])
@@ -128,7 +130,7 @@ def logDebug(level, msg):
         if (int(level) == 1):
             file.write(time.ctime() + ': ' + str(msg)+ '\n')
         if (int(level) == 2):
-            file.write(time.ctime() + ': ' + str('\x1b[6;30;42m' + msg + '\x1b[0m')+ '\n')
+            file.write(time.ctime() + ' ERROR: ' + str(msg)+ '\n')
         file.close()
 
 def simcount(watt2, pref, importfn, exportfn, nummer,wattks):
@@ -230,14 +232,6 @@ def simcount(watt2, pref, importfn, exportfn, nummer,wattks):
         f.close()
 
 def publishmqtt():
-    """ arg parser not used here
-    TODO remove lines
-    parser = argparse.ArgumentParser(description='openWB MQTT Publisher')
-    parser.add_argument('--qos', '-q', metavar='qos', type=int, help='The QOS setting', default=0)
-    parser.add_argument('--retain', '-r', dest='retain', action='store_true', help='If true, retain this publish')
-    parser.set_defaults(retain=False)
-    args = parser.parse_args()
-    """
     client = mqtt.Client("openWB-SmartHome-bulkpublisher-" + str(os.getpid()))
     client.connect("localhost")
     for key in DeviceValues:
@@ -285,6 +279,7 @@ def loadregelvars():
     global loglevel
     global reread
     global wattbezug
+    global numberOfSupportedDevices
     try:
         with open('ramdisk/wattbezug', 'r') as value:
             wattbezug = int(float(value.read())) * -1
@@ -327,13 +322,13 @@ def loadregelvars():
         f.write(str(0))
         f.close()
         logDebug("2", "Config reRead")
-    for i in range(1, 11):
+    for i in range(1, (numberOfSupportedDevices+1)):
         try:
             with open('ramdisk/smarthome_device_manual_' + str(i), 'r') as value:
                 DeviceValues.update( {str(i) + "manual": int(value.read())}) 
         except:
             DeviceValues.update( {str(i) + "manual": 0})
-    for i in range(1, 11):
+    for i in range(1, (numberOfSupportedDevices+1)):
         try:
             with open('ramdisk/smarthome_device_manual_control_' + str(i), 'r') as value:
                 DeviceValues.update( {str(i) + "manualmodevar": int(value.read())}) 
@@ -345,32 +340,20 @@ def on_connect(client, userdata, flags, rc):
     client.subscribe("openWB/SmartHome/#", 2)
 
 def on_message(client, userdata, msg):
+    global numberOfSupportedDevices
     if (( "openWB/SmartHome/Device" in msg.topic) and ("WHImported_temp" in msg.topic)):
         devicenumb=re.sub(r'\D', '', msg.topic)
-        if ( 1 <= int(devicenumb) <= 10 ):
+        if ( 1 <= int(devicenumb) <= numberOfSupportedDevices ):
             DeviceValues.update( {str(devicenumb)+"WHImported_tmp": int(msg.payload)})
     if (( "openWB/SmartHome/Device" in msg.topic) and ("RunningTimeToday" in msg.topic)):
         devicenumb=re.sub(r'\D', '', msg.topic)
-        if ( 1 <= int(devicenumb) <= 10 ):
+        if ( 1 <= int(devicenumb) <= numberOfSupportedDevices ):
             DeviceValues.update( {str(devicenumb)+"runningtime": int(msg.payload)})
-
-client = mqtt.Client("openWB-mqttsmarthome")
-client.on_connect = on_connect
-client.on_message = on_message
-startTime = time.time()
-waitTime = 3
-client.connect("localhost")
-while True:
-    client.loop()
-    client.subscribe("openWB/SmartHome/#", 2)
-    elapsedTime = time.time() - startTime
-    if elapsedTime > waitTime:
-        client.disconnect()
-        break
 
 # Auslesen des Smarthome Devices (Watt und/oder Temperatur)
 def getdevicevalues():
-    DeviceList = [config.get('smarthomedevices', 'device_configured_1'), config.get('smarthomedevices', 'device_configured_2'), config.get('smarthomedevices', 'device_configured_3'), config.get('smarthomedevices', 'device_configured_4'), config.get('smarthomedevices', 'device_configured_5'), config.get('smarthomedevices', 'device_configured_6'), config.get('smarthomedevices', 'device_configured_7'), config.get('smarthomedevices', 'device_configured_8'), config.get('smarthomedevices', 'device_configured_9'), config.get('smarthomedevices', 'device_configured_10')] 
+    # TODO: iterate from over num devices
+    DeviceList = [config.get('smarthomedevices', 'device_configured_1'), config.get('smarthomedevices', 'device_configured_2'), config.get('smarthomedevices', 'device_configured_3'), config.get('smarthomedevices', 'device_configured_4'), config.get('smarthomedevices', 'device_configured_5'), config.get('smarthomedevices', 'device_configured_6'), config.get('smarthomedevices', 'device_configured_7'), config.get('smarthomedevices', 'device_configured_8'), config.get('smarthomedevices', 'device_configured_9')]
     numberOfDevices = 0
     totalwatt = 0
     for n in DeviceList:
@@ -404,7 +387,7 @@ def getdevicevalues():
             switchtyp =  str(config.get('smarthomedevices', 'device_type_'+str(numberOfDevices)))
             devicename = str(config.get('smarthomedevices', 'device_name_'+str(numberOfDevices)))
             try:
-                device_leistungurl = str(config.get('smarthomedevices', 'device_leistungurl'+str(numberOfDevices))) 
+                device_leistungurl = str(config.get('smarthomedevices', 'device_leistungurl_'+str(numberOfDevices))) 
             except:
                 device_leistungurl = "undef"
             pyname0 = getdir(switchtyp,devicename)
@@ -427,7 +410,7 @@ def getdevicevalues():
                    wattstart = 0
                    wattkstart = 0
                    relais = 0
-                   # only relevant for canswitch == 1, file not found, 
+                   # only relevant for canswitch == 1, file not found
                    if (canswitch == 1):
                       logDebug("0", "Device " + str(switchtyp) + str(numberOfDevices) + str(devicename) + " File not found: " + str(pyname))
                 #Shelly temp sensor
@@ -443,7 +426,7 @@ def getdevicevalues():
                               f.close()
                    except:
                       pass
-                # Separate Leistungs messung ?    
+                # Separate Leistungs messung ?
                 (watt,wattk) = sepwatt(wattstart,wattkstart,numberOfDevices)
                 if abschalt == 1:
                    totalwatt = totalwatt + watt
@@ -512,11 +495,11 @@ def turndevicerelais(nummer, zustand):
     switchtyp =  str(config.get('smarthomedevices', 'device_type_'+str(nummer)))
     devicename = str(config.get('smarthomedevices', 'device_name_'+str(nummer)))
     try:
-       device_einschalturl = str(config.get('smarthomedevices', 'device_einschalturl'+str(nummer))) 
+       device_einschalturl = str(config.get('smarthomedevices', 'device_einschalturl_'+str(nummer))) 
     except:
        device_einschalturl = "undef"
     try:
-       device_ausschalturl = str(config.get('smarthomedevices', 'device_ausschalturl'+str(nummer))) 
+       device_ausschalturl = str(config.get('smarthomedevices', 'device_ausschalturl_'+str(nummer))) 
     except:
        device_ausschalturl = "undef"
     pyname0 = getdir(switchtyp,devicename)
@@ -543,6 +526,7 @@ def turndevicerelais(nummer, zustand):
               logDebug("0", "Device " + str(switchtyp) + str(nummer) + str(devicename) + " File not found: " + str(pyname)) 
        except Exception as e:
            logDebug("2", "Fehler beim Ausschalten von Device " + str(nummer) + " Fehlermeldung: " + str(e))
+
 def conditions(nummer):
     try:
         speichersocbeforestop = int(config.get('smarthomedevices', 'device_speichersocbeforestop_'+str(nummer)))
@@ -692,12 +676,13 @@ def conditions(nummer):
 
 def resetmaxeinschaltdauerfunc():
     global resetmaxeinschaltdauer
+    global numberOfSupportedDevices
 
     hour=time.strftime("%H")
     if (int(hour) == 0):
         try:
             if (int(resetmaxeinschaltdauer) == 0):
-                for i in range(1, 11):
+                for i in range(1, (numberOfSupportedDevices+1)):
                     DeviceValues.update({str(i) + "runningtime" : '0'})
                 resetmaxeinschaltdauer=1
         except:
@@ -705,12 +690,26 @@ def resetmaxeinschaltdauerfunc():
     if (int(hour) == 2):
         resetmaxeinschaltdauer=0
 
+client = mqtt.Client("openWB-mqttsmarthome")
+client.on_connect = on_connect
+client.on_message = on_message
+startTime = time.time()
+waitTime = 3
+client.connect("localhost")
+while True:
+    client.loop()
+    client.subscribe("openWB/SmartHome/#", 2)
+    elapsedTime = time.time() - startTime
+    if elapsedTime > waitTime:
+        client.disconnect()
+        break
+
 while True:
     config.read(shconfigfile)
     loadregelvars()
     getdevicevalues()
     resetmaxeinschaltdauerfunc()
-    for i in range(1, 11):
+    for i in range(1, (numberOfSupportedDevices+1)):
         try:
             configured = config.get('smarthomedevices', 'device_configured_' + str(i))
             if (configured == "1"):

--- a/web/settings/helperFunctions.js
+++ b/web/settings/helperFunctions.js
@@ -12,8 +12,10 @@ var changedValuesHandler = {
         // if array is empty after delete, all send topics have been received with correct value
         // so redirect to main page
         // array is only filled by function getChangedValues!
+        console.log("num changed values left: "+Object.keys(changedValues).length);
         if ( Object.keys(changedValues).length === 0 ) {
-            window.location.href = './index.php';
+            // window.location.href = './index.php';
+            console.log("done");
         } else {
             return true;
         }
@@ -109,6 +111,7 @@ function sendValues() {
         Object.keys(changedValues).forEach(function(topic, index) {
             var value = this[topic].toString();
             setTimeout(function () {
+                console.log("publishing changed value: "+topic+": "+value);
                 publish(value, topic);
             }, index * intervall);
         }, changedValues);
@@ -159,6 +162,7 @@ function getChangedValues() {
         if ( ( value != undefined ) && ( originalValues[topic] != value ) ) {
             topic = topic.replace('/get/', '/set/');
             changedValues[topic] = value;
+            console.log("ChangedValue found: "+topic+": "+value);
         }
     });
 }

--- a/web/settings/processAllMqttMsg.js
+++ b/web/settings/processAllMqttMsg.js
@@ -27,6 +27,7 @@ function processMessages(mqttmsg, mqttpayload) {
      * @requires function:setInputValue - is declared in pvconfig.html
      * @requires function:setToggleBtnGroup  - is declared in pvconfig.html
      */
+    console.log("new message: "+mqttmsg+": "+mqttpayload);
     checkAllSaved(mqttmsg, mqttpayload);
     // last part of topic after /
     var topicIdentifier = mqttmsg.substring(mqttmsg.lastIndexOf('/')+1);

--- a/web/settings/smarthomeconfig.php
+++ b/web/settings/smarthomeconfig.php
@@ -1,6 +1,9 @@
 <!DOCTYPE html>
 <html lang="de">
-
+<?php
+// set number of supported smarthome devices
+$numDevices = 9;
+?>
 	<head>
 		<base href="/openWB/web/">
 
@@ -105,7 +108,7 @@
 
 			<form id="myForm">
 				<h1>Einstellungen für SmartHome Geräte</h1>
-<?php for( $devicenum = 1; $devicenum < 10; $devicenum++ ) { // Limited to devices 1-9 as device 10 is not properly implemented in various parts of the code ?>
+<?php for( $devicenum = 1; $devicenum <= $numDevices; $devicenum++ ) { ?>
 				<div class="card border-secondary">
 					<div class="card-header bg-secondary">
 						<div class="form-group mb-0">
@@ -114,10 +117,10 @@
 								<div class="col">
 									<div class="btn-group btn-group-toggle btn-block" id="device_configuredDevices<?php echo $devicenum; ?>" name="device_configured" data-toggle="buttons" data-default="0" value="0" data-topicprefix="openWB/config/get/SmartHome/" data-topicsubgroup="Devices/<?php echo $devicenum; ?>/">
 										<label class="btn btn-sm btn-outline-info">
-											<input type="radio" name="device_configuredDevices<?php echo $devicenum; ?>" id="device_configuredDevices<?php echo $devicenum; ?>Off" data-option="0">Aus
+											<input type="radio" name="device_configuredDevices<?php echo $devicenum; ?>" id="device_configuredDevices<?php echo $devicenum; ?>Off" data-option="0" value="0" checked="checked">Aus
 										</label>
 										<label class="btn btn-sm btn-outline-info">
-											<input type="radio" name="device_configuredDevices<?php echo $devicenum; ?>" id="device_configuredDevices<?php echo $devicenum; ?>On" data-option="1">An
+											<input type="radio" name="device_configuredDevices<?php echo $devicenum; ?>" id="device_configuredDevices<?php echo $devicenum; ?>On" data-option="1" value="1">An
 										</label>
 									</div>
 								</div>
@@ -129,7 +132,7 @@
 							<div class="form-row mb-1">
 								<label for="device_nameDevices<?php echo $devicenum; ?>" class="col-md-4 col-form-label">Name</label>
 								<div class="col">
-									<input id="device_nameDevices<?php echo $devicenum; ?>" name="device_name" class="form-control" type="text" minlength="3" maxlength="12" pattern="[a-zA-Z]*" inputmode="text" value="Name" data-default="Name" data-topicprefix="openWB/config/get/SmartHome/" data-topicsubgroup="Devices/<?php echo $devicenum; ?>/">
+									<input id="device_nameDevices<?php echo $devicenum; ?>" name="device_name" class="form-control" type="text" required="required" minlength="3" maxlength="12" pattern="[a-zA-Z]*" inputmode="text" value="Name" data-default="Name" data-topicprefix="openWB/config/get/SmartHome/" data-topicsubgroup="Devices/<?php echo $devicenum; ?>/">
 									<span class="form-text small">Der Name muss aus 3-12 Zeichen bestehen und darf nur Buchstaben enthalten.</span>
 								</div>
 							</div>
@@ -137,6 +140,7 @@
 								<label class="col-md-4 col-form-label">Gerätetyp</label>
 								<div class="col">
 									<select class="form-control" name="device_type" id="device_typeDevices<?php echo $devicenum; ?>" data-default="shelly" value="shelly" data-topicprefix="openWB/config/get/SmartHome/" data-topicsubgroup="Devices/<?php echo $devicenum; ?>/">
+										<option value ="" data-option="" disabled="disabled" selected="selected">-- Bitte auswählen --</option>
 										<option value="shelly" data-option="shelly">Shelly</option>
 										<option value="tasmota" data-option="tasmota">Tasmota</option>
 										<option value="acthor" data-option="acthor">Acthor</option>
@@ -185,29 +189,15 @@
 						<div class="form-row mb-1 device<?php echo $devicenum; ?>-option device<?php echo $devicenum; ?>-option-shelly device<?php echo $devicenum; ?>-option-tasmota device<?php echo $devicenum; ?>-option-acthor device<?php echo $devicenum; ?>-option-elwa device<?php echo $devicenum; ?>-option-idm device<?php echo $devicenum; ?>-option-stiebel device<?php echo $devicenum; ?>-option-pyt hide">
 							<label for="device_ipDevices<?php echo $devicenum; ?>" class="col-md-4 col-form-label">IP Adresse</label>
 							<div class="col">
-								<input id="device_ipDevices<?php echo $devicenum; ?>" name="device_ip" class="form-control" type="text" pattern="^((\d{1,2}|1\d\d|2[0-4]\d|25[0-5])\.){3}(\d{1,2}|1\d\d|2[0-4]\d|25[0-5])$" data-default="192.168.1.1" value="192.168.1.1" inputmode="text"  data-topicprefix="openWB/config/get/SmartHome/" data-topicsubgroup="Devices/<?php echo $devicenum; ?>/">
+								<input id="device_ipDevices<?php echo $devicenum; ?>" name="device_ip" class="form-control" type="text" required="required" pattern="^((\d{1,2}|1\d\d|2[0-4]\d|25[0-5])\.){3}(\d{1,2}|1\d\d|2[0-4]\d|25[0-5])$" data-default="192.168.1.1" value="192.168.1.1" inputmode="text"  data-topicprefix="openWB/config/get/SmartHome/" data-topicsubgroup="Devices/<?php echo $devicenum; ?>/">
 							</div>
 						</div>
 						<div class="device<?php echo $devicenum; ?>-option device<?php echo $devicenum; ?>-option-http hide">
 							<div class="form-group">
 								<div class="form-row mb-1">
-									<label for="device_einschalturlDevices<?php echo $devicenum; ?>" class="col-md-4 col-form-label">Einschalt-URL</label>
-									<div class="col">
-										<input id="device_einschalturlDevices<?php echo $devicenum; ?>" name="device_einschalturl" class="form-control" type="text" data-default="" value="" data-topicprefix="openWB/config/get/SmartHome/" data-topicsubgroup="Devices/<?php echo $devicenum; ?>/">
-										<span class="form-text small">Die hier angegebene URL wird aufgerufen, um das Gerät einzuschalten.</span>
-									</div>
-								</div>
-								<div class="form-row mb-1">
-									<label for="device_ausschalturlDevices<?php echo $devicenum; ?>" class="col-md-4 col-form-label">Ausschalt-URL</label>
-									<div class="col">
-										<input id="device_ausschalturlDevices<?php echo $devicenum; ?>" name="device_ausschalturl" class="form-control" type="text" data-default="" value="" data-topicprefix="openWB/config/get/SmartHome/" data-topicsubgroup="Devices/<?php echo $devicenum; ?>/">
-										<span class="form-text small">Die hier angegebene URL wird aufgerufen, um das Gerät auszuschalten.</span>
-									</div>
-								</div>
-								<div class="form-row mb-1 device<?php echo $devicenum; ?>noDifferentMeasurement hide">
 									<label for="device_leistungurlDevices<?php echo $devicenum; ?>" class="col-md-4 col-form-label">Leistungs-URL</label>
 									<div class="col">
-										<input id="device_leistungurlDevices<?php echo $devicenum; ?>" name="device_leistungurl" class="form-control" type="text" data-default="" value="" data-topicprefix="openWB/config/get/SmartHome/" data-topicsubgroup="Devices/<?php echo $devicenum; ?>/">
+										<input id="device_leistungurlDevices<?php echo $devicenum; ?>" name="device_leistungurl" class="form-control" type="text" required="required" data-default="" value="" data-topicprefix="openWB/config/get/SmartHome/" data-topicsubgroup="Devices/<?php echo $devicenum; ?>/">
 										<span class="form-text small">Die hier angegebene URL wird aufgerufen, um die aktuelle Leistung des Geräts zu erhalten.</span>
 									</div>
 								</div>
@@ -220,10 +210,10 @@
 								<div class="col">
 									<div class="btn-group btn-group-toggle btn-block" id="device_canSwitchDevices<?php echo $devicenum; ?>" name="device_canSwitch" data-toggle="buttons" data-default="0" value="0" data-topicprefix="openWB/config/get/SmartHome/" data-topicsubgroup="Devices/<?php echo $devicenum; ?>/">
 										<label class="btn btn-outline-info">
-											<input type="radio" name="device_canSwitchDevices<?php echo $devicenum; ?>" id="device_canSwitch<?php echo $devicenum; ?>0" data-option="0">Nein
+											<input type="radio" name="device_canSwitchDevices<?php echo $devicenum; ?>" id="device_canSwitch<?php echo $devicenum; ?>0" data-option="0" value="0" checked="checked">Nein
 										</label>
 										<label class="btn btn-outline-info">
-											<input type="radio" name="device_canSwitchDevices<?php echo $devicenum; ?>" id="device_canSwitch<?php echo $devicenum; ?>1" data-option="1">Ja
+											<input type="radio" name="device_canSwitchDevices<?php echo $devicenum; ?>" id="device_canSwitch<?php echo $devicenum; ?>1" data-option="1" value="1">Ja
 										</label>
 									</div>
 									<span class="form-text small">Ist diese Option aktiviert, dann wird das Gerät anhand des Überschusses automatisch oder manuell geschaltet.</span>
@@ -232,6 +222,24 @@
 						</div>
 						<div class="device<?php echo $devicenum; ?>canSwitch">
 							<hr class="border-secondary">
+							<div class="device<?php echo $devicenum; ?>-option device<?php echo $devicenum; ?>-option-http hide">
+								<div class="form-group">
+									<div class="form-row mb-1">
+										<label for="device_einschalturlDevices<?php echo $devicenum; ?>" class="col-md-4 col-form-label">Einschalt-URL</label>
+										<div class="col">
+											<input id="device_einschalturlDevices<?php echo $devicenum; ?>" name="device_einschalturl" class="form-control" type="text" required="required" data-default="" value="" data-topicprefix="openWB/config/get/SmartHome/" data-topicsubgroup="Devices/<?php echo $devicenum; ?>/">
+											<span class="form-text small">Die hier angegebene URL wird aufgerufen, um das Gerät einzuschalten.</span>
+										</div>
+									</div>
+									<div class="form-row mb-1">
+										<label for="device_ausschalturlDevices<?php echo $devicenum; ?>" class="col-md-4 col-form-label">Ausschalt-URL</label>
+										<div class="col">
+											<input id="device_ausschalturlDevices<?php echo $devicenum; ?>" name="device_ausschalturl" class="form-control" type="text" required="required" data-default="" value="" data-topicprefix="openWB/config/get/SmartHome/" data-topicsubgroup="Devices/<?php echo $devicenum; ?>/">
+											<span class="form-text small">Die hier angegebene URL wird aufgerufen, um das Gerät auszuschalten.</span>
+										</div>
+									</div>
+								</div>
+							</div>
 							<div class="form-group">
 								<div class="form-row mb-1">
 									<label for="device_mineinschaltdauerDevices<?php echo $devicenum; ?>" class="col-md-4 col-form-label">Mindesteinschaltdauer</label>
@@ -255,10 +263,10 @@
 									<div class="col">
 										<div class="btn-group btn-group-toggle btn-block" id="device_deactivateWhileEvChargingDevices<?php echo $devicenum; ?>" name="device_deactivateWhileEvCharging" data-toggle="buttons" data-default="0" value="0" data-topicprefix="openWB/config/get/SmartHome/" data-topicsubgroup="Devices/<?php echo $devicenum; ?>/">
 											<label class="btn btn-outline-info">
-												<input type="radio" name="device_deactivateWhileEvChargingDevices<?php echo $devicenum; ?>" id="device_deactivateWhileEvCharging<?php echo $devicenum; ?>0" data-option="0">Nein
+												<input type="radio" name="device_deactivateWhileEvChargingDevices<?php echo $devicenum; ?>" id="device_deactivateWhileEvCharging<?php echo $devicenum; ?>0" data-option="0" value="0" checked="checked">Nein
 											</label>
 											<label class="btn btn-outline-info">
-												<input type="radio" name="device_deactivateWhileEvChargingDevices<?php echo $devicenum; ?>" id="device_deactivateWhileEvCharging<?php echo $devicenum; ?>1" data-option="1">Ja
+												<input type="radio" name="device_deactivateWhileEvChargingDevices<?php echo $devicenum; ?>" id="device_deactivateWhileEvCharging<?php echo $devicenum; ?>1" data-option="1" value="1">Ja
 											</label>
 										</div>
 										<span class="form-text small">Diese Option sorgt dafür, dass das Gerät gezielt abgeschaltet wird, wenn ein Auto geladen wird. Dem Auto steht somit entweder mehr PV-Überschuss zur Verfügung oder der Bezug verringert sich.</span>
@@ -315,7 +323,7 @@
 								<div class="form-row mb-1">
 									<label for="device_ausschaltverzoegerungDevices<?php echo $devicenum; ?>" class="col-md-4 col-form-label">Ausschaltverzögerung</label>
 									<div class="col">
-										<input id="device_ausschaltverzoegerungDevices<?php echo $devicenum; ?>" name="device_ausschaltverzoegerung" class="form-control naturalNumber" type="number" inputmode="decimal" required min="0" max="1000"  data-default="0" value="0" data-topicprefix="openWB/config/get/SmartHome/" data-topicsubgroup="Devices/<?php echo $devicenum; ?>/">
+										<input id="device_ausschaltverzoegerungDevices<?php echo $devicenum; ?>" name="device_ausschaltverzoegerung" class="form-control naturalNumber" type="number" inputmode="decimal" required min="0" max="1000" data-default="0" value="0" data-topicprefix="openWB/config/get/SmartHome/" data-topicsubgroup="Devices/<?php echo $devicenum; ?>/">
 										<span class="form-text small">Parameter in Minuten der bestimmt wie lange die Ausschaltschwelle <b>am Stück</b> überschritten werden muss bevor das Gerät ausgeschaltet wird.</span>
 									</div>
 								</div>
@@ -359,16 +367,16 @@
 								<div class="col">
 									<div class="btn-group btn-group-toggle btn-block" id="device_temperatur_configuredDevices<?php echo $devicenum; ?>" name="device_temperatur_configured" data-toggle="buttons" data-default="0" value="0" data-topicprefix="openWB/config/get/SmartHome/" data-topicsubgroup="Devices/<?php echo $devicenum; ?>/">
 										<label class="btn btn-outline-info">
-											<input type="radio" name="device_temperatur_configuredDevices<?php echo $devicenum; ?>" id="device_temperatur_configuredDevices<?php echo $devicenum; ?>0" data-option="0">0
+											<input type="radio" name="device_temperatur_configuredDevices<?php echo $devicenum; ?>" id="device_temperatur_configuredDevices<?php echo $devicenum; ?>0" data-option="0" value="0" checked="checked">0
 										</label>
 										<label class="btn btn-outline-info">
-											<input type="radio" name="device_temperatur_configuredDevices<?php echo $devicenum; ?>" id="device_temperatur_configuredDevices<?php echo $devicenum; ?>1" data-option="1">1
+											<input type="radio" name="device_temperatur_configuredDevices<?php echo $devicenum; ?>" id="device_temperatur_configuredDevices<?php echo $devicenum; ?>1" data-option="1" value="1">1
 										</label>
 										<label class="btn btn-outline-info">
-											<input type="radio" name="device_temperatur_configuredDevices<?php echo $devicenum; ?>" id="device_temperatur_configuredDevices<?php echo $devicenum; ?>2" data-option="2">2
+											<input type="radio" name="device_temperatur_configuredDevices<?php echo $devicenum; ?>" id="device_temperatur_configuredDevices<?php echo $devicenum; ?>2" data-option="2" value="2">2
 										</label>
 										<label class="btn btn-outline-info">
-											<input type="radio" name="device_temperatur_configuredDevices<?php echo $devicenum; ?>" id="device_temperatur_configuredDevices<?php echo $devicenum; ?>3" data-option="3">3
+											<input type="radio" name="device_temperatur_configuredDevices<?php echo $devicenum; ?>" id="device_temperatur_configuredDevices<?php echo $devicenum; ?>3" data-option="3" value="3">3
 										</label>
 									</div>
 									<span class="form-text small">Anzahl der Temperatursensoren die an einem Shelly Unterputzgerät anschließbar sind.</span>
@@ -382,10 +390,10 @@
 								<div class="col">
 									<div class="btn-group btn-group-toggle btn-block" id="device_differentMeasurementDevices<?php echo $devicenum; ?>" name="device_differentMeasurement" data-toggle="buttons" data-default="0" value="0" data-topicprefix="openWB/config/get/SmartHome/" data-topicsubgroup="Devices/<?php echo $devicenum; ?>/">
 										<label class="btn btn-outline-info">
-											<input type="radio" name="device_differentMeasurementDevices<?php echo $devicenum; ?>" id="device_differentMeasurement<?php echo $devicenum; ?>0" data-option="0">Nein
+											<input type="radio" name="device_differentMeasurementDevices<?php echo $devicenum; ?>" id="device_differentMeasurement<?php echo $devicenum; ?>0" data-option="0" value="0" checked="checked">Nein
 										</label>
 										<label class="btn btn-outline-info">
-											<input type="radio" name="device_differentMeasurementDevices<?php echo $devicenum; ?>" id="device_differentMeasurement<?php echo $devicenum; ?>1" data-option="1">Ja
+											<input type="radio" name="device_differentMeasurementDevices<?php echo $devicenum; ?>" id="device_differentMeasurement<?php echo $devicenum; ?>1" data-option="1" value="1">Ja
 										</label>
 									</div>
 									<span class="form-text small">Wenn diese Option aktiviert wird, wird für die Leistungserfassung einseparates Gerät abgefragt. Das kann genutzt werden, wenn z. B. ein Gerät über keine Leistungsmessung verfügt, jedoch ein Zwischenstecker mit Messung eingesetzt wird.</span>
@@ -398,13 +406,13 @@
 								<div class="col">
 									<div class="btn-group btn-group-toggle btn-block" id="device_measureTypeDevices<?php echo $devicenum; ?>" name="device_measureType" data-toggle="buttons" data-default="sdm630" value="sdm630" data-topicprefix="openWB/config/get/SmartHome/" data-topicsubgroup="Devices/<?php echo $devicenum; ?>/">
 										<label class="btn btn-outline-info">
-											<input type="radio" name="device_measureTypeDevices<?php echo $devicenum; ?>" id="device_measureTypeDevices<?php echo $devicenum; ?>Shelly" data-option="shelly">Shelly
+											<input type="radio" name="device_measureTypeDevices<?php echo $devicenum; ?>" id="device_measureTypeDevices<?php echo $devicenum; ?>Shelly" data-option="shelly" value="shelly" checked="checked">Shelly
 										</label>
 										<label class="btn btn-outline-info btn-toggle">
-											<input type="radio" name="device_measureTypeDevices<?php echo $devicenum; ?>" id="device_measureTypeDevices<?php echo $devicenum; ?>SDM630" data-option="sdm630"> SDM630
+											<input type="radio" name="device_measureTypeDevices<?php echo $devicenum; ?>" id="device_measureTypeDevices<?php echo $devicenum; ?>SDM630" data-option="sdm630" value="sdm630"> SDM630
 										</label>
 										<label class="btn btn-outline-info">
-											<input type="radio" name="device_measureTypeDevices<?php echo $devicenum; ?>" id="device_measureTypeDevices<?php echo $devicenum; ?>http" data-option="http">Http
+											<input type="radio" name="device_measureTypeDevices<?php echo $devicenum; ?>" id="device_measureTypeDevices<?php echo $devicenum; ?>http" data-option="http" value="http">Http
 										</label>
 									</div>
 								</div>
@@ -412,7 +420,7 @@
 							<div class="form-row mb-1 deviceMeasureTypeDevices<?php echo $devicenum; ?>-option deviceMeasureTypeDevices<?php echo $devicenum; ?>-option-shelly deviceMeasureTypeDevices<?php echo $devicenum; ?>-option-sdm630 hide">
 								<label for="device_measureipDevices<?php echo $devicenum; ?>" class="col-md-4 col-form-label">IP Adresse</label>
 								<div class="col">
-									<input id="device_measureipDevices<?php echo $devicenum; ?>" name="device_measureip" class="form-control" type="text" pattern="^((\d{1,2}|1\d\d|2[0-4]\d|25[0-5])\.){3}(\d{1,2}|1\d\d|2[0-4]\d|25[0-5])$" data-default="192.168.1.1" value="192.168.1.1" inputmode="text"  data-topicprefix="openWB/config/get/SmartHome/" data-topicsubgroup="Devices/<?php echo $devicenum; ?>/">
+									<input id="device_measureipDevices<?php echo $devicenum; ?>" name="device_measureip" class="form-control" type="text" required="required" pattern="^((\d{1,2}|1\d\d|2[0-4]\d|25[0-5])\.){3}(\d{1,2}|1\d\d|2[0-4]\d|25[0-5])$" data-default="192.168.1.1" value="192.168.1.1" inputmode="text"  data-topicprefix="openWB/config/get/SmartHome/" data-topicsubgroup="Devices/<?php echo $devicenum; ?>/">
 								</div>
 							</div>
 							<div class="form-row mb-1 deviceMeasureTypeDevices<?php echo $devicenum; ?>-option deviceMeasureTypeDevices<?php echo $devicenum; ?>-option-sdm630 hide">
@@ -424,7 +432,7 @@
 							<div class="form-row mb-1 deviceMeasureTypeDevices<?php echo $devicenum; ?>-option deviceMeasureTypeDevices<?php echo $devicenum; ?>-option-http hide">
 								<label for="device_measureurlDevices<?php echo $devicenum; ?>" class="col-md-4 col-form-label">Leistungs-URL</label>
 								<div class="col">
-									<input id="device_measureurlDevices<?php echo $devicenum; ?>" name="device_measureurld" class="form-control" data-default="" value=""  data-topicprefix="openWB/config/get/SmartHome/" data-topicsubgroup="Devices/<?php echo $devicenum; ?>/">
+									<input id="device_measureurlDevices<?php echo $devicenum; ?>" name="device_measureurld" class="form-control" type="text" required="required" data-default="" value=""  data-topicprefix="openWB/config/get/SmartHome/" data-topicsubgroup="Devices/<?php echo $devicenum; ?>/">
 								</div>
 							</div>
 						</div>
@@ -442,7 +450,7 @@
 								<label for="logLevel" class="col-md-4 col-form-label">SmartHome Loglevel</label>
 								<div class="col">
 									<select name="logLevel" id="logLevel" class="form-control" data-default="0" value="0" data-topicprefix="openWB/config/get/SmartHome/">
-										<option value="0" data-option="0">0</option>
+										<option value="0" data-option="0" checked="checked">0</option>
 										<option value="1" data-option="1">1</option>
 										<option value="2" data-option="2">2</option>
 									</select>
@@ -552,7 +560,7 @@
 		<script src = "settings/processAllMqttMsg.js?ver=20201207" ></script>
 
 		<script>
-			<?php for( $devicenum = 1; $devicenum <= 10; $devicenum++ ) { ?>
+			<?php for( $devicenum = 1; $devicenum <= $numDevices; $devicenum++ ) { ?>
 				function visibility_device_configuredDevices<?php echo $devicenum; ?>( data ){
 					// console.log("device_configuredDevices: data: "+data);
 					if( typeof data == 'undefined' ){
@@ -602,11 +610,11 @@
 				}
 
 				function visibility_device_canSwitchDevices<?php echo $devicenum; ?>( data ){
-					console.log("device_canSwitchDevices: data: "+data);
+					// console.log("device_canSwitchDevices: data: "+data);
 					if( typeof data == 'undefined' ){
 						data = $('input[name=device_canSwitchDevices<?php echo $devicenum; ?>]:checked').attr("data-option");
 					}
-					console.log("device_canSwitchDevices: data: "+data);
+					// console.log("device_canSwitchDevices: data: "+data);
 					if( data == 0 ){
 						hideSection('.device<?php echo $devicenum; ?>canSwitch');
 					} else {
@@ -615,6 +623,11 @@
 				}
 
 				function visibility_device_nameDevices<?php echo $devicenum; ?>( data ){
+					// console.log("device_nameDevices: data: "+data);
+					if( typeof data =='undefined' ){
+						data = $('input[name=device_nameDevices<?php echo $devicenum; ?>]').val();
+					}
+					// console.log("device_nameDevices: data: "+data);
 					if ( data != "Name" ) {
 						$('#deviceHeader<?php echo $devicenum; ?>').text('Gerät <?php echo $devicenum; ?> ('+data+')');
 					} else {
@@ -632,11 +645,7 @@
 			}
 
 			function visibiltycheck(elementId, mqttpayload) {
-				<?php for( $devicenum = 1; $devicenum <= 10; $devicenum++ ) { ?>
-					if ( elementId == 'boolHouseBatteryConfigured' ) {
-						visibility_housebatteryConfigured( mqttpayload );
-					}
-
+				<?php for( $devicenum = 1; $devicenum <= $numDevices; $devicenum++ ) { ?>
 					if ( elementId == 'device_configuredDevices<?php echo $devicenum; ?>') {
 						visibility_device_configuredDevices<?php echo $devicenum; ?>( mqttpayload );
 					}
@@ -661,10 +670,14 @@
 						visibility_device_nameDevices<?php echo $devicenum; ?>( mqttpayload );
 					}
 				<?php } ?>
+
+				if ( elementId == 'boolHouseBatteryConfigured' ) {
+						visibility_housebatteryConfigured( mqttpayload );
+					}
 			}
 
 			$(function() {
-				<?php for( $devicenum = 1; $devicenum <= 10; $devicenum++ ) { ?>
+				<?php for( $devicenum = 1; $devicenum <= $numDevices; $devicenum++ ) { ?>
 					$('#device_configuredDevices<?php echo $devicenum; ?>').change(function(){
 						visibility_device_configuredDevices<?php echo $devicenum; ?>();
 					});
@@ -711,6 +724,17 @@
 				sendValues();
 			}
 
+			function initForm() {
+				<?php for( $devicenum = 1; $devicenum <= $numDevices; $devicenum++ ) { ?>
+					visibility_device_configuredDevices<?php echo $devicenum; ?>();
+					visibility_device_typeDevices<?php echo $devicenum; ?>();
+					visibility_device_differentMeasurementDevices<?php echo $devicenum; ?>();
+					visibility_device_measureTypeDevices<?php echo $devicenum; ?>();
+					visibility_device_canSwitchDevices<?php echo $devicenum; ?>();
+					visibility_device_nameDevices<?php echo $devicenum; ?>();
+				<?php } ?>
+			}
+
 			$(document).ready(function(){
 
 				$('input').blur(function(event) {
@@ -752,6 +776,8 @@
 					// on the fly input validation
 					formatToNaturalNumber(this);
 				});
+
+				initForm();
 			});  // end document ready function
 
 		</script>


### PR DESCRIPTION
- removed some code still referencing device 10
- changed static limit of 9 devices to global variable in several scripts
- removed color formating in logging of smarthomehandler (not compatible with displaying in browsers)
- added missing underscore "_" for new url parameters (http device type)
- temporary added some js console logging to smarthome config page
- changed clearing of set messages in mqttsub.py to always clear topics (also for wrong payloads)
- proper init of all form fields in smarthomeconfig (fixes initially wrong hidden sections and infinite waiting on save)
- setting all text input fields to required (only validated if visible/not disabled)
- moved "Einschalt-URL" and "Ausschalt-URL" for http devices down into "device can switch" section
- always display "Leistungs-URL" for http devices