### PR TITLE
Fronius Bugfix + improved variant handling

### DIFF
--- a/modules/bezug_fronius_sm/main.sh
+++ b/modules/bezug_fronius_sm/main.sh
@@ -17,7 +17,7 @@ elif [[ $froniusvar2 == "1" ]]; then
 	json_id=".\"$froniuserzeugung\""
 	# Hole die JSON-Daten
 	response_sm=$(curl --connect-timeout 5 -s "$wrfroniusip/solar_api/v1/GetMeterRealtimeData.cgi?Scope=System")
-	# selbe response_sm wie in Variante0 mit folgendem Aufruf:
+	# TODO: Evtl. ist es noch weiter zu vereinfachen -> selbe response_sm wie in Variante0 mit folgendem Aufruf:
 	# response_sm=$(curl --connect-timeout 5 -s "$wrfroniusip/solar_api/v1/GetMeterRealtimeData.cgi?Scope=Device&DeviceID=$froniuserzeugung&DataCollection=MeterRealtimeData")
 	# dann auch json_id wieder gleich:
 	# json_id=""

--- a/modules/bezug_fronius_sm/main.sh
+++ b/modules/bezug_fronius_sm/main.sh
@@ -5,117 +5,110 @@
 # Einspeiseleistung: PV-Leistung > Verbrauch, es wird Strom eingespeist
 # Bezugsleistug: PV-Leistung < Verbrauch, es wird Strom aus dem Netz bezogen
 
-
 # Fordere die Werte vom SmartMeter an.
 if [[ $froniusvar2 == "0" ]]; then
+	# Setze die für JSON Abruf benötigte DeviceID
+	json_id=""
+	# Hole die JSON Daten
 	response_sm=$(curl --connect-timeout 5 -s "$wrfroniusip/solar_api/v1/GetMeterRealtimeData.cgi?Scope=Device&DeviceID=$froniuserzeugung")
 
-	# Überprüfe den Einbauort des SmartMeters.
-	meter_location=$(echo $response_sm | jq '.Body.Data.Meter_Location_Current')
-	# Wenn das SmartMeter nicht im Verbrauchszweig (also im Einspeisepunkt) sitzt, verwende direkt dessen Werte.
-	if [[ $meter_location != "1" ]]; then
-	    # Lese alle wichtigen Werte aus der JSON-Antwort und skaliere sie gleich.
-	    wattbezug=$(echo "scale=0; $(echo $response_sm | jq '.Body.Data.PowerReal_P_Sum')/1" | bc)
-	    evuv1=$(echo "scale=2; $(echo $response_sm | jq '.Body.Data.Voltage_AC_Phase_1')/1" | bc)
-	    evuv2=$(echo "scale=2; $(echo $response_sm | jq '.Body.Data.Voltage_AC_Phase_2')/1" | bc)
-	    evuv3=$(echo "scale=2; $(echo $response_sm | jq '.Body.Data.Voltage_AC_Phase_3')/1" | bc)
-	    bezugw1=$(echo "scale=2; $(echo $response_sm | jq '.Body.Data.PowerReal_P_Phase_1')/1" | bc)
-	    bezugw2=$(echo "scale=2; $(echo $response_sm | jq '.Body.Data.PowerReal_P_Phase_2')/1" | bc)
-	    bezugw3=$(echo "scale=2; $(echo $response_sm | jq '.Body.Data.PowerReal_P_Phase_3')/1" | bc)
-	    # Berechne den Strom und lese ihn nicht direkt (der eigentlich zu lesende direkte Wert
-	    # "Current_AC_Phase_1" wäre der Absolutwert und man würde das Vorzeichen verlieren).
-	    bezuga1=$(echo "scale=2; $bezugw1 / $evuv1" | bc)
-	    bezuga2=$(echo "scale=2; $bezugw2 / $evuv2" | bc)
-	    bezuga3=$(echo "scale=2; $bezugw3 / $evuv3" | bc)
-	    evuhz=$(echo "scale=2; $(echo $response_sm | jq '.Body.Data.Frequency_Phase_Average')/1" | bc)
-	    evupf1=$(echo "scale=2; $(echo $response_sm | jq '.Body.Data.PowerFactor_Phase_1')/1" | bc)
-	    evupf2=$(echo "scale=2; $(echo $response_sm | jq '.Body.Data.PowerFactor_Phase_2')/1" | bc)
-	    evupf3=$(echo "scale=2; $(echo $response_sm | jq '.Body.Data.PowerFactor_Phase_3')/1" | bc)
-	    ikwh=$(echo $response_sm | jq '.Body.Data.EnergyReal_WAC_Sum_Consumed')
-	    ekwh=$(echo $response_sm | jq '.Body.Data.EnergyReal_WAC_Sum_Produced')
-	# ... ansonsten, wenn das SmartMeter im Verbrauchszweig sitzt, kombiniere dessen Werte mit denen des Wechselrichters.
-	else
-	    # Lese die aktuelle PV-Leistung des Wechselrichters ein.
-	    response_fi=$(curl --connect-timeout 3 -s "$wrfroniusip/solar_api/v1/GetPowerFlowRealtimeData.fcgi?Scope=System")
-	    pvwatt=$(echo $response_fi | jq '.Body.Data.Site.P_PV' | sed 's/\..*$//')
-	    # Wenn WR aus bzw. im Standby (keine Antwort), ersetze leeren Wert durch eine 0.
-	    re='^-?[0-9]+$'
-	    if ! [[ $pvwatt =~ $re ]] ; then
-		pvwatt="0"
-	    fi
-	    
-	    wattbezug=$(echo "scale=0; $(echo $response_fi | jq '.Body.Data.Site.P_Grid')/1" | bc)
-	    # Hier gehen wir mal davon aus, dass es keinen großen Unterschied zwischen Verbrauchs- und Einspeisepunkt gibt.
-	    evuv1=$(echo "scale=2; $(echo $response_sm | jq '.Body.Data.Voltage_AC_Phase_1')/1" | bc)
-	    evuv2=$(echo "scale=2; $(echo $response_sm | jq '.Body.Data.Voltage_AC_Phase_2')/1" | bc)
-	    evuv3=$(echo "scale=2; $(echo $response_sm | jq '.Body.Data.Voltage_AC_Phase_3')/1" | bc)
-	    # Hier gehen wir mal davon aus, dass der Wechselrichter seine PV-Leistung gleichmäßig auf alle Phasen aufteilt.
-	    bezugw1=$(echo "scale=2; (-1 * $(echo $response_sm | jq '.Body.Data.PowerReal_P_Phase_1') - $pvwatt/3)/1" | bc)
-	    bezugw2=$(echo "scale=2; (-1 * $(echo $response_sm | jq '.Body.Data.PowerReal_P_Phase_2') - $pvwatt/3)/1" | bc)
-	    bezugw3=$(echo "scale=2; (-1 * $(echo $response_sm | jq '.Body.Data.PowerReal_P_Phase_3') - $pvwatt/3)/1" | bc)
-	    # Berechne den Strom und lese ihn nicht direkt (der eigentlich zu lesende direkte Wert
-	    # "Current_AC_Phase_1" wäre der Absolutwert und man würde das Vorzeichen verlieren).
-	    bezuga1=$(echo "scale=2; $bezugw1 / $evuv1" | bc)
-	    bezuga2=$(echo "scale=2; $bezugw2 / $evuv2" | bc)
-	    bezuga3=$(echo "scale=2; $bezugw3 / $evuv3" | bc)
-	    evuhz=$(echo "scale=2; $(echo $response_sm | jq '.Body.Data.Frequency_Phase_Average')/1" | bc)
-	    # Hier gehen wir mal davon aus, dass der Wechselrichter vor dem SmartMeter den Leistungsfaktor nicht
-	    # maßgeblich beeinflusst. Falls dies falsch ist -> Leistungsfaktor auf 0 setzen!
-	    evupf1=$(echo "scale=2; $(echo $response_sm | jq '.Body.Data.PowerFactor_Phase_1')/1" | bc)
-	    evupf2=$(echo "scale=2; $(echo $response_sm | jq '.Body.Data.PowerFactor_Phase_2')/1" | bc)
-	    evupf3=$(echo "scale=2; $(echo $response_sm | jq '.Body.Data.PowerFactor_Phase_3')/1" | bc)
-	    # Beim Energiebezug ist nicht klar, welcher Anteil aus dem Netz bezogen wurde, und was aus dem Wechselrichter kam.
-	    #ikwh=$(echo $response_sm | jq '.Body.Data.EnergyReal_WAC_Sum_Consumed')
-	    ikwh=0
-	    # Beim Energieexport ist nicht klar, wie hoch der Eigenverbrauch während der Produktion war.
-	    #ekwh=$(echo $response_fi | jq '.Body.Data.Site.E_Total')
-	    ekwh=0
-	fi
 elif [[ $froniusvar2 == "1" ]]; then
+	# Setze die für JSON Abruf benötigte DeviceID
+	json_id=".\"$froniuserzeugung\""
+	# Hole die JSON-Daten
 	response_sm=$(curl --connect-timeout 5 -s "$wrfroniusip/solar_api/v1/GetMeterRealtimeData.cgi?Scope=System")
-	    # Lese alle wichtigen Werte aus der JSON-Antwort und skaliere sie gleich.
-	    wattbezug=$(echo "scale=0; $(echo $response_sm | jq '.Body.Data."$froniuserzeugung".PowerReal_P_Sum')/1" | bc)
-	    evuv1=$(echo "scale=2; $(echo $response_sm | jq '.Body.Data."$froniuserzeugung".Voltage_AC_Phase_1')/1" | bc)
-	    evuv2=$(echo "scale=2; $(echo $response_sm | jq '.Body.Data."$froniuserzeugung".Voltage_AC_Phase_2')/1" | bc)
-	    evuv3=$(echo "scale=2; $(echo $response_sm | jq '.Body.Data."$froniuserzeugung".Voltage_AC_Phase_3')/1" | bc)
-	    bezugw1=$(echo "scale=2; $(echo $response_sm | jq '.Body.Data."$froniuserzeugung".PowerReal_P_Phase_1')/1" | bc)
-	    bezugw2=$(echo "scale=2; $(echo $response_sm | jq '.Body.Data."$froniuserzeugung".PowerReal_P_Phase_2')/1" | bc)
-	    bezugw3=$(echo "scale=2; $(echo $response_sm | jq '.Body.Data."$froniuserzeugung".PowerReal_P_Phase_3')/1" | bc)
-	    # Berechne den Strom und lese ihn nicht direkt (der eigentlich zu lesende direkte Wert
-	    # "Current_AC_Phase_1" wäre der Absolutwert und man würde das Vorzeichen verlieren).
-	    bezuga1=$(echo "scale=2; $bezugw1 / $evuv1" | bc)
-	    bezuga2=$(echo "scale=2; $bezugw2 / $evuv2" | bc)
-	    bezuga3=$(echo "scale=2; $bezugw3 / $evuv3" | bc)
-	    evuhz=$(echo "scale=2; $(echo $response_sm | jq '.Body.Data."$froniuserzeugung".Frequency_Phase_Average')/1" | bc)
-	    evupf1=$(echo "scale=2; $(echo $response_sm | jq '.Body.Data."$froniuserzeugung".PowerFactor_Phase_1')/1" | bc)
-	    evupf2=$(echo "scale=2; $(echo $response_sm | jq '.Body.Data."$froniuserzeugung".PowerFactor_Phase_2')/1" | bc)
-	    evupf3=$(echo "scale=2; $(echo $response_sm | jq '.Body.Data."$froniuserzeugung".PowerFactor_Phase_3')/1" | bc)
-	    ikwh=$(echo $response_sm | jq '.Body.Data."$froniuserzeugung".EnergyReal_WAC_Sum_Consumed')
-	    ekwh=$(echo $response_sm | jq '.Body.Data."$froniuserzeugung".EnergyReal_WAC_Sum_Produced')
-	# ... ansonsten, wenn das SmartMeter im Verbrauchszweig sitzt, kombiniere dessen Werte mit denen des Wechselrichters.
+	# selbe response_sm wie in Variante0 mit folgendem Aufruf:
+	# response_sm=$(curl --connect-timeout 5 -s "$wrfroniusip/solar_api/v1/GetMeterRealtimeData.cgi?Scope=Device&DeviceID=$froniuserzeugung&DataCollection=MeterRealtimeData")
+	# dann auch json_id wieder gleich:
+	# json_id=""
+
 elif [[ $froniusvar2 == "2" ]]; then
+	# Setze die für JSON Abruf benötigte DeviceID
+	json_id=".\"$froniuserzeugung\""
+	# Hole die JSON-Daten
 	response_sm=$(curl --connect-timeout 5 -s "$wrfroniusip/solar_api/v1/GetMeterRealtimeData.cgi?Scope=System")
+	
+	# TODO: meter_location für diese Variante korrekt ermitteln
+	# Überprüfe den Einbauort des SmartMeters.
+	meter_location=$(echo $response_sm | jq '.Body.Data'$json_id'.Meter_Location_Current')
+	
 	# Lese alle wichtigen Werte aus der JSON-Antwort und skaliere sie gleich.
-	wattbezug=$(echo "scale=0; $(echo $response_sm | jq '.Body.Data."0".SMARTMETER_POWERACTIVE_MEAN_SUM_F64')/1" | bc)
-	evuv1=$(echo "scale=2; $(echo $response_sm | jq '.Body.Data."0".SMARTMETER_VOLTAGE_01_F64')/1" | bc)
-	evuv2=$(echo "scale=2; $(echo $response_sm | jq '.Body.Data."0".SMARTMETER_VOLTAGE_02_F64')/1" | bc)
-	evuv3=$(echo "scale=2; $(echo $response_sm | jq '.Body.Data."0".SMARTMETER_VOLTAGE_03_F64')/1" | bc)
-	bezugw1=$(echo "scale=2; $(echo $response_sm | jq '.Body.Data."0".SMARTMETER_POWERACTIVE_MEAN_01_F64')/1" | bc)
-	bezugw2=$(echo "scale=2; $(echo $response_sm | jq '.Body.Data."0".SMARTMETER_POWERACTIVE_MEAN_02_F64')/1" | bc)
-	bezugw3=$(echo "scale=2; $(echo $response_sm | jq '.Body.Data."0".SMARTMETER_POWERACTIVE_MEAN_03_F64')/1" | bc)
+	wattbezug=$(echo "scale=0; $(echo $response_sm | jq '.Body.Data'$json_id'.SMARTMETER_POWERACTIVE_MEAN_SUM_F64')/1" | bc)
+	evuv1=$(echo "scale=2; $(echo $response_sm | jq '.Body.Data'$json_id'.SMARTMETER_VOLTAGE_01_F64')/1" | bc)
+	evuv2=$(echo "scale=2; $(echo $response_sm | jq '.Body.Data'$json_id'.SMARTMETER_VOLTAGE_02_F64')/1" | bc)
+	evuv3=$(echo "scale=2; $(echo $response_sm | jq '.Body.Data'$json_id'.SMARTMETER_VOLTAGE_03_F64')/1" | bc)
+	bezugw1=$(echo "scale=2; $(echo $response_sm | jq '.Body.Data'$json_id'.SMARTMETER_POWERACTIVE_MEAN_01_F64')/1" | bc)
+	bezugw2=$(echo "scale=2; $(echo $response_sm | jq '.Body.Data'$json_id'.SMARTMETER_POWERACTIVE_MEAN_02_F64')/1" | bc)
+	bezugw3=$(echo "scale=2; $(echo $response_sm | jq '.Body.Data'$json_id'.SMARTMETER_POWERACTIVE_MEAN_03_F64')/1" | bc)
 	# Berechne den Strom und lese ihn nicht direkt (der eigentlich zu lesende direkte Wert
 	# "Current_AC_Phase_1" wäre der Absolutwert und man würde das Vorzeichen verlieren).
 	bezuga1=$(echo "scale=2; $bezugw1 / $evuv1" | bc)
 	bezuga2=$(echo "scale=2; $bezugw2 / $evuv2" | bc)
 	bezuga3=$(echo "scale=2; $bezugw3 / $evuv3" | bc)
-	evuhz=$(echo "scale=2; $(echo $response_sm | jq '.Body.Data."1".Frequency_Phase_Average')/1" | bc)
-	evupf1=$(echo "scale=2; $(echo $response_sm | jq '.Body.Data."0".SMARTMETER_FACTOR_POWER_01_F64')/1" | bc)
-	evupf2=$(echo "scale=2; $(echo $response_sm | jq '.Body.Data."0".SMARTMETER_FACTOR_POWER_02_F64')/1" | bc)
-	evupf3=$(echo "scale=2; $(echo $response_sm | jq '.Body.Data."0".SMARTMETER_FACTOR_POWER_03_F64')/1" | bc)
-	ikwh=$(echo $response_sm | jq '.Body.Data."0".SMARTMETER_ENERGYACTIVE_CONSUMED_SUM_F64')
-	ekwh=$(echo $response_sm | jq '.Body.Data."0".SMARTMETER_ENERGYACTIVE_PRODUCED_SUM_F64')
+	# TODO: ist dieser Parameter für diese Variante korrekt? sieht aus wie Copy-Paste
+	evuhz=$(echo "scale=2; $(echo $response_sm | jq '.Body.Data'$json_id'.Frequency_Phase_Average')/1" | bc)
+	evupf1=$(echo "scale=2; $(echo $response_sm | jq '.Body.Data'$json_id'.SMARTMETER_FACTOR_POWER_01_F64')/1" | bc)
+	evupf2=$(echo "scale=2; $(echo $response_sm | jq '.Body.Data'$json_id'.SMARTMETER_FACTOR_POWER_02_F64')/1" | bc)
+	evupf3=$(echo "scale=2; $(echo $response_sm | jq '.Body.Data'$json_id'.SMARTMETER_FACTOR_POWER_03_F64')/1" | bc)
+	ikwh=$(echo $response_sm | jq '.Body.Data'$json_id'.SMARTMETER_ENERGYACTIVE_CONSUMED_SUM_F64')
+	ekwh=$(echo $response_sm | jq '.Body.Data'$json_id'.SMARTMETER_ENERGYACTIVE_PRODUCED_SUM_F64')
 
 fi
+
+# Auswertung für Variante0 und Variante1 gebündelt
+if [[ $froniusvar2 != "2" ]]; then
+	# Überprüfe den Einbauort des SmartMeters.
+	meter_location=$(echo $response_sm | jq '.Body.Data'$json_id'.Meter_Location_Current')
+	
+	# Lese alle wichtigen Werte aus der JSON-Antwort und skaliere sie gleich.
+	wattbezug=$(echo "scale=0; $(echo $response_sm | jq '.Body.Data'$json_id'.PowerReal_P_Sum')/1" | bc)
+	evuv1=$(echo "scale=2; $(echo $response_sm | jq '.Body.Data'$json_id'.Voltage_AC_Phase_1')/1" | bc)
+	evuv2=$(echo "scale=2; $(echo $response_sm | jq '.Body.Data'$json_id'.Voltage_AC_Phase_2')/1" | bc)
+	evuv3=$(echo "scale=2; $(echo $response_sm | jq '.Body.Data'$json_id'.Voltage_AC_Phase_3')/1" | bc)
+	bezugw1=$(echo "scale=2; $(echo $response_sm | jq '.Body.Data'$json_id'.PowerReal_P_Phase_1')/1" | bc)
+	bezugw2=$(echo "scale=2; $(echo $response_sm | jq '.Body.Data'$json_id'.PowerReal_P_Phase_2')/1" | bc)
+	bezugw3=$(echo "scale=2; $(echo $response_sm | jq '.Body.Data'$json_id'.PowerReal_P_Phase_3')/1" | bc)
+	# Berechne den Strom und lese ihn nicht direkt (der eigentlich zu lesende direkte Wert
+	# "Current_AC_Phase_1" wäre der Absolutwert und man würde das Vorzeichen verlieren).
+	bezuga1=$(echo "scale=2; $bezugw1 / $evuv1" | bc)
+	bezuga2=$(echo "scale=2; $bezugw2 / $evuv2" | bc)
+	bezuga3=$(echo "scale=2; $bezugw3 / $evuv3" | bc)
+	evuhz=$(echo "scale=2; $(echo $response_sm | jq '.Body.Data'$json_id'.Frequency_Phase_Average')/1" | bc)
+	evupf1=$(echo "scale=2; $(echo $response_sm | jq '.Body.Data'$json_id'.PowerFactor_Phase_1')/1" | bc)
+	evupf2=$(echo "scale=2; $(echo $response_sm | jq '.Body.Data'$json_id'.PowerFactor_Phase_2')/1" | bc)
+	evupf3=$(echo "scale=2; $(echo $response_sm | jq '.Body.Data'$json_id'.PowerFactor_Phase_3')/1" | bc)
+	ikwh=$(echo $response_sm | jq '.Body.Data'$json_id'.EnergyReal_WAC_Sum_Consumed')
+	ekwh=$(echo $response_sm | jq '.Body.Data'$json_id'.EnergyReal_WAC_Sum_Produced')
+
+fi
+
+if [[ $meter_location == "1" ]]; then
+	# wenn SmartMeter im Verbrauchszweig sitzt sind folgende Annahmen getroffen:
+	# PV Leistung wird gleichmäßig auf alle Phasen verteilt
+	# Spannungen und Leistungsfaktoren sind am Verbrauchszweig == Einspeisepunkt
+
+	# Lese die aktuelle PV-Leistung des Wechselrichters ein.
+	response_fi=$(curl --connect-timeout 3 -s "$wrfroniusip/solar_api/v1/GetPowerFlowRealtimeData.fcgi?Scope=System")
+	pvwatt=$(echo $response_fi | jq '.Body.Data.Site.P_PV' | sed 's/\..*$//')
+	# Wenn WR aus bzw. im Standby (keine Antwort), ersetze leeren Wert durch eine 0.
+	re='^-?[0-9]+$'
+	if ! [[ $pvwatt =~ $re ]] ; then
+		pvwatt="0"
+	fi
+	# Hier gehen wir mal davon aus, dass der Wechselrichter seine PV-Leistung gleichmäßig auf alle Phasen aufteilt.
+	bezugw1=$(echo "scale=2; (-1 * $(echo $bezugw1) - $pvwatt/3)/1" | bc)
+	bezugw2=$(echo "scale=2; (-1 * $(echo $bezugw2) - $pvwatt/3)/1" | bc)
+	bezugw3=$(echo "scale=2; (-1 * $(echo $bezugw3) - $pvwatt/3)/1" | bc)
+	# Beim Energiebezug ist nicht klar, welcher Anteil aus dem Netz bezogen wurde, und was aus dem Wechselrichter kam.
+	#ikwh=$(echo $response_sm | jq '.Body.Data.EnergyReal_WAC_Sum_Consumed')
+	ikwh=0
+	# Beim Energieexport ist nicht klar, wie hoch der Eigenverbrauch während der Produktion war.
+	#ekwh=$(echo $response_fi | jq '.Body.Data.Site.E_Total')
+	ekwh=0
+fi
+	
+
+
 # Gib den wichtigsten Wert direkt zurück (auch sinnvoll beim Debuggen).
 echo $wattbezug
 

--- a/modules/bezug_fronius_sm/main.sh
+++ b/modules/bezug_fronius_sm/main.sh
@@ -8,77 +8,77 @@
 # Fordere die Werte vom SmartMeter an.
 if [[ $froniusvar2 == "0" ]]; then
 	# Setze die für JSON Abruf benötigte DeviceID
-	json_id=""
+	json_id=".Body.Data"
 	# Hole die JSON Daten
 	response_sm=$(curl --connect-timeout 5 -s "$wrfroniusip/solar_api/v1/GetMeterRealtimeData.cgi?Scope=Device&DeviceID=$froniuserzeugung")
 
 elif [[ $froniusvar2 == "1" ]]; then
 	# Setze die für JSON Abruf benötigte DeviceID
-	json_id=".\"$froniuserzeugung\""
+	json_id=".Body.Data.\"$froniuserzeugung\""
 	# Hole die JSON-Daten
 	response_sm=$(curl --connect-timeout 5 -s "$wrfroniusip/solar_api/v1/GetMeterRealtimeData.cgi?Scope=System")
 	# TODO: Evtl. ist es noch weiter zu vereinfachen -> selbe response_sm wie in Variante0 mit folgendem Aufruf:
 	# response_sm=$(curl --connect-timeout 5 -s "$wrfroniusip/solar_api/v1/GetMeterRealtimeData.cgi?Scope=Device&DeviceID=$froniuserzeugung&DataCollection=MeterRealtimeData")
 	# dann auch json_id wieder gleich:
-	# json_id=""
+	# json_id=".Body.Data"
 
 elif [[ $froniusvar2 == "2" ]]; then
 	# Setze die für JSON Abruf benötigte DeviceID
-	json_id=".\"$froniuserzeugung\""
+	json_id=".Body.Data.\"$froniuserzeugung\""
 	# Hole die JSON-Daten
 	response_sm=$(curl --connect-timeout 5 -s "$wrfroniusip/solar_api/v1/GetMeterRealtimeData.cgi?Scope=System")
 	
 	# TODO: meter_location für diese Variante korrekt ermitteln
 	# Überprüfe den Einbauort des SmartMeters.
-	meter_location=$(echo $response_sm | jq '.Body.Data'$json_id'.Meter_Location_Current')
+	meter_location=$(echo $response_sm | jq $json_id'.Meter_Location_Current')
 	
 	# Lese alle wichtigen Werte aus der JSON-Antwort und skaliere sie gleich.
-	wattbezug=$(echo "scale=0; $(echo $response_sm | jq '.Body.Data'$json_id'.SMARTMETER_POWERACTIVE_MEAN_SUM_F64')/1" | bc)
-	evuv1=$(echo "scale=2; $(echo $response_sm | jq '.Body.Data'$json_id'.SMARTMETER_VOLTAGE_01_F64')/1" | bc)
-	evuv2=$(echo "scale=2; $(echo $response_sm | jq '.Body.Data'$json_id'.SMARTMETER_VOLTAGE_02_F64')/1" | bc)
-	evuv3=$(echo "scale=2; $(echo $response_sm | jq '.Body.Data'$json_id'.SMARTMETER_VOLTAGE_03_F64')/1" | bc)
-	bezugw1=$(echo "scale=2; $(echo $response_sm | jq '.Body.Data'$json_id'.SMARTMETER_POWERACTIVE_MEAN_01_F64')/1" | bc)
-	bezugw2=$(echo "scale=2; $(echo $response_sm | jq '.Body.Data'$json_id'.SMARTMETER_POWERACTIVE_MEAN_02_F64')/1" | bc)
-	bezugw3=$(echo "scale=2; $(echo $response_sm | jq '.Body.Data'$json_id'.SMARTMETER_POWERACTIVE_MEAN_03_F64')/1" | bc)
+	wattbezug=$(echo "scale=0; $(echo $response_sm | jq $json_id'.SMARTMETER_POWERACTIVE_MEAN_SUM_F64')/1" | bc)
+	evuv1=$(echo "scale=2; $(echo $response_sm | jq $json_id'.SMARTMETER_VOLTAGE_01_F64')/1" | bc)
+	evuv2=$(echo "scale=2; $(echo $response_sm | jq $json_id'.SMARTMETER_VOLTAGE_02_F64')/1" | bc)
+	evuv3=$(echo "scale=2; $(echo $response_sm | jq $json_id'.SMARTMETER_VOLTAGE_03_F64')/1" | bc)
+	bezugw1=$(echo "scale=2; $(echo $response_sm | jq $json_id'.SMARTMETER_POWERACTIVE_MEAN_01_F64')/1" | bc)
+	bezugw2=$(echo "scale=2; $(echo $response_sm | jq $json_id'.SMARTMETER_POWERACTIVE_MEAN_02_F64')/1" | bc)
+	bezugw3=$(echo "scale=2; $(echo $response_sm | jq $json_id'.SMARTMETER_POWERACTIVE_MEAN_03_F64')/1" | bc)
 	# Berechne den Strom und lese ihn nicht direkt (der eigentlich zu lesende direkte Wert
 	# "Current_AC_Phase_1" wäre der Absolutwert und man würde das Vorzeichen verlieren).
 	bezuga1=$(echo "scale=2; $bezugw1 / $evuv1" | bc)
 	bezuga2=$(echo "scale=2; $bezugw2 / $evuv2" | bc)
 	bezuga3=$(echo "scale=2; $bezugw3 / $evuv3" | bc)
 	# TODO: ist dieser Parameter für diese Variante korrekt? sieht aus wie Copy-Paste
-	evuhz=$(echo "scale=2; $(echo $response_sm | jq '.Body.Data'$json_id'.Frequency_Phase_Average')/1" | bc)
-	evupf1=$(echo "scale=2; $(echo $response_sm | jq '.Body.Data'$json_id'.SMARTMETER_FACTOR_POWER_01_F64')/1" | bc)
-	evupf2=$(echo "scale=2; $(echo $response_sm | jq '.Body.Data'$json_id'.SMARTMETER_FACTOR_POWER_02_F64')/1" | bc)
-	evupf3=$(echo "scale=2; $(echo $response_sm | jq '.Body.Data'$json_id'.SMARTMETER_FACTOR_POWER_03_F64')/1" | bc)
-	ikwh=$(echo $response_sm | jq '.Body.Data'$json_id'.SMARTMETER_ENERGYACTIVE_CONSUMED_SUM_F64')
-	ekwh=$(echo $response_sm | jq '.Body.Data'$json_id'.SMARTMETER_ENERGYACTIVE_PRODUCED_SUM_F64')
+	evuhz=$(echo "scale=2; $(echo $response_sm | jq $json_id'.Frequency_Phase_Average')/1" | bc)
+	evupf1=$(echo "scale=2; $(echo $response_sm | jq $json_id'.SMARTMETER_FACTOR_POWER_01_F64')/1" | bc)
+	evupf2=$(echo "scale=2; $(echo $response_sm | jq $json_id'.SMARTMETER_FACTOR_POWER_02_F64')/1" | bc)
+	evupf3=$(echo "scale=2; $(echo $response_sm | jq $json_id'.SMARTMETER_FACTOR_POWER_03_F64')/1" | bc)
+	ikwh=$(echo $response_sm | jq $json_id'.SMARTMETER_ENERGYACTIVE_CONSUMED_SUM_F64')
+	ekwh=$(echo $response_sm | jq $json_id'.SMARTMETER_ENERGYACTIVE_PRODUCED_SUM_F64')
 
 fi
 
 # Auswertung für Variante0 und Variante1 gebündelt
 if [[ $froniusvar2 != "2" ]]; then
 	# Überprüfe den Einbauort des SmartMeters.
-	meter_location=$(echo $response_sm | jq '.Body.Data'$json_id'.Meter_Location_Current')
+	meter_location=$(echo $response_sm | jq $json_id'.Meter_Location_Current')
 	
 	# Lese alle wichtigen Werte aus der JSON-Antwort und skaliere sie gleich.
-	wattbezug=$(echo "scale=0; $(echo $response_sm | jq '.Body.Data'$json_id'.PowerReal_P_Sum')/1" | bc)
-	evuv1=$(echo "scale=2; $(echo $response_sm | jq '.Body.Data'$json_id'.Voltage_AC_Phase_1')/1" | bc)
-	evuv2=$(echo "scale=2; $(echo $response_sm | jq '.Body.Data'$json_id'.Voltage_AC_Phase_2')/1" | bc)
-	evuv3=$(echo "scale=2; $(echo $response_sm | jq '.Body.Data'$json_id'.Voltage_AC_Phase_3')/1" | bc)
-	bezugw1=$(echo "scale=2; $(echo $response_sm | jq '.Body.Data'$json_id'.PowerReal_P_Phase_1')/1" | bc)
-	bezugw2=$(echo "scale=2; $(echo $response_sm | jq '.Body.Data'$json_id'.PowerReal_P_Phase_2')/1" | bc)
-	bezugw3=$(echo "scale=2; $(echo $response_sm | jq '.Body.Data'$json_id'.PowerReal_P_Phase_3')/1" | bc)
+	wattbezug=$(echo "scale=0; $(echo $response_sm | jq $json_id'.PowerReal_P_Sum')/1" | bc)
+	evuv1=$(echo "scale=2; $(echo $response_sm | jq $json_id'.Voltage_AC_Phase_1')/1" | bc)
+	evuv2=$(echo "scale=2; $(echo $response_sm | jq $json_id'.Voltage_AC_Phase_2')/1" | bc)
+	evuv3=$(echo "scale=2; $(echo $response_sm | jq $json_id'.Voltage_AC_Phase_3')/1" | bc)
+	bezugw1=$(echo "scale=2; $(echo $response_sm | jq $json_id'.PowerReal_P_Phase_1')/1" | bc)
+	bezugw2=$(echo "scale=2; $(echo $response_sm | jq $json_id'.PowerReal_P_Phase_2')/1" | bc)
+	bezugw3=$(echo "scale=2; $(echo $response_sm | jq $json_id'.PowerReal_P_Phase_3')/1" | bc)
 	# Berechne den Strom und lese ihn nicht direkt (der eigentlich zu lesende direkte Wert
 	# "Current_AC_Phase_1" wäre der Absolutwert und man würde das Vorzeichen verlieren).
 	bezuga1=$(echo "scale=2; $bezugw1 / $evuv1" | bc)
 	bezuga2=$(echo "scale=2; $bezugw2 / $evuv2" | bc)
 	bezuga3=$(echo "scale=2; $bezugw3 / $evuv3" | bc)
-	evuhz=$(echo "scale=2; $(echo $response_sm | jq '.Body.Data'$json_id'.Frequency_Phase_Average')/1" | bc)
-	evupf1=$(echo "scale=2; $(echo $response_sm | jq '.Body.Data'$json_id'.PowerFactor_Phase_1')/1" | bc)
-	evupf2=$(echo "scale=2; $(echo $response_sm | jq '.Body.Data'$json_id'.PowerFactor_Phase_2')/1" | bc)
-	evupf3=$(echo "scale=2; $(echo $response_sm | jq '.Body.Data'$json_id'.PowerFactor_Phase_3')/1" | bc)
-	ikwh=$(echo $response_sm | jq '.Body.Data'$json_id'.EnergyReal_WAC_Sum_Consumed')
-	ekwh=$(echo $response_sm | jq '.Body.Data'$json_id'.EnergyReal_WAC_Sum_Produced')
+	evuhz=$(echo "scale=2; $(echo $response_sm | jq $json_id'.Frequency_Phase_Average')/1" | bc)
+	evupf1=$(echo "scale=2; $(echo $response_sm | jq $json_id'.PowerFactor_Phase_1')/1" | bc)
+	evupf2=$(echo "scale=2; $(echo $response_sm | jq $json_id'.PowerFactor_Phase_2')/1" | bc)
+	evupf3=$(echo "scale=2; $(echo $response_sm | jq $json_id'.PowerFactor_Phase_3')/1" | bc)
+	ikwh=$(echo $response_sm | jq $json_id'.EnergyReal_WAC_Sum_Consumed')
+	ekwh=$(echo $response_sm | jq $json_id'.EnergyReal_WAC_Sum_Produced')
 
 fi
 


### PR DESCRIPTION
Die Variable $froniuserzeugung wurde innerhalb des jq Aufrufs nicht als Variable interpretiert.

Diese Version ist live getestet mit froniuserzeugung=0 und froniusvar2=1