### PR TITLE
Fix writing AVM session ID to ramdisk

### DIFF
--- a/modules/smarthome/avmhomeautomation/avmcommon.py
+++ b/modules/smarthome/avmhomeautomation/avmcommon.py
@@ -112,7 +112,7 @@ class AVMHomeAutomation:
         # with username/password.
         try:
             f = open(file_stringsessionid, 'w')
-            print ('%s' % (sessionid),file = f)
+            print ('%s' % (self.sessionID),file = f)
             f.close()
         except IOError:
             pass


### PR DESCRIPTION
I forgot to substitute a variable `sessionid` with the data member `AVMHomeAutomation.sessionID` in #831. The relevant line was not reached outside of an openWB environment where the ramdisk does not exist.