### PR TITLE
SoC Peugeot: kombiniere manuell+berechnung und PSA modul, ersetzt #899

### DIFF
--- a/modules/soc_mypeugeot/main.sh
+++ b/modules/soc_mypeugeot/main.sh
@@ -3,12 +3,25 @@
 OPENWBBASEDIR=$(cd `dirname $0`/../../ && pwd)
 RAMDISKDIR="$OPENWBBASEDIR/ramdisk"
 MODULEDIR=$(cd `dirname $0` && pwd)
+LOGFILE="$RAMDISKDIR/soc.log"
 CHARGEPOINT=$1
+
+socDebug=$debug
+# for developement only
+socDebug=1
 
 case $CHARGEPOINT in
 	2)
 		# second charge point
+		manualSocFile="$RAMDISKDIR/manual_soc_lp2"
+		manualMeterFile="$RAMDISKDIR/manual_soc_meter_lp2"
+		socFile="$RAMDISKDIR/soc1"
 		soctimerfile="$RAMDISKDIR/soctimer1"
+		socIntervall=1 # update every minute if script is called every 10 seconds
+		meterFile="$RAMDISKDIR/llkwhs1"
+		ladungaktivFile="$RAMDISKDIR/ladungaktivlp2"
+		akkug=$akkuglp2
+		efficiency=$wirkungsgradlp2
 		username=$mypeugeot_userlp2
 		password=$mypeugeot_passlp2
 		clientId=$mypeugeot_clientidlp2
@@ -18,7 +31,15 @@ case $CHARGEPOINT in
 		# defaults to first charge point for backward compatibility
 		# set CHARGEPOINT in case it is empty (needed for logging)
 		CHARGEPOINT=1
+		manualSocFile="$RAMDISKDIR/manual_soc_lp1"
+		manualMeterFile="$RAMDISKDIR/manual_soc_meter_lp1"
+		socFile="$RAMDISKDIR/soc"
 		soctimerfile="$RAMDISKDIR/soctimer"
+		socIntervall=1 # update every minute if script is called every 10 seconds
+		meterFile="$RAMDISKDIR/llkwh"
+		ladungaktivFile="$RAMDISKDIR/ladungaktivlp1"
+		akkug=$akkuglp1
+		efficiency=$wirkungsgradlp1
 		username=$mypeugeot_userlp1
 		password=$mypeugeot_passlp1
 		clientId=$mypeugeot_clientidlp1
@@ -26,11 +47,108 @@ case $CHARGEPOINT in
 		;;
 esac
 
-timer=$(<$soctimerfile)
-if (( timer < 60 )); then
-	timer=$((timer+1))
-	echo $timer > $soctimerfile
-else
+socDebugLog(){
+	if (( socDebug > 0 )); then
+		timestamp=`date --rfc-3339=seconds`
+		echo "$timestamp: Lp$CHARGEPOINT: $@" >> $LOGFILE
+	fi
+}
+
+incrementTimer(){
+	soctimer=$((soctimer+1))
+	echo $soctimer > $soctimerfile
+}
+
+soctimer=$(<$soctimerfile)
+
+# if charging started this round fetch once from myPeugeot out of order
+if [[ $(<$ladungaktivFile) == 1 ]] && [ "$ladungaktivFile" -nt "$manualSocFile" ]; then
+	socDebugLog "Ladestatus changed to laedt. Fetching SoC from myPeugeot out of order."
+	soctimer=0
 	echo 0 > $soctimerfile
 	sudo python $MODULEDIR/peugeotsoc.py $CHARGEPOINT $username $password $clientId $clientSecret
+	echo $(<$socFile) > $manualSocFile
+	socDebugLog "Fetched from myPeugeot: $(<$socFile)%"
+fi
+
+chargestat=$(</var/www/html/openWB/ramdisk/chargestat)
+
+# if charging ist not active fetch SoC from myPeugeot
+if [[ $chargestat == "0" ]] ; then
+	if (( soctimer < 60 )); then
+		socDebugLog "Nothing to do yet. Incrementing timer. Extralong myPeugeot wait: $soctimer"
+		incrementTimer
+	else
+		socDebugLog "Fetching SoC from myPeugeot"
+		echo 0 > $soctimerfile
+		sudo python $MODULEDIR/peugeotsoc.py $CHARGEPOINT $username $password $clientId $clientSecret
+		echo $(<$socFile) > $manualSocFile
+		socDebugLog "Fetched from myPeugeot: $(<$socFile)%"
+	fi
+# if charging ist active calculate SoC manually
+else
+	if (( soctimer < socIntervall )); then
+		socDebugLog "Nothing to do yet. Incrementing timer."
+		incrementTimer
+	else
+		socDebugLog "Calculating manual SoC"
+		# reset timer
+		echo 0 > $soctimerfile
+
+		# read current meter
+		if [[ -f "$meterFile" ]]; then
+			currentMeter=$(<$meterFile)
+			socDebugLog "currentMeter: $currentMeter"
+
+			# read manual Soc
+			if [[ -f "$manualSocFile" ]]; then
+				manualSoc=$(<$manualSocFile)
+			else
+				# set manualSoc to 0 as a starting point
+				manualSoc=0
+				echo $manualSoc > $manualSocFile
+			fi
+			socDebugLog "manual SoC: $manualSoc"
+
+			# read manualMeterFile if file exists and manualMeterFile is newer than manualSocFile
+			if [[ -f "$manualMeterFile" ]] && [ "$manualMeterFile" -nt "$manualSocFile" ]; then
+				manualMeter=$(<$manualMeterFile)
+			else
+				# manualMeterFile does not exist or is outdated
+				# update manualMeter with currentMeter
+				manualMeter=$currentMeter
+				echo $manualMeter > $manualMeterFile
+			fi
+			socDebugLog "manualMeter: $manualMeter"
+
+			# read current soc
+			if [[ -f "$socFile" ]]; then
+				currentSoc=$(<$socFile)
+			else
+				currentSoc=$manualSoc
+				echo $currentSoc > $socFile
+			fi
+			socDebugLog "currentSoc: $currentSoc"
+
+			# calculate newSoc
+			currentMeterDiff=$(echo "scale=5;$currentMeter - $manualMeter" | bc)
+			socDebugLog "currentMeterDiff: $currentMeterDiff"
+			currentEffectiveMeterDiff=$(echo "scale=5;$currentMeterDiff * $efficiency / 100" | bc)
+			socDebugLog "currentEffectiveMeterDiff: $currentEffectiveMeterDiff ($efficiency %)"
+			currentSocDiff=$(echo "100 / $akkug * $currentEffectiveMeterDiff" | bc | sed 's/\..*$//')
+			socDebugLog "currentSocDiff: $currentSocDiff"
+			newSoc=$(echo "$manualSoc + $currentSocDiff" | bc)
+			if (( newSoc > 100 )); then
+				newSoc=100
+			fi
+			if (( newSoc < 0 )); then
+				newSoc=0
+			fi
+			socDebugLog "newSoc: $newSoc"
+			echo $newSoc > $socFile
+		else
+			# no current meter value for calculation -> Exit
+			socDebugLog "ERROR: no meter value for calculation! ($meterFile)"
+		fi
+	fi
 fi

--- a/modules/soc_mypeugeot/main.sh
+++ b/modules/soc_mypeugeot/main.sh
@@ -8,7 +8,7 @@ CHARGEPOINT=$1
 
 socDebug=$debug
 # for developement only
-socDebug=1
+# socDebug=1
 
 case $CHARGEPOINT in
 	2)
@@ -26,6 +26,8 @@ case $CHARGEPOINT in
 		password=$mypeugeot_passlp2
 		clientId=$mypeugeot_clientidlp2
 		clientSecret=$mypeugeot_clientsecretlp2
+		soccalc=$mypeugeot_soccalclp2
+		chargestat=$(</var/www/html/openWB/ramdisk/chargestats1)
 		;;
 	*)
 		# defaults to first charge point for backward compatibility
@@ -44,6 +46,8 @@ case $CHARGEPOINT in
 		password=$mypeugeot_passlp1
 		clientId=$mypeugeot_clientidlp1
 		clientSecret=$mypeugeot_clientsecretlp1
+		soccalc=$mypeugeot_soccalclp1
+		chargestat=$(</var/www/html/openWB/ramdisk/chargestat)
 		;;
 esac
 
@@ -61,7 +65,7 @@ incrementTimer(){
 
 soctimer=$(<$soctimerfile)
 
-if (($mypeugeot_soccalclp1 == 0)); then #manual calculation not enabled, using existing logic
+if (($soccalc == 0)); then #manual calculation not enabled, using existing logic
 	timer=$(<$soctimerfile)
 	if (( timer < 60 )); then
 		timer=$((timer+1))
@@ -80,8 +84,6 @@ else	# manual calculation enabled, combining PSA module with manual calc method
 		echo $(<$socFile) > $manualSocFile
 		socDebugLog "Fetched from myPeugeot: $(<$socFile)%"
 	fi
-
-	chargestat=$(</var/www/html/openWB/ramdisk/chargestat)
 
 	# if charging ist not active fetch SoC from myPeugeot
 	if [[ $chargestat == "0" ]] ; then

--- a/modules/soc_mypeugeot/main.sh
+++ b/modules/soc_mypeugeot/main.sh
@@ -61,94 +61,105 @@ incrementTimer(){
 
 soctimer=$(<$soctimerfile)
 
-# if charging started this round fetch once from myPeugeot out of order
-if [[ $(<$ladungaktivFile) == 1 ]] && [ "$ladungaktivFile" -nt "$manualSocFile" ]; then
-	socDebugLog "Ladestatus changed to laedt. Fetching SoC from myPeugeot out of order."
-	soctimer=0
-	echo 0 > $soctimerfile
-	sudo python $MODULEDIR/peugeotsoc.py $CHARGEPOINT $username $password $clientId $clientSecret
-	echo $(<$socFile) > $manualSocFile
-	socDebugLog "Fetched from myPeugeot: $(<$socFile)%"
-fi
-
-chargestat=$(</var/www/html/openWB/ramdisk/chargestat)
-
-# if charging ist not active fetch SoC from myPeugeot
-if [[ $chargestat == "0" ]] ; then
-	if (( soctimer < 60 )); then
-		socDebugLog "Nothing to do yet. Incrementing timer. Extralong myPeugeot wait: $soctimer"
-		incrementTimer
+if (($mypeugeot_soccalclp1 == 0)); then #manual calculation not enabled, using existing logic
+	timer=$(<$soctimerfile)
+	if (( timer < 60 )); then
+		timer=$((timer+1))
+		echo $timer > $soctimerfile
 	else
-		socDebugLog "Fetching SoC from myPeugeot"
+		echo 0 > $soctimerfile
+		sudo python $MODULEDIR/peugeotsoc.py $CHARGEPOINT $username $password $clientId $clientSecret
+	fi
+else	# manual calculation enabled, combining PSA module with manual calc method
+	# if charging started this round fetch once from myPeugeot out of order
+	if [[ $(<$ladungaktivFile) == 1 ]] && [ "$ladungaktivFile" -nt "$manualSocFile" ]; then
+		socDebugLog "Ladestatus changed to laedt. Fetching SoC from myPeugeot out of order."
+		soctimer=0
 		echo 0 > $soctimerfile
 		sudo python $MODULEDIR/peugeotsoc.py $CHARGEPOINT $username $password $clientId $clientSecret
 		echo $(<$socFile) > $manualSocFile
 		socDebugLog "Fetched from myPeugeot: $(<$socFile)%"
 	fi
-# if charging ist active calculate SoC manually
-else
-	if (( soctimer < socIntervall )); then
-		socDebugLog "Nothing to do yet. Incrementing timer."
-		incrementTimer
-	else
-		socDebugLog "Calculating manual SoC"
-		# reset timer
-		echo 0 > $soctimerfile
 
-		# read current meter
-		if [[ -f "$meterFile" ]]; then
-			currentMeter=$(<$meterFile)
-			socDebugLog "currentMeter: $currentMeter"
+	chargestat=$(</var/www/html/openWB/ramdisk/chargestat)
 
-			# read manual Soc
-			if [[ -f "$manualSocFile" ]]; then
-				manualSoc=$(<$manualSocFile)
-			else
-				# set manualSoc to 0 as a starting point
-				manualSoc=0
-				echo $manualSoc > $manualSocFile
-			fi
-			socDebugLog "manual SoC: $manualSoc"
-
-			# read manualMeterFile if file exists and manualMeterFile is newer than manualSocFile
-			if [[ -f "$manualMeterFile" ]] && [ "$manualMeterFile" -nt "$manualSocFile" ]; then
-				manualMeter=$(<$manualMeterFile)
-			else
-				# manualMeterFile does not exist or is outdated
-				# update manualMeter with currentMeter
-				manualMeter=$currentMeter
-				echo $manualMeter > $manualMeterFile
-			fi
-			socDebugLog "manualMeter: $manualMeter"
-
-			# read current soc
-			if [[ -f "$socFile" ]]; then
-				currentSoc=$(<$socFile)
-			else
-				currentSoc=$manualSoc
-				echo $currentSoc > $socFile
-			fi
-			socDebugLog "currentSoc: $currentSoc"
-
-			# calculate newSoc
-			currentMeterDiff=$(echo "scale=5;$currentMeter - $manualMeter" | bc)
-			socDebugLog "currentMeterDiff: $currentMeterDiff"
-			currentEffectiveMeterDiff=$(echo "scale=5;$currentMeterDiff * $efficiency / 100" | bc)
-			socDebugLog "currentEffectiveMeterDiff: $currentEffectiveMeterDiff ($efficiency %)"
-			currentSocDiff=$(echo "100 / $akkug * $currentEffectiveMeterDiff" | bc | sed 's/\..*$//')
-			socDebugLog "currentSocDiff: $currentSocDiff"
-			newSoc=$(echo "$manualSoc + $currentSocDiff" | bc)
-			if (( newSoc > 100 )); then
-				newSoc=100
-			fi
-			if (( newSoc < 0 )); then
-				newSoc=0
-			fi
-			socDebugLog "newSoc: $newSoc"
-			echo $newSoc > $socFile
+	# if charging ist not active fetch SoC from myPeugeot
+	if [[ $chargestat == "0" ]] ; then
+		if (( soctimer < 60 )); then
+			socDebugLog "Nothing to do yet. Incrementing timer. Extralong myPeugeot wait: $soctimer"
+			incrementTimer
 		else
-			# no current meter value for calculation -> Exit
-			socDebugLog "ERROR: no meter value for calculation! ($meterFile)"
+			socDebugLog "Fetching SoC from myPeugeot"
+			echo 0 > $soctimerfile
+			sudo python $MODULEDIR/peugeotsoc.py $CHARGEPOINT $username $password $clientId $clientSecret
+			echo $(<$socFile) > $manualSocFile
+			socDebugLog "Fetched from myPeugeot: $(<$socFile)%"
+		fi
+	# if charging ist active calculate SoC manually
+	else
+		if (( soctimer < socIntervall )); then
+			socDebugLog "Nothing to do yet. Incrementing timer."
+			incrementTimer
+		else
+			socDebugLog "Calculating manual SoC"
+			# reset timer
+			echo 0 > $soctimerfile
+
+			# read current meter
+			if [[ -f "$meterFile" ]]; then
+				currentMeter=$(<$meterFile)
+				socDebugLog "currentMeter: $currentMeter"
+
+				# read manual Soc
+				if [[ -f "$manualSocFile" ]]; then
+					manualSoc=$(<$manualSocFile)
+				else
+					# set manualSoc to 0 as a starting point
+					manualSoc=0
+					echo $manualSoc > $manualSocFile
+				fi
+				socDebugLog "manual SoC: $manualSoc"
+
+				# read manualMeterFile if file exists and manualMeterFile is newer than manualSocFile
+				if [[ -f "$manualMeterFile" ]] && [ "$manualMeterFile" -nt "$manualSocFile" ]; then
+					manualMeter=$(<$manualMeterFile)
+				else
+					# manualMeterFile does not exist or is outdated
+					# update manualMeter with currentMeter
+					manualMeter=$currentMeter
+					echo $manualMeter > $manualMeterFile
+				fi
+				socDebugLog "manualMeter: $manualMeter"
+
+				# read current soc
+				if [[ -f "$socFile" ]]; then
+					currentSoc=$(<$socFile)
+				else
+					currentSoc=$manualSoc
+					echo $currentSoc > $socFile
+				fi
+				socDebugLog "currentSoc: $currentSoc"
+
+				# calculate newSoc
+				currentMeterDiff=$(echo "scale=5;$currentMeter - $manualMeter" | bc)
+				socDebugLog "currentMeterDiff: $currentMeterDiff"
+				currentEffectiveMeterDiff=$(echo "scale=5;$currentMeterDiff * $efficiency / 100" | bc)
+				socDebugLog "currentEffectiveMeterDiff: $currentEffectiveMeterDiff ($efficiency %)"
+				currentSocDiff=$(echo "100 / $akkug * $currentEffectiveMeterDiff" | bc | sed 's/\..*$//')
+				socDebugLog "currentSocDiff: $currentSocDiff"
+				newSoc=$(echo "$manualSoc + $currentSocDiff" | bc)
+				if (( newSoc > 100 )); then
+					newSoc=100
+				fi
+				if (( newSoc < 0 )); then
+					newSoc=0
+				fi
+				socDebugLog "newSoc: $newSoc"
+				echo $newSoc > $socFile
+			else
+				# no current meter value for calculation -> Exit
+				socDebugLog "ERROR: no meter value for calculation! ($meterFile)"
+			fi
 		fi
 	fi
 fi

--- a/runs/atreboot.sh
+++ b/runs/atreboot.sh
@@ -2807,6 +2807,16 @@ if ! grep -Fq "solaxip=" /var/www/html/openWB/openwb.conf
 then
 	echo "solaxip=192.168.1.1" >> /var/www/html/openWB/openwb.conf
 fi
+if ! grep -Fq "mypeugeot_soccalclp1=" /var/www/html/openWB/openwb.conf
+then
+	echo "mypeugeot_soccalclp1=0" >> /var/www/html/openWB/openwb.conf
+fi
+if ! grep -Fq "mypeugeot_soccalclp2=" /var/www/html/openWB/openwb.conf
+then
+	echo "mypeugeot_soccalclp2=0" >> /var/www/html/openWB/openwb.conf
+fi
+
+
 
 sudo kill $(ps aux |grep '[s]marthomehandler.py' | awk '{print $2}')
 if ps ax |grep -v grep |grep "python3 /var/www/html/openWB/runs/smarthomehandler.py" > /dev/null

--- a/web/settings/modulconfiglp.php
+++ b/web/settings/modulconfiglp.php
@@ -1222,6 +1222,49 @@
 											<input class="form-control" type="text" name="mypeugeot_clientsecretlp1" id="mypeugeot_clientsecretlp1" value="<?php echo $mypeugeot_clientsecretlp1old ?>">
 										</div>
 									</div>
+									<div class="form-row mb-1">
+									<label class="col-md-4 col-form-label">Kombiniere Peugeot SoC Modul und manuelle Berechnung</label>
+									<div class="col">
+										<div class="btn-group btn-group-toggle btn-block" data-toggle="buttons">
+											<label class="btn btn-outline-info<?php if($mypeugeot_soccalclp1old == 0) echo " active" ?>">
+												<input type="radio" name="mypeugeot_soccalclp1" id="mypeugeot_soccalclp1Off" value="0"<?php if($mypeugeot_soccalclp1old == 0) echo " checked=\"checked\"" ?>>Nein
+											</label>
+											<label class="btn btn-outline-info<?php if($mypeugeot_soccalclp1old == 1) echo " active" ?>">
+												<input type="radio" name="mypeugeot_soccalclp1" id="mypeugeot_soccalclp1On" value="1"<?php if($mypeugeot_soccalclp1old == 1) echo " checked=\"checked\"" ?>>Ja
+											</label>
+										</div>
+										<span class="form-text small">
+											Aktuell liefert die Peugeot API keine SoC Aktualisierung während des Ladevorgangs.<br>
+											Wenn Ja gewählt wird, wird der SoC vor dem Laden über die API abgerufen. Während des Ladens wird der SoC dann anhand des Zählerstands im Ladepunkt berechnet. Dies erlaubt eine SoC-gesteuerte Ladung.<br>
+											Bei Nein wird immer der SoC über die API abgefragt. SoC gesteuerte Ladung ist erst möglich nachdem PSA den SoC auch während des Ladens übermittelt.<br>
+										</span>
+										<div class="form-row mb-1">
+											<label for="akkuglp1" class="col-md-4 col-form-label">Akkugröße in kWh bei manueller Berechnung</label>
+											<div class="col">
+												<input class="form-control" type="number" min="1" step="1" name="akkuglp1" id="akkuglp1" value="<?php echo $akkuglp1old ?>">
+												<span class="form-text small">
+													Angabe der Netto-Kapazität der Fahrzeugbatterie in kWh. Dient zur Berechnung des manuellen SoC. Für Peugeot e208 und e2008: 46kWh<br>
+													Nur Notwendig falls SoC Modul und manuelle Berechnung kombinieren gewählt wurde.
+												</span>
+											</div>
+										</div>
+										<div class="form-row mb-1">
+											<label for="wirkungsgradlp1" class="col-md-4 col-form-label">Wirkungsgrad Ladeelektronik bei manueller Berechnung</label>
+											<div class="col">
+												<input class="form-control" type="number" min="1" step="1" max="100" name="wirkungsgradlp1" id="wirkungsgradlp1" value="<?php echo $wirkungsgradlp1old ?>">
+												<span class="form-text small">
+													Wert in Prozent, der den gemittelten Wirkungsgrad der Ladeelektronik angibt. Für Peugeot e208 und e2008: 93-94 Prozent<br>
+													Durch Verluste in der Ladeelektronik (z. B. Umwandlung Wechselspannung in Gleichspannung) gelangt nicht die komplette Energie, welche durch den Zähler in der Wallbox gemesen wird, im Akku des Fahrzeugs.
+													Der anzugebende Wert liegt bei gängigen Fahrzeugen im Bereich 90-95%. Eine Ausnahme stellt der Zoe dar, dessen Chameleonlader je nach Modellversion und freigegebener Leistung der Wallbox teilweise nur auf ca. 50% kommt.<br>
+													Liegen die Angaben der Wallbox und des Fahrzeugs nach der Ladung mehrere Prozent auseinander, dann kann mit dieser Einstellung eine Feinabstimmung erfolgen:<br>
+													SoC an der Wallbox zu hoch: Wirkungsgrad um ein paar Prozent reduzieren<br>
+													SoC an der Wallbox zu gering: Wirkungsgras um ein paar Prozent erhöhen
+													Nur Notwendig falls SoC Modul und manuelle Berechnung kombinieren gewählt wurde.
+												</span>
+											</div>
+										</div>
+									</div>
+								</div>
 								</div>
 							</div>
 							<div id="socmyopel" class="hide">

--- a/web/settings/modulconfiglp.php
+++ b/web/settings/modulconfiglp.php
@@ -1224,48 +1224,65 @@
 									</div>
 									<div class="form-row mb-1">
 									<label class="col-md-4 col-form-label">Kombiniere Peugeot SoC Modul und manuelle Berechnung</label>
-									<div class="col">
-										<div class="btn-group btn-group-toggle btn-block" data-toggle="buttons">
-											<label class="btn btn-outline-info<?php if($mypeugeot_soccalclp1old == 0) echo " active" ?>">
-												<input type="radio" name="mypeugeot_soccalclp1" id="mypeugeot_soccalclp1Off" value="0"<?php if($mypeugeot_soccalclp1old == 0) echo " checked=\"checked\"" ?>>Nein
-											</label>
-											<label class="btn btn-outline-info<?php if($mypeugeot_soccalclp1old == 1) echo " active" ?>">
-												<input type="radio" name="mypeugeot_soccalclp1" id="mypeugeot_soccalclp1On" value="1"<?php if($mypeugeot_soccalclp1old == 1) echo " checked=\"checked\"" ?>>Ja
-											</label>
-										</div>
-										<span class="form-text small">
-											Aktuell liefert die Peugeot API keine SoC Aktualisierung während des Ladevorgangs.<br>
-											Wenn Ja gewählt wird, wird der SoC vor dem Laden über die API abgerufen. Während des Ladens wird der SoC dann anhand des Zählerstands im Ladepunkt berechnet. Dies erlaubt eine SoC-gesteuerte Ladung.<br>
-											Bei Nein wird immer der SoC über die API abgefragt. SoC gesteuerte Ladung ist erst möglich nachdem PSA den SoC auch während des Ladens übermittelt.<br>
-										</span>
-										<div class="form-row mb-1">
-											<label for="akkuglp1" class="col-md-4 col-form-label">Akkugröße in kWh bei manueller Berechnung</label>
-											<div class="col">
-												<input class="form-control" type="number" min="1" step="1" name="akkuglp1" id="akkuglp1" value="<?php echo $akkuglp1old ?>">
-												<span class="form-text small">
-													Angabe der Netto-Kapazität der Fahrzeugbatterie in kWh. Dient zur Berechnung des manuellen SoC. Für Peugeot e208 und e2008: 46kWh<br>
-													Nur Notwendig falls SoC Modul und manuelle Berechnung kombinieren gewählt wurde.
-												</span>
+										<div class="col">
+											<div class="btn-group btn-group-toggle btn-block" data-toggle="buttons">
+												<label class="btn btn-outline-info<?php if($mypeugeot_soccalclp1old == 0) echo " active" ?>">
+													<input type="radio" name="mypeugeot_soccalclp1" id="mypeugeot_soccalclp1Off" value="0"<?php if($mypeugeot_soccalclp1old == 0) echo " checked=\"checked\"" ?>>Nein
+												</label>
+												<label class="btn btn-outline-info<?php if($mypeugeot_soccalclp1old == 1) echo " active" ?>">
+													<input type="radio" name="mypeugeot_soccalclp1" id="mypeugeot_soccalclp1On" value="1"<?php if($mypeugeot_soccalclp1old == 1) echo " checked=\"checked\"" ?>>Ja
+												</label>
 											</div>
+											<span class="form-text small">
+												Aktuell liefert die Peugeot API keine SoC Aktualisierung während des Ladevorgangs.<br>
+												Wenn Ja gewählt wird, wird der SoC vor dem Laden über die API abgerufen. Während des Ladens wird der SoC dann anhand des Zählerstands im Ladepunkt berechnet. Dies erlaubt eine SoC-gesteuerte Ladung.<br>
+												Bei Nein wird immer der SoC über die API abgefragt. SoC gesteuerte Ladung ist erst möglich nachdem PSA den SoC auch während des Ladens übermittelt.<br>
+											</span>
 										</div>
-										<div class="form-row mb-1">
-											<label for="wirkungsgradlp1" class="col-md-4 col-form-label">Wirkungsgrad Ladeelektronik bei manueller Berechnung</label>
-											<div class="col">
-												<input class="form-control" type="number" min="1" step="1" max="100" name="wirkungsgradlp1" id="wirkungsgradlp1" value="<?php echo $wirkungsgradlp1old ?>">
-												<span class="form-text small">
-													Wert in Prozent, der den gemittelten Wirkungsgrad der Ladeelektronik angibt. Für Peugeot e208 und e2008: 93-94 Prozent<br>
-													Durch Verluste in der Ladeelektronik (z. B. Umwandlung Wechselspannung in Gleichspannung) gelangt nicht die komplette Energie, welche durch den Zähler in der Wallbox gemesen wird, im Akku des Fahrzeugs.
-													Der anzugebende Wert liegt bei gängigen Fahrzeugen im Bereich 90-95%. Eine Ausnahme stellt der Zoe dar, dessen Chameleonlader je nach Modellversion und freigegebener Leistung der Wallbox teilweise nur auf ca. 50% kommt.<br>
-													Liegen die Angaben der Wallbox und des Fahrzeugs nach der Ladung mehrere Prozent auseinander, dann kann mit dieser Einstellung eine Feinabstimmung erfolgen:<br>
-													SoC an der Wallbox zu hoch: Wirkungsgrad um ein paar Prozent reduzieren<br>
-													SoC an der Wallbox zu gering: Wirkungsgras um ein paar Prozent erhöhen
-													Nur Notwendig falls SoC Modul und manuelle Berechnung kombinieren gewählt wurde.
-												</span>
+										<div id="peugeotmanualcalcdiv" class="hide">
+											<div class="form-row mb-1">
+												<label for="akkuglp1" class="col-md-4 col-form-label">Akkugröße in kWh bei manueller Berechnung</label>
+												<div class="col">
+													<input class="form-control" type="number" min="1" step="1" name="akkuglp1" id="akkuglp1" value="<?php echo $akkuglp1old ?>">
+													<span class="form-text small">
+														Angabe der Netto-Kapazität der Fahrzeugbatterie in kWh. Dient zur Berechnung des manuellen SoC.<br>Für Peugeot e208 und e2008: 46kWh<br>
+													</span>
+												</div>
+											</div>
+											<div class="form-row mb-1">
+												<label for="wirkungsgradlp1" class="col-md-4 col-form-label">Wirkungsgrad Ladeelektronik bei manueller Berechnung</label>
+												<div class="col">
+													<input class="form-control" type="number" min="1" step="1" max="100" name="wirkungsgradlp1" id="wirkungsgradlp1" value="<?php echo $wirkungsgradlp1old ?>">
+													<span class="form-text small">
+														Wert in Prozent, der den gemittelten Wirkungsgrad der Ladeelektronik angibt.<br>Für Peugeot e208 und e2008: 93-94 Prozent<br>
+														Durch Verluste in der Ladeelektronik (z. B. Umwandlung Wechselspannung in Gleichspannung) gelangt nicht die komplette Energie, welche durch den Zähler in der Wallbox gemesen wird, im Akku des Fahrzeugs.
+														Der anzugebende Wert liegt bei gängigen Fahrzeugen im Bereich 90-95%. Eine Ausnahme stellt der Zoe dar, dessen Chameleonlader je nach Modellversion und freigegebener Leistung der Wallbox teilweise nur auf ca. 50% kommt.<br>
+														Liegen die Angaben der Wallbox und des Fahrzeugs nach der Ladung mehrere Prozent auseinander, dann kann mit dieser Einstellung eine Feinabstimmung erfolgen:<br>
+														SoC an der Wallbox zu hoch: Wirkungsgrad um ein paar Prozent reduzieren<br>
+														SoC an der Wallbox zu gering: Wirkungsgras um ein paar Prozent erhöhen<br>
+													</span>
+												</div>
 											</div>
 										</div>
 									</div>
 								</div>
-								</div>
+								<script>
+								$(function() {
+									function visibility_mypeugeot_soccalclp1() {
+										if($('#mypeugeot_soccalclp1Off').prop("checked")) {
+											hideSection('#peugeotmanualcalcdiv');
+										} else {
+											showSection('#peugeotmanualcalcdiv');
+										}
+									}
+
+									$('input[type=radio][name=mypeugeot_soccalclp1]').change(function(){
+										visibility_mypeugeot_soccalclp1();
+									});
+
+									visibility_mypeugeot_soccalclp1();
+								});
+								</script>
 							</div>
 							<div id="socmyopel" class="hide">
 								<div class="form-group">

--- a/web/settings/modulconfiglp.php
+++ b/web/settings/modulconfiglp.php
@@ -2514,7 +2514,67 @@
 											<input class="form-control" type="text" name="mypeugeot_clientsecretlp2" id="mypeugeot_clientsecretlp2" value="<?php echo $mypeugeot_clientsecretlp2old ?>">
 										</div>
 									</div>
+									<div class="form-row mb-1">
+									<label class="col-md-4 col-form-label">Kombiniere Peugeot SoC Modul und manuelle Berechnung</label>
+										<div class="col">
+											<div class="btn-group btn-group-toggle btn-block" data-toggle="buttons">
+												<label class="btn btn-outline-info<?php if($mypeugeot_soccalclp2old == 0) echo " active" ?>">
+													<input type="radio" name="mypeugeot_soccalclp2" id="mypeugeot_soccalclp2Off" value="0"<?php if($mypeugeot_soccalclp2old == 0) echo " checked=\"checked\"" ?>>Nein
+												</label>
+												<label class="btn btn-outline-info<?php if($mypeugeot_soccalclp2old == 1) echo " active" ?>">
+													<input type="radio" name="mypeugeot_soccalclp2" id="mypeugeot_soccalclp2On" value="1"<?php if($mypeugeot_soccalclp2old == 1) echo " checked=\"checked\"" ?>>Ja
+												</label>
+											</div>
+											<span class="form-text small">
+												Aktuell liefert die Peugeot API keine SoC Aktualisierung während des Ladevorgangs.<br>
+												Wenn Ja gewählt wird, wird der SoC vor dem Laden über die API abgerufen. Während des Ladens wird der SoC dann anhand des Zählerstands im Ladepunkt berechnet. Dies erlaubt eine SoC-gesteuerte Ladung.<br>
+												Bei Nein wird immer der SoC über die API abgefragt. SoC gesteuerte Ladung ist erst möglich nachdem PSA den SoC auch während des Ladens übermittelt.<br>
+											</span>
+										</div>
+										<div id="peugeotmanualcalclp2div" class="hide">
+											<div class="form-row mb-1">
+												<label for="akkuglp2" class="col-md-4 col-form-label">Akkugröße in kWh bei manueller Berechnung</label>
+												<div class="col">
+													<input class="form-control" type="number" min="1" step="1" name="akkuglp2" id="akkuglp2" value="<?php echo $akkuglp2old ?>">
+													<span class="form-text small">
+														Angabe der Netto-Kapazität der Fahrzeugbatterie in kWh. Dient zur Berechnung des manuellen SoC.<br>Für Peugeot e208 und e2008: 46kWh<br>
+													</span>
+												</div>
+											</div>
+											<div class="form-row mb-1">
+												<label for="wirkungsgradlp2" class="col-md-4 col-form-label">Wirkungsgrad Ladeelektronik bei manueller Berechnung</label>
+												<div class="col">
+													<input class="form-control" type="number" min="1" step="1" max="100" name="wirkungsgradlp2" id="wirkungsgradlp2" value="<?php echo $wirkungsgradlp2old ?>">
+													<span class="form-text small">
+														Wert in Prozent, der den gemittelten Wirkungsgrad der Ladeelektronik angibt.<br>Für Peugeot e208 und e2008: 93-94 Prozent<br>
+														Durch Verluste in der Ladeelektronik (z. B. Umwandlung Wechselspannung in Gleichspannung) gelangt nicht die komplette Energie, welche durch den Zähler in der Wallbox gemesen wird, im Akku des Fahrzeugs.
+														Der anzugebende Wert liegt bei gängigen Fahrzeugen im Bereich 90-95%. Eine Ausnahme stellt der Zoe dar, dessen Chameleonlader je nach Modellversion und freigegebener Leistung der Wallbox teilweise nur auf ca. 50% kommt.<br>
+														Liegen die Angaben der Wallbox und des Fahrzeugs nach der Ladung mehrere Prozent auseinander, dann kann mit dieser Einstellung eine Feinabstimmung erfolgen:<br>
+														SoC an der Wallbox zu hoch: Wirkungsgrad um ein paar Prozent reduzieren<br>
+														SoC an der Wallbox zu gering: Wirkungsgras um ein paar Prozent erhöhen<br>
+													</span>
+												</div>
+											</div>
+										</div>
+									</div>
 								</div>
+								<script>
+								$(function() {
+									function visibility_mypeugeot_soccalclp2() {
+										if($('#mypeugeot_soccalclp2Off').prop("checked")) {
+											hideSection('#peugeotmanualcalclp2div');
+										} else {
+											showSection('#peugeotmanualcalclp2div');
+										}
+									}
+
+									$('input[type=radio][name=mypeugeot_soccalclp2]').change(function(){
+										visibility_mypeugeot_soccalclp2();
+									});
+
+									visibility_mypeugeot_soccalclp2();
+								});
+								</script>
 							</div>
 							<div id="socmyopellp2" class="hide">
 								<div class="form-group">


### PR DESCRIPTION
Ersetzt PR899

PSA liefert während des Ladens derzeit keine SoC Aktualisierung. In der Modulkonfiguration für Peugeot kann nun zusätzlich Manuell+Berechnung aktiviert werden.
Dies sorgt dafür dass der initiale SoC zu Ladebeginn über die API abgerufen wird, während des Ladevorgangs wird der SoC dann basierend auf dem Ladezähler berechnet.