### PR TITLE
August hat wieder 31 tage...

### DIFF
--- a/runs/sendmonthgraphdata.sh
+++ b/runs/sendmonthgraphdata.sh
@@ -9,7 +9,7 @@ elif [[ "$input" == "201812" ]]; then
 
 else
 	month=${input: -2}
-	month=$(( month + 1 ))
+	month=$(( ${month#0} +1))
 	if (( month < 10 )); then
 		month=$(printf "0$month")
 	fi


### PR DESCRIPTION
Die Bash Anweisung zur Berechnung vom Folgemonat (month=$(( month + 1 ))) wurde aufgrund der führenden 0 für die Monate Januar 01 bis Monat September  09 als octale Zahl  interpretiert. Deshalb klappte die Addition nur bis Juni (06 -> 07).
July war falsch ohne Absturz (07 -> 10)
August und September gab es keinen gültigen Folgemonat.
Ab October (führende 1) wurde die Zahl korrekt decimal interpretiert,