### PR TITLE
tasmota als gerät kann schalten = nein

### DIFF
--- a/runs/smarthomehandler.py
+++ b/runs/smarthomehandler.py
@@ -397,7 +397,7 @@ def getdevicevalues():
             pyname0 = getdir(switchtyp,devicename)
             try:
                 pyname = pyname0 +"/watt.py"
-                if os.path.isfile(pyname) and (canswitch == 1):
+                if os.path.isfile(pyname):
                    argumentList = ['python3', pyname, str(numberOfDevices)]
                    argumentList.append(config.get('smarthomedevices', 'device_ip_'+str(numberOfDevices)))
                    argumentList.append(str(uberschuss))


### PR DESCRIPTION
tasmota als gerät kann schalten = nein wieder unterstützt.