### PR TITLE
Add smart home module for AVM Home Automation (FRITZ!Box) switches 

### DIFF
--- a/modules/smarthome/avmhomeautomation/avmcommon.py
+++ b/modules/smarthome/avmhomeautomation/avmcommon.py
@@ -8,6 +8,8 @@ import hashlib
 import credentials
 import xml.etree.ElementTree as ET
 
+# getAVMSessionID retrieves a session ID for issuing commands to a FRITZ!Box webinterface.
+# See https://avm.de/fileadmin/user_upload/Global/Service/Schnittstellen/Session-ID_deutsch_13Nov18.pdf for a description of the challenge-response-method.
 def getAVMSessionID(
         baseurl, 
         password,
@@ -44,6 +46,10 @@ def getAVMSessionID(
     sessionid = sessioninfo.find('SID').text
     return sessionid
 
+# getDevicesDict returns a dictionary that maps defined actor names to its
+# unique hardware ID (called "AIN": "Actuator Identification Number") and
+# current values for the power, voltage, integraded energy, temperature (not
+# for group actors).
 def getDevicesDict(baseurl, sessionid):
     getdevicelistinfosurl = baseurl + "/webservices/homeautoswitch.lua?sid="+sessionid+"&switchcmd=getdevicelistinfos"
     getdevicelistinfosResponseBody = str(urllib.request.urlopen(getdevicelistinfosurl).read(), "utf-8").strip()

--- a/modules/smarthome/avmhomeautomation/avmcommon.py
+++ b/modules/smarthome/avmhomeautomation/avmcommon.py
@@ -14,7 +14,7 @@ def getAVMSessionID(
         baseurl, 
         password,
         username, 
-        previoussessionid="0000000000000000",
+        previoussessionid = "0000000000000000",
         ):
 
     # fallback for storing password and credentials locally
@@ -25,7 +25,7 @@ def getAVMSessionID(
         
     loginurl = baseurl + '/login_sid.lua'
     challengeURL = loginurl + "?sid="+previoussessionid
-    challengeResponse = ET.fromstring(urllib.request.urlopen(loginurl, timeout=5).read())
+    challengeResponse = ET.fromstring(urllib.request.urlopen(loginurl, timeout = 5).read())
     sessionid = challengeResponse.find('SID').text
     if sessionid != "0000000000000000":
         # We already had valid session id, so return directly
@@ -40,8 +40,8 @@ def getAVMSessionID(
             }
     data = urllib.parse.urlencode(dataDict).encode()
     # with data parameter, the request will be of HTTP method POST
-    loginRequest = urllib.request.Request(loginurl, data=data)
-    loginResponseBody = urllib.request.urlopen(loginRequest, timeout=5).read()
+    loginRequest = urllib.request.Request(loginurl, data = data)
+    loginResponseBody = urllib.request.urlopen(loginRequest, timeout = 5).read()
     sessioninfo = ET.fromstring(loginResponseBody)
     sessionid = sessioninfo.find('SID').text
     return sessionid
@@ -65,5 +65,112 @@ def getDevicesDict(baseurl, sessionid):
         deviceNames[name] = {'ain': ain, 'power': power, 'voltage': voltage, 'energy': energy}
         temperatureBlock = device.find("temperature")
         if temperatureBlock != None:
-            deviceNames['temperature'] = float(temperatureBlock.find("celsius").text)/10.0 
+            deviceNames[name]['temperature'] = float(temperatureBlock.find("celsius").text)/10.0 
+        switchBlock = device.find("switch")
+        if switchBlock != None:
+            if int(switchBlock.find("state").text) == 1:
+                deviceNames[name]['state'] = True
+            else:
+                deviceNames[name]['state'] = False
     return deviceNames
+
+class AVMHomeAutomation:
+    # Parse configuration from command line arguments as proviced by /runs/smarthomehandler.py
+    def __init__(self):
+        self.devicenumber = str(sys.argv[1])
+        self.baseURL = "http://" + str(sys.argv[2]) # IP or hostname (e.g. "fritz.box")
+        self.switchname = str(sys.argv[5])
+        self.username = str(sys.argv[6])
+        self.password = str(sys.argv[7])
+        self.sessionID = ""
+
+    # connect checks the currently known session ID for validity and
+    # performs an authentication to obtain a new session ID if neccessary
+    def connect(self):
+        file_stringsessionid = '/var/www/html/openWB/ramdisk/smarthome_device_' + str(self.devicenumber) + '_sessionid'
+
+        # try to read previous session id from ramdisk file. If this operation fails,
+        # no harm is done as we can proceed with normal authentication. Reusing
+        # a session ID (which is valid up to 60 minutes) saves some time, though.
+        try:
+            if os.path.isfile(file_stringsessionid):
+                f = open(file_stringsessionid, 'r')
+                self.sessionID = f.read()
+                f.close()
+        except IOError:
+            pass
+
+        # perform login
+        self.sessionID = getAVMSessionID(
+                self.baseURL,
+                previoussessionid = self.sessionID,
+                username = self.username,
+                password = self.password)
+
+        # Try to store potentially new session id to ramdisk for next run
+        # If this operations fails, no harm is done as we can always authenticate
+        # with username/password.
+        try:
+            f = open(file_stringsessionid, 'w')
+            print ('%s' % (sessionid),file = f)
+            f.close()
+        except IOError:
+            pass
+
+    # logAction writes a message to the logfile for the smarthome device.
+    def logAction(self, action):
+        named_tuple = time.localtime() # getstruct_time
+        time_string = time.strftime("%m/%d/%Y, %H:%M:%S", named_tuple)
+        logfile_string = '/var/www/html/openWB/ramdisk/smarthome_device_' + str(self.devicenumber) + '_avmhomeautomation.log'
+        try:
+            if os.path.isfile(logfile_string):
+                f = open( logfile_string , 'a')
+            else:
+                f = open( logfile_string , 'w') 
+                print ('%s devicenr %s avmhomeautomation %s' % (time_string, self.devicenumber, action),file = f)
+                f.close()
+        except IOError:
+            pass
+
+
+    # switchDevice sets the relais of the AVM Home Automation actor
+    # state parameter: true -> on, false -> off
+    def switchDevice(self, state):
+        if state:
+            cmd = "setswitchon"
+        else:
+            cmd = "setswitchoff"
+        self.logAction(cmd)
+
+        switch = getDevicesDict(self.baseURL, self.sessionID)[self.switchname]
+        ain = urllib.parse.quote(switch["ain"])
+
+        commandURL = self.baseURL + \
+            "/webservices/homeautoswitch.lua?" + \
+            "sid=" + self.sessionID + \
+            "&switchcmd=" + cmd + \
+            "&ain=" + ain
+        urllib.request.urlopen(commandURL, timeout = 5)
+
+    # getActualPower returns current observed power and the state of the switch relais.
+    # The JSON answer is either written to the according smarthome device return file
+    # or dumped to stdout if no such file exists (for local development)
+    def getActualPower(self):
+        self.logAction("fetch power")
+
+        switch = getDevicesDict(self.baseURL, self.sessionID)[self.switchname]
+        aktpower = switch['power']
+
+        if switch['state']:
+            relais = 1
+        else:
+            relais = 0
+        powerc = 0
+        answer = '{"power":' + str(aktpower) + ',"powerc":' + str(powerc) + ',"on":' + str(relais) + '} '
+        try:
+            f1 = open('/var/www/html/openWB/ramdisk/smarthome_device_ret' + str(self.devicenumber), 'w')
+            json.dump(answer, f1)
+            f1.close()
+        except IOError:
+            print(answer) # dump answer to stdout if file cannot be written
+

--- a/modules/smarthome/avmhomeautomation/avmcommon.py
+++ b/modules/smarthome/avmhomeautomation/avmcommon.py
@@ -35,3 +35,21 @@ def getAVMSessionID(
     sessioninfo = ET.fromstring(loginResponseBody)
     sessionid = sessioninfo.find('SID').text
     return sessionid
+
+def getDevicesDict(baseurl, sessionid):
+    getdevicelistinfosurl = baseurl + "/webservices/homeautoswitch.lua?sid="+sessionid+"&switchcmd=getdevicelistinfos"
+    getdevicelistinfosResponseBody = str(urllib.request.urlopen(getdevicelistinfosurl).read(), "utf-8").strip()
+    devicelistinfos = ET.fromstring(getdevicelistinfosResponseBody)
+    deviceNames = {}
+    for device in devicelistinfos:
+        name = device.find("name").text
+        ain = device.attrib["identifier"]
+        powermeter = device.find("powermeter")
+        power = float(powermeter.find("power").text)/1000.0
+        voltage = float(powermeter.find("voltage").text)/1000.0
+        energy = powermeter.find("energy").text
+        deviceNames[name] = {'ain': ain, 'power': power, 'voltage': voltage, 'energy': energy}
+        temperatureBlock = device.find("temperature")
+        if temperatureBlock != None:
+            deviceNames['temperature'] = float(temperatureBlock.find("celsius").text)/10.0 
+    return deviceNames

--- a/modules/smarthome/avmhomeautomation/avmcommon.py
+++ b/modules/smarthome/avmhomeautomation/avmcommon.py
@@ -1,0 +1,37 @@
+#!/usr/bin/python3
+import sys
+import os
+import time
+import json
+import urllib.request
+import hashlib
+import xml.etree.ElementTree as ET
+
+def getAVMSessionID(
+        baseurl, 
+        password,
+        username, 
+        previoussessionid="0000000000000000",
+        ):
+    loginurl = baseurl + '/login_sid.lua'
+    challengeURL = loginurl + "?sid="+previoussessionid
+    challengeResponse = ET.fromstring(urllib.request.urlopen(loginurl, timeout=5).read())
+    sessionid = challengeResponse.find('SID').text
+    if sessionid != "0000000000000000":
+        # We already had valid session id, so return directly
+        return sessionid
+    challenge = challengeResponse.find('Challenge').text
+    m = hashlib.md5()
+    m.update((challenge + "-" + password).encode('utf-16le'))
+    hashedPassword = m.hexdigest()
+    dataDict = {
+            'username': username,
+            'response': challenge + "-" + hashedPassword
+            }
+    data = urllib.parse.urlencode(dataDict).encode()
+    # with data parameter, the request will be of HTTP method POST
+    loginRequest = urllib.request.Request(loginurl, data=data)
+    loginResponseBody = urllib.request.urlopen(loginRequest, timeout=5).read()
+    sessioninfo = ET.fromstring(loginResponseBody)
+    sessionid = sessioninfo.find('SID').text
+    return sessionid

--- a/modules/smarthome/avmhomeautomation/avmcommon.py
+++ b/modules/smarthome/avmhomeautomation/avmcommon.py
@@ -59,9 +59,9 @@ def getDevicesDict(baseurl, sessionid):
         name = device.find("name").text
         ain = device.attrib["identifier"]
         powermeter = device.find("powermeter")
-        power = float(powermeter.find("power").text)/1000.0
-        voltage = float(powermeter.find("voltage").text)/1000.0
-        energy = powermeter.find("energy").text
+        power = float(powermeter.find("power").text)/1000.0 # AVM returns mW, convert to W here
+        voltage = float(powermeter.find("voltage").text)/1000.0 # AVM returns mV, convert to V here
+        energy = powermeter.find("energy").text # AVM returns Wh
         deviceNames[name] = {'ain': ain, 'power': power, 'voltage': voltage, 'energy': energy}
         temperatureBlock = device.find("temperature")
         if temperatureBlock != None:
@@ -160,12 +160,12 @@ class AVMHomeAutomation:
 
         switch = getDevicesDict(self.baseURL, self.sessionID)[self.switchname]
         aktpower = switch['power']
+        powerc = switch['energy']
 
         if switch['state']:
             relais = 1
         else:
             relais = 0
-        powerc = 0
         answer = '{"power":' + str(aktpower) + ',"powerc":' + str(powerc) + ',"on":' + str(relais) + '} '
         try:
             f1 = open('/var/www/html/openWB/ramdisk/smarthome_device_ret' + str(self.devicenumber), 'w')

--- a/modules/smarthome/avmhomeautomation/avmcommon.py
+++ b/modules/smarthome/avmhomeautomation/avmcommon.py
@@ -5,6 +5,7 @@ import time
 import json
 import urllib.request
 import hashlib
+import credentials
 import xml.etree.ElementTree as ET
 
 def getAVMSessionID(
@@ -13,6 +14,13 @@ def getAVMSessionID(
         username, 
         previoussessionid="0000000000000000",
         ):
+
+    # fallback for storing password and credentials locally
+    if username == '':
+        username = credentials.username
+    if password == '':
+        password = credentials.password
+        
     loginurl = baseurl + '/login_sid.lua'
     challengeURL = loginurl + "?sid="+previoussessionid
     challengeResponse = ET.fromstring(urllib.request.urlopen(loginurl, timeout=5).read())

--- a/modules/smarthome/avmhomeautomation/credentials.py
+++ b/modules/smarthome/avmhomeautomation/credentials.py
@@ -1,0 +1,2 @@
+username = ''
+password = ''

--- a/modules/smarthome/avmhomeautomation/off.py
+++ b/modules/smarthome/avmhomeautomation/off.py
@@ -5,34 +5,22 @@ import time
 import json
 import urllib.request
 import avmcommon
-import credentials
 
 #from urllib.parse import urlparse
 named_tuple = time.localtime() # getstruct_time
 time_string = time.strftime("%m/%d/%Y, %H:%M:%S avmhomeautomation on.py", named_tuple)
 devicenumber=str(sys.argv[1])
-switchname=str(sys.argv[2])
+fritzboxAddress = str(sys.argv[2]) # IP or hostname (e.g. "fritz.box")
+switchname = str(sys.argv[5])
+username = str(sys.argv[6])
+password = str(sys.argv[7])
 # needs to be configurable
 file_string = '/var/www/html/openWB/ramdisk/smarthome_device_' + str(devicenumber) + '_avmhomeautomation.log'
 file_stringsessionid = '/var/www/html/openWB/ramdisk/smarthome_device_' + str(devicenumber) + '_sessionid'
-file_stringuser= '/var/www/html/openWB/ramdisk/smarthome_device_' + str(devicenumber) + '_user'
-file_stringpass= '/var/www/html/openWB/ramdisk/smarthome_device_' + str(devicenumber) + '_pass'
-username = credentials.username
-password = credentials.password
 sessionid = '0000000000000000'
 if os.path.isfile(file_stringsessionid):
     f = open(file_stringsessionid, 'r')
     sessionid = f.read()
-    f.close()
-
-if os.path.isfile(file_stringuser):
-    f = open(file_stringsessionid, 'r')
-    username = f.read()
-    f.close()
-
-if os.path.isfile(file_stringpass):
-    f = open(file_stringsessionid, 'r')
-    password = f.read()
     f.close()
 
 try:
@@ -45,10 +33,7 @@ try:
 except IOError:
     pass
 
-if username == '' or password == '':
-    sys.exit()
-
-baseurl='http://fritz.box'
+baseurl='http://' + fritzboxAddress
 sessionid = avmcommon.getAVMSessionID(
         baseurl, 
         previoussessionid=sessionid,

--- a/modules/smarthome/avmhomeautomation/off.py
+++ b/modules/smarthome/avmhomeautomation/off.py
@@ -1,0 +1,77 @@
+#!/usr/bin/python3
+import sys
+import os
+import time
+import json
+import urllib.request
+import login
+import credentials
+
+#from urllib.parse import urlparse
+named_tuple = time.localtime() # getstruct_time
+time_string = time.strftime("%m/%d/%Y, %H:%M:%S avmhomeautomation off.py", named_tuple)
+devicenumber=str(sys.argv[1])
+switchname=str(sys.argv[2])
+# needs to be configurable
+file_string = '/var/www/html/openWB/ramdisk/smarthome_device_' + str(devicenumber) + '_avmhomeautomation.log'
+file_stringsessionid = '/var/www/html/openWB/ramdisk/smarthome_device_' + str(devicenumber) + '_sessionid'
+file_stringuser= '/var/www/html/openWB/ramdisk/smarthome_device_' + str(devicenumber) + '_user'
+file_stringpass= '/var/www/html/openWB/ramdisk/smarthome_device_' + str(devicenumber) + '_pass'
+username = credentials.username
+password = credentials.password
+sessionid = '0000000000000000'
+if os.path.isfile(file_stringsessionid):
+    f = open(file_stringsessionid, 'r')
+    sessionid = f.read()
+    f.close()
+
+if os.path.isfile(file_stringuser):
+    f = open(file_stringsessionid, 'r')
+    username = f.read()
+    f.close()
+
+if os.path.isfile(file_stringpass):
+    f = open(file_stringsessionid, 'r')
+    password = f.read()
+    f.close()
+
+try:
+    if os.path.isfile(file_string):
+        f = open( file_string , 'a')
+    else:
+        f = open( file_string , 'w') 
+        print ('%s devicenr %s %s on' % (time_string,devicenumber,url),file=f)
+        f.close()
+except IOError:
+    pass
+
+if username == '' or password == '':
+    sys.exit()
+
+baseurl='http://fritz.box'
+sessionid = login.getAVMSessionID(
+        baseurl, 
+        previoussessionid=sessionid,
+        username=username,
+        password=password)
+
+try:
+    f = open(file_stringsessionid, 'w')
+    print ('%s' % (sessionid),file=f)
+    f.close()
+except IOError:
+    pass
+
+baseurl += "/webservices/homeautoswitch.lua?sid="+sessionid+"&switchcmd="
+
+getswitchlisturl=baseurl+"getswitchlist"
+getswitchlistResponseBody = str(urllib.request.urlopen(getswitchlisturl).read(), "utf-8").strip()
+switchIDs = getswitchlistResponseBody.split(",")
+for id in switchIDs:
+    getswitchnameurl=baseurl+"getswitchname&ain=" + id
+    foundswitchname = str(urllib.request.urlopen(getswitchnameurl).read(), "utf-8").strip()
+    if foundswitchname == switchname:
+        setswitchoffurl=baseurl+"setswitchoff&ain=" + id
+        urllib.request.urlopen(setswitchoffurl)
+        sys.exit()
+

--- a/modules/smarthome/avmhomeautomation/off.py
+++ b/modules/smarthome/avmhomeautomation/off.py
@@ -1,55 +1,6 @@
 #!/usr/bin/python3
-import sys
-import os
-import time
-import json
-import urllib.request
 import avmcommon
 
-#from urllib.parse import urlparse
-named_tuple = time.localtime() # getstruct_time
-time_string = time.strftime("%m/%d/%Y, %H:%M:%S avmhomeautomation on.py", named_tuple)
-devicenumber=str(sys.argv[1])
-fritzboxAddress = str(sys.argv[2]) # IP or hostname (e.g. "fritz.box")
-switchname = str(sys.argv[5])
-username = str(sys.argv[6])
-password = str(sys.argv[7])
-# needs to be configurable
-file_string = '/var/www/html/openWB/ramdisk/smarthome_device_' + str(devicenumber) + '_avmhomeautomation.log'
-file_stringsessionid = '/var/www/html/openWB/ramdisk/smarthome_device_' + str(devicenumber) + '_sessionid'
-sessionid = '0000000000000000'
-if os.path.isfile(file_stringsessionid):
-    f = open(file_stringsessionid, 'r')
-    sessionid = f.read()
-    f.close()
-
-try:
-    if os.path.isfile(file_string):
-        f = open( file_string , 'a')
-    else:
-        f = open( file_string , 'w') 
-        print ('%s devicenr %s %s on' % (time_string,devicenumber,url),file=f)
-        f.close()
-except IOError:
-    pass
-
-baseurl='http://' + fritzboxAddress
-sessionid = avmcommon.getAVMSessionID(
-        baseurl, 
-        previoussessionid=sessionid,
-        username=username,
-        password=password)
-
-try:
-    f = open(file_stringsessionid, 'w')
-    print ('%s' % (sessionid),file=f)
-    f.close()
-except IOError:
-    pass
-
-
-switch = avmcommon.getDevicesDict(baseurl, sessionid)[switchname]
-ain = urllib.parse.quote(switch["ain"])
-setswitchoffurl=baseurl+"/webservices/homeautoswitch.lua?sid="+sessionid+"&switchcmd=setswitchoff&ain="+ain
-urllib.request.urlopen(setswitchoffurl)
-
+interface = avmcommon.AVMHomeAutomation()
+interface.connect()
+interface.switchDevice(False)

--- a/modules/smarthome/avmhomeautomation/off.py
+++ b/modules/smarthome/avmhomeautomation/off.py
@@ -4,12 +4,12 @@ import os
 import time
 import json
 import urllib.request
-import login
+import avmcommon
 import credentials
 
 #from urllib.parse import urlparse
 named_tuple = time.localtime() # getstruct_time
-time_string = time.strftime("%m/%d/%Y, %H:%M:%S avmhomeautomation off.py", named_tuple)
+time_string = time.strftime("%m/%d/%Y, %H:%M:%S avmhomeautomation on.py", named_tuple)
 devicenumber=str(sys.argv[1])
 switchname=str(sys.argv[2])
 # needs to be configurable
@@ -49,7 +49,7 @@ if username == '' or password == '':
     sys.exit()
 
 baseurl='http://fritz.box'
-sessionid = login.getAVMSessionID(
+sessionid = avmcommon.getAVMSessionID(
         baseurl, 
         previoussessionid=sessionid,
         username=username,
@@ -62,16 +62,9 @@ try:
 except IOError:
     pass
 
-baseurl += "/webservices/homeautoswitch.lua?sid="+sessionid+"&switchcmd="
 
-getswitchlisturl=baseurl+"getswitchlist"
-getswitchlistResponseBody = str(urllib.request.urlopen(getswitchlisturl).read(), "utf-8").strip()
-switchIDs = getswitchlistResponseBody.split(",")
-for id in switchIDs:
-    getswitchnameurl=baseurl+"getswitchname&ain=" + id
-    foundswitchname = str(urllib.request.urlopen(getswitchnameurl).read(), "utf-8").strip()
-    if foundswitchname == switchname:
-        setswitchoffurl=baseurl+"setswitchoff&ain=" + id
-        urllib.request.urlopen(setswitchoffurl)
-        sys.exit()
+switch = avmcommon.getDevicesDict(baseurl, sessionid)[switchname]
+ain = urllib.parse.quote(switch["ain"])
+setswitchoffurl=baseurl+"/webservices/homeautoswitch.lua?sid="+sessionid+"&switchcmd=setswitchoff&ain="+ain
+urllib.request.urlopen(setswitchoffurl)
 

--- a/modules/smarthome/avmhomeautomation/on.py
+++ b/modules/smarthome/avmhomeautomation/on.py
@@ -1,0 +1,77 @@
+#!/usr/bin/python3
+import sys
+import os
+import time
+import json
+import urllib.request
+import login
+import credentials
+
+#from urllib.parse import urlparse
+named_tuple = time.localtime() # getstruct_time
+time_string = time.strftime("%m/%d/%Y, %H:%M:%S avmhomeautomation on.py", named_tuple)
+devicenumber=str(sys.argv[1])
+url=str(sys.argv[4])
+# needs to be configurable
+file_string = '/var/www/html/openWB/ramdisk/smarthome_device_' + str(devicenumber) + '_avmhomeautomation.log'
+file_stringsessionid = '/var/www/html/openWB/ramdisk/smarthome_device_' + str(devicenumber) + '_sessionid'
+file_stringuser= '/var/www/html/openWB/ramdisk/smarthome_device_' + str(devicenumber) + '_user'
+file_stringpass= '/var/www/html/openWB/ramdisk/smarthome_device_' + str(devicenumber) + '_pass'
+username = credentials.username
+password = credentials.password
+sessionid = '0000000000000000'
+if os.path.isfile(file_stringsessionid):
+    f = open(file_stringsessionid, 'r')
+    sessionid = f.read()
+    f.close()
+
+if os.path.isfile(file_stringuser):
+    f = open(file_stringsessionid, 'r')
+    username = f.read()
+    f.close()
+
+if os.path.isfile(file_stringpass):
+    f = open(file_stringsessionid, 'r')
+    password = f.read()
+    f.close()
+
+try:
+    if os.path.isfile(file_string):
+        f = open( file_string , 'a')
+    else:
+        f = open( file_string , 'w') 
+        print ('%s devicenr %s %s on' % (time_string,devicenumber,url),file=f)
+        f.close()
+except IOError:
+    pass
+
+if username == '' or password == '':
+    sys.exit()
+
+baseurl='http://fritz.box'
+sessionid = login.getAVMSessionID(
+        baseurl, 
+        previoussessionid=sessionid,
+        username=username,
+        password=password)
+
+try:
+    f = open(file_stringsessionid, 'w')
+    print ('%s' % (sessionid),file=f)
+    f.close()
+except IOError:
+    pass
+
+baseurl += "/webservices/homeautoswitch.lua?sid="+sessionid+"&switchcmd="
+
+getswitchlisturl=baseurl+"getswitchlist"
+getswitchlistResponseBody = str(urllib.request.urlopen(getswitchlisturl).read(), "utf-8").strip()
+switchIDs = getswitchlistResponseBody.split(",")
+for id in switchIDs:
+    getswitchnameurl=baseurl+"getswitchname&ain=" + id
+    foundswitchname = str(urllib.request.urlopen(getswitchnameurl).read(), "utf-8").strip()
+    if foundswitchname == switchname:
+        setswitchonurl=baseurl+"setswitchon&ain=" + id
+        urllib.request.urlopen(setswitchonurl)
+        sys.exit()
+

--- a/modules/smarthome/avmhomeautomation/on.py
+++ b/modules/smarthome/avmhomeautomation/on.py
@@ -4,14 +4,14 @@ import os
 import time
 import json
 import urllib.request
-import login
+import avmcommon
 import credentials
 
 #from urllib.parse import urlparse
 named_tuple = time.localtime() # getstruct_time
 time_string = time.strftime("%m/%d/%Y, %H:%M:%S avmhomeautomation on.py", named_tuple)
 devicenumber=str(sys.argv[1])
-url=str(sys.argv[4])
+switchname=str(sys.argv[2])
 # needs to be configurable
 file_string = '/var/www/html/openWB/ramdisk/smarthome_device_' + str(devicenumber) + '_avmhomeautomation.log'
 file_stringsessionid = '/var/www/html/openWB/ramdisk/smarthome_device_' + str(devicenumber) + '_sessionid'
@@ -49,7 +49,7 @@ if username == '' or password == '':
     sys.exit()
 
 baseurl='http://fritz.box'
-sessionid = login.getAVMSessionID(
+sessionid = avmcommon.getAVMSessionID(
         baseurl, 
         previoussessionid=sessionid,
         username=username,
@@ -62,16 +62,9 @@ try:
 except IOError:
     pass
 
-baseurl += "/webservices/homeautoswitch.lua?sid="+sessionid+"&switchcmd="
 
-getswitchlisturl=baseurl+"getswitchlist"
-getswitchlistResponseBody = str(urllib.request.urlopen(getswitchlisturl).read(), "utf-8").strip()
-switchIDs = getswitchlistResponseBody.split(",")
-for id in switchIDs:
-    getswitchnameurl=baseurl+"getswitchname&ain=" + id
-    foundswitchname = str(urllib.request.urlopen(getswitchnameurl).read(), "utf-8").strip()
-    if foundswitchname == switchname:
-        setswitchonurl=baseurl+"setswitchon&ain=" + id
-        urllib.request.urlopen(setswitchonurl)
-        sys.exit()
+switch = avmcommon.getDevicesDict(baseurl, sessionid)[switchname]
+ain = urllib.parse.quote(switch["ain"])
+setswitchonurl=baseurl+"/webservices/homeautoswitch.lua?sid="+sessionid+"&switchcmd=setswitchon&ain="+ain
+urllib.request.urlopen(setswitchonurl)
 

--- a/modules/smarthome/avmhomeautomation/on.py
+++ b/modules/smarthome/avmhomeautomation/on.py
@@ -1,56 +1,6 @@
 #!/usr/bin/python3
-import sys
-import os
-import time
-import json
-import urllib.request
 import avmcommon
 
-#from urllib.parse import urlparse
-named_tuple = time.localtime() # getstruct_time
-time_string = time.strftime("%m/%d/%Y, %H:%M:%S avmhomeautomation on.py", named_tuple)
-devicenumber = str(sys.argv[1])
-fritzboxAddress = str(sys.argv[2]) # IP or hostname (e.g. "fritz.box")
-switchname = str(sys.argv[5])
-username = str(sys.argv[6])
-password = str(sys.argv[7])
-
-# needs to be configurable
-file_string = '/var/www/html/openWB/ramdisk/smarthome_device_' + str(devicenumber) + '_avmhomeautomation.log'
-file_stringsessionid = '/var/www/html/openWB/ramdisk/smarthome_device_' + str(devicenumber) + '_sessionid'
-sessionid = '0000000000000000'
-if os.path.isfile(file_stringsessionid):
-    f = open(file_stringsessionid, 'r')
-    sessionid = f.read()
-    f.close()
-
-try:
-    if os.path.isfile(file_string):
-        f = open( file_string , 'a')
-    else:
-        f = open( file_string , 'w') 
-        print ('%s devicenr %s %s on' % (time_string,devicenumber,url),file=f)
-        f.close()
-except IOError:
-    pass
-
-baseurl='http://' + fritzboxAddress
-sessionid = avmcommon.getAVMSessionID(
-        baseurl, 
-        previoussessionid=sessionid,
-        username=username,
-        password=password)
-
-try:
-    f = open(file_stringsessionid, 'w')
-    print ('%s' % (sessionid),file=f)
-    f.close()
-except IOError:
-    pass
-
-
-switch = avmcommon.getDevicesDict(baseurl, sessionid)[switchname]
-ain = urllib.parse.quote(switch["ain"])
-setswitchonurl=baseurl+"/webservices/homeautoswitch.lua?sid="+sessionid+"&switchcmd=setswitchon&ain="+ain
-urllib.request.urlopen(setswitchonurl)
-
+interface = avmcommon.AVMHomeAutomation()
+interface.connect()
+interface.switchDevice(True)

--- a/modules/smarthome/avmhomeautomation/on.py
+++ b/modules/smarthome/avmhomeautomation/on.py
@@ -5,34 +5,23 @@ import time
 import json
 import urllib.request
 import avmcommon
-import credentials
 
 #from urllib.parse import urlparse
 named_tuple = time.localtime() # getstruct_time
 time_string = time.strftime("%m/%d/%Y, %H:%M:%S avmhomeautomation on.py", named_tuple)
-devicenumber=str(sys.argv[1])
-switchname=str(sys.argv[2])
+devicenumber = str(sys.argv[1])
+fritzboxAddress = str(sys.argv[2]) # IP or hostname (e.g. "fritz.box")
+switchname = str(sys.argv[5])
+username = str(sys.argv[6])
+password = str(sys.argv[7])
+
 # needs to be configurable
 file_string = '/var/www/html/openWB/ramdisk/smarthome_device_' + str(devicenumber) + '_avmhomeautomation.log'
 file_stringsessionid = '/var/www/html/openWB/ramdisk/smarthome_device_' + str(devicenumber) + '_sessionid'
-file_stringuser= '/var/www/html/openWB/ramdisk/smarthome_device_' + str(devicenumber) + '_user'
-file_stringpass= '/var/www/html/openWB/ramdisk/smarthome_device_' + str(devicenumber) + '_pass'
-username = credentials.username
-password = credentials.password
 sessionid = '0000000000000000'
 if os.path.isfile(file_stringsessionid):
     f = open(file_stringsessionid, 'r')
     sessionid = f.read()
-    f.close()
-
-if os.path.isfile(file_stringuser):
-    f = open(file_stringsessionid, 'r')
-    username = f.read()
-    f.close()
-
-if os.path.isfile(file_stringpass):
-    f = open(file_stringsessionid, 'r')
-    password = f.read()
     f.close()
 
 try:
@@ -45,10 +34,7 @@ try:
 except IOError:
     pass
 
-if username == '' or password == '':
-    sys.exit()
-
-baseurl='http://fritz.box'
+baseurl='http://' + fritzboxAddress
 sessionid = avmcommon.getAVMSessionID(
         baseurl, 
         previoussessionid=sessionid,

--- a/modules/smarthome/avmhomeautomation/watt.py
+++ b/modules/smarthome/avmhomeautomation/watt.py
@@ -5,33 +5,21 @@ import time
 import json
 import urllib.request
 import avmcommon
-import credentials
 #from urllib.parse import urlparse
 named_tuple = time.localtime() # getstruct_time
 time_string = time.strftime("%m/%d/%Y, %H:%M:%S avmhomeautomation watt.py", named_tuple)
 devicenumber=str(sys.argv[1])
-switchname=str(sys.argv[2])
+fritzboxAddress = str(sys.argv[2]) # IP or hostname (e.g. "fritz.box")
+switchname = str(sys.argv[5])
+username = str(sys.argv[6])
+password = str(sys.argv[7])
 # needs to be configurable
 file_string = '/var/www/html/openWB/ramdisk/smarthome_device_' + str(devicenumber) + '_avmhomeautomation.log'
 file_stringsessionid = '/var/www/html/openWB/ramdisk/smarthome_device_' + str(devicenumber) + '_sessionid'
-file_stringuser= '/var/www/html/openWB/ramdisk/smarthome_device_' + str(devicenumber) + '_user'
-file_stringpass= '/var/www/html/openWB/ramdisk/smarthome_device_' + str(devicenumber) + '_pass'
-username = credentials.username
-password = credentials.password
 sessionid = '0000000000000000'
 if os.path.isfile(file_stringsessionid):
     f = open(file_stringsessionid, 'r')
     sessionid = f.read()
-    f.close()
-
-if os.path.isfile(file_stringuser):
-    f = open(file_stringsessionid, 'r')
-    username = f.read()
-    f.close()
-
-if os.path.isfile(file_stringpass):
-    f = open(file_stringsessionid, 'r')
-    password = f.read()
     f.close()
 
 try:
@@ -44,10 +32,7 @@ try:
 except IOError:
     pass
 
-if username == '' or password == '':
-    sys.exit()
-
-baseurl='http://fritz.box'
+baseurl='http://' + fritzboxAddress
 sessionid = avmcommon.getAVMSessionID(
         baseurl, 
         previoussessionid=sessionid,

--- a/modules/smarthome/avmhomeautomation/watt.py
+++ b/modules/smarthome/avmhomeautomation/watt.py
@@ -4,7 +4,7 @@ import os
 import time
 import json
 import urllib.request
-import login
+import avmcommon
 import credentials
 #from urllib.parse import urlparse
 named_tuple = time.localtime() # getstruct_time
@@ -48,32 +48,21 @@ if username == '' or password == '':
     sys.exit()
 
 baseurl='http://fritz.box'
-sessionid = login.getAVMSessionID(
+sessionid = avmcommon.getAVMSessionID(
         baseurl, 
         previoussessionid=sessionid,
         username=username,
         password=password)
 
-baseurl += "/webservices/homeautoswitch.lua?sid="+sessionid+"&switchcmd="
 
-getswitchlisturl=baseurl+"getswitchlist"
-getswitchlistResponseBody = str(urllib.request.urlopen(getswitchlisturl).read(), "utf-8").strip()
-switchIDs = getswitchlistResponseBody.split(",")
-for id in switchIDs:
-    getswitchnameurl=baseurl+"getswitchname&ain=" + id
-    foundswitchname = str(urllib.request.urlopen(getswitchnameurl).read(), "utf-8").strip()
-    if foundswitchname == switchname:
-        getswitchpower=baseurl+"getswitchpower&ain=" + id
-        getswitchpowerResponseBody = str(urllib.request.urlopen(getswitchpower).read(), "utf-8").strip()
-        aktpower = float(getswitchpowerResponseBody)/1000.0
-        print (aktpower)
-        if aktpower > 50:
-            relais = 1
-        else:
-            relais = 0
-        powerc = 0
-        answer = '{"power":' + str(aktpower) + ',"powerc":' + str(powerc) + ',"on":' + str(relais) + '} '
-        f1 = open('/var/www/html/openWB/ramdisk/smarthome_device_ret' + str(devicenumber), 'w')
-        json.dump(answer,f1)
-        f1.close()
-        sys.exit()
+switch = avmcommon.getDevicesDict(baseurl, sessionid)[switchname]
+aktpower = switch['power']
+if aktpower > 50:
+    relais = 1
+else:
+    relais = 0
+powerc = 0
+answer = '{"power":' + str(aktpower) + ',"powerc":' + str(powerc) + ',"on":' + str(relais) + '} '
+f1 = open('/var/www/html/openWB/ramdisk/smarthome_device_ret' + str(devicenumber), 'w')
+json.dump(answer,f1)
+f1.close()

--- a/modules/smarthome/avmhomeautomation/watt.py
+++ b/modules/smarthome/avmhomeautomation/watt.py
@@ -1,0 +1,79 @@
+#!/usr/bin/python3
+import sys
+import os
+import time
+import json
+import urllib.request
+import login
+import credentials
+#from urllib.parse import urlparse
+named_tuple = time.localtime() # getstruct_time
+time_string = time.strftime("%m/%d/%Y, %H:%M:%S avmhomeautomation watt.py", named_tuple)
+devicenumber=str(sys.argv[1])
+switchname=str(sys.argv[2])
+# needs to be configurable
+file_string = '/var/www/html/openWB/ramdisk/smarthome_device_' + str(devicenumber) + '_avmhomeautomation.log'
+file_stringsessionid = '/var/www/html/openWB/ramdisk/smarthome_device_' + str(devicenumber) + '_sessionid'
+file_stringuser= '/var/www/html/openWB/ramdisk/smarthome_device_' + str(devicenumber) + '_user'
+file_stringpass= '/var/www/html/openWB/ramdisk/smarthome_device_' + str(devicenumber) + '_pass'
+username = credentials.username
+password = credentials.password
+sessionid = '0000000000000000'
+if os.path.isfile(file_stringsessionid):
+    f = open(file_stringsessionid, 'r')
+    sessionid = f.read()
+    f.close()
+
+if os.path.isfile(file_stringuser):
+    f = open(file_stringsessionid, 'r')
+    username = f.read()
+    f.close()
+
+if os.path.isfile(file_stringpass):
+    f = open(file_stringsessionid, 'r')
+    password = f.read()
+    f.close()
+
+try:
+    if os.path.isfile(file_string):
+        f = open( file_string , 'a')
+    else:
+        f = open( file_string , 'w') 
+        print ('%s devicenr %s %s on' % (time_string,devicenumber,url),file=f)
+        f.close()
+except IOError:
+    pass
+
+if username == '' or password == '':
+    sys.exit()
+
+baseurl='http://fritz.box'
+sessionid = login.getAVMSessionID(
+        baseurl, 
+        previoussessionid=sessionid,
+        username=username,
+        password=password)
+
+baseurl += "/webservices/homeautoswitch.lua?sid="+sessionid+"&switchcmd="
+
+getswitchlisturl=baseurl+"getswitchlist"
+getswitchlistResponseBody = str(urllib.request.urlopen(getswitchlisturl).read(), "utf-8").strip()
+switchIDs = getswitchlistResponseBody.split(",")
+for id in switchIDs:
+    getswitchnameurl=baseurl+"getswitchname&ain=" + id
+    foundswitchname = str(urllib.request.urlopen(getswitchnameurl).read(), "utf-8").strip()
+    if foundswitchname == switchname:
+        getswitchpower=baseurl+"getswitchpower&ain=" + id
+        getswitchpowerResponseBody = str(urllib.request.urlopen(getswitchpower).read(), "utf-8").strip()
+        aktpower = float(getswitchpowerResponseBody)/1000.0
+        print (aktpower)
+        if aktpower > 50:
+            relais = 1
+        else:
+            relais = 0
+        powerc = 0
+        answer = '{"power":' + str(aktpower) + ',"powerc":' + str(powerc) + ',"on":' + str(relais) + '} '
+        f1 = open('/var/www/html/openWB/ramdisk/smarthome_device_ret' + str(devicenumber), 'w')
+        json.dump(answer,f1)
+        f1.close()
+        sys.exit()

--- a/modules/smarthome/avmhomeautomation/watt.py
+++ b/modules/smarthome/avmhomeautomation/watt.py
@@ -1,53 +1,6 @@
 #!/usr/bin/python3
-import sys
-import os
-import time
-import json
-import urllib.request
 import avmcommon
-#from urllib.parse import urlparse
-named_tuple = time.localtime() # getstruct_time
-time_string = time.strftime("%m/%d/%Y, %H:%M:%S avmhomeautomation watt.py", named_tuple)
-devicenumber=str(sys.argv[1])
-fritzboxAddress = str(sys.argv[2]) # IP or hostname (e.g. "fritz.box")
-switchname = str(sys.argv[5])
-username = str(sys.argv[6])
-password = str(sys.argv[7])
-# needs to be configurable
-file_string = '/var/www/html/openWB/ramdisk/smarthome_device_' + str(devicenumber) + '_avmhomeautomation.log'
-file_stringsessionid = '/var/www/html/openWB/ramdisk/smarthome_device_' + str(devicenumber) + '_sessionid'
-sessionid = '0000000000000000'
-if os.path.isfile(file_stringsessionid):
-    f = open(file_stringsessionid, 'r')
-    sessionid = f.read()
-    f.close()
 
-try:
-    if os.path.isfile(file_string):
-        f = open( file_string , 'a')
-    else:
-        f = open( file_string , 'w') 
-        print ('%s devicenr %s %s on' % (time_string,devicenumber,url),file=f)
-        f.close()
-except IOError:
-    pass
-
-baseurl='http://' + fritzboxAddress
-sessionid = avmcommon.getAVMSessionID(
-        baseurl, 
-        previoussessionid=sessionid,
-        username=username,
-        password=password)
-
-
-switch = avmcommon.getDevicesDict(baseurl, sessionid)[switchname]
-aktpower = switch['power']
-if aktpower > 50:
-    relais = 1
-else:
-    relais = 0
-powerc = 0
-answer = '{"power":' + str(aktpower) + ',"powerc":' + str(powerc) + ',"on":' + str(relais) + '} '
-f1 = open('/var/www/html/openWB/ramdisk/smarthome_device_ret' + str(devicenumber), 'w')
-json.dump(answer,f1)
-f1.close()
+interface = avmcommon.AVMHomeAutomation()
+interface.connect()
+interface.getActualPower()

--- a/runs/smarthomehandler.py
+++ b/runs/smarthomehandler.py
@@ -397,7 +397,14 @@ def getdevicevalues():
             try:
                 pyname = pyname0 +"/watt.py"
                 if os.path.isfile(pyname) and (canswitch == 1):
-                   proc=subprocess.Popen( ['python3',pyname,str(numberOfDevices),config.get('smarthomedevices', 'device_ip_'+str(numberOfDevices)),str(uberschuss),device_leistungurl])
+                   argumentList = ['python3', pyname, str(nummer)]
+                   argumentList.append(config.get('smarthomedevices', 'device_ip_'+str(nummer)))
+                   argumentList.append(str(uberschuss))
+                   argumentList.append(device_leistungurl)
+                   argumentList.append(config.get('smarthomedevices', 'device_actor_'+str(nummer)))
+                   argumentList.append(config.get('smarthomedevices', 'device_username_'+str(nummer)))
+                   argumentList.append(config.get('smarthomedevices', 'device_password_'+str(nummer)))
+                   proc=subprocess.Popen(argumentList)
                    proc.communicate() 
                    f1 = open(basePath+'/ramdisk/smarthome_device_ret' +str(numberOfDevices) , 'r')
                    answerj=json.load(f1)
@@ -506,16 +513,25 @@ def turndevicerelais(nummer, zustand):
     except:
        device_ausschalturl = "undef"
     pyname0 = getdir(switchtyp,devicename)
+    argumentList = ['python3', "", str(nummer)] # element with index 1 will be set to on.py or off.py
+    argumentList.append(config.get('smarthomedevices', 'device_ip_'+str(nummer)))
+    argumentList.append(str(uberschuss))
+    argumentList.append("") # element with index 5 will be set on URL for switch on or off
+    argumentList.append(config.get('smarthomedevices', 'device_actor_'+str(nummer)))
+    argumentList.append(config.get('smarthomedevices', 'device_username_'+str(nummer)))
+    argumentList.append(config.get('smarthomedevices', 'device_password_'+str(nummer)))
     if ( zustand == 1):
        try:
            pyname = pyname0 +"/on.py"
            if os.path.isfile(pyname):
+              argumentList[1] = pyname
+              argumentList[5] = device_einschalturl
               logDebug("1", "Device: " + str(nummer) + " " + str(devicename) + " angeschaltet")
               f = open(basePath+'/ramdisk/device' + str(nummer) + '_req_relais', 'w')
               f.write(str(zustand))
               f.close()
               DeviceCounters.update( {str(nummer) + "eintime" : time.time()})
-              proc=subprocess.Popen( ['python3',pyname,str(nummer),config.get('smarthomedevices', 'device_ip_'+str(nummer)),str(uberschuss),device_einschalturl])
+              proc=subprocess.Popen(argumentList)
               proc.communicate()
            else:
               logDebug("0", "Device " + str(switchtyp) + str(nummer) + str(devicename) + " File not found: " + str(pyname)) 
@@ -525,7 +541,9 @@ def turndevicerelais(nummer, zustand):
        try:
            pyname = pyname0 +"/off.py"
            if os.path.isfile( pyname  ): 
-              proc=subprocess.Popen( ['python3',pyname,str(nummer),config.get('smarthomedevices', 'device_ip_'+str(nummer)),str(uberschuss),device_ausschalturl])
+              argumentList[1] = pyname
+              argumentList[5] = device_ausschalturl
+              proc=subprocess.Popen(argumentList)
               proc.communicate()
               logDebug("1", "Device: " + str(nummer) + " " + str(devicename) + " ausgeschaltet")
               f = open(basePath+'/ramdisk/device' + str(nummer) + '_req_relais', 'w')


### PR DESCRIPTION
This PR adds three scripts `on.py`, `off.py`, and `watt.py` that fulfill the same role as for other smarthome devices. The actors are addressed via a master device (usually a AVM FRITZ!Box router) which itself communications via DECT with the individual actors.

As the AVM Home Automation requires authentication to the DECT master and selection of the actor (here: via name), the call interface to smarthome scripts has been extended to take three additional call arguments. The subprocess call has been slightly refactored as the argument list is constructed explicitely prior to the call to `subprocess.Popen`. 