### PR TITLE
Clear RCR message explicitely

### DIFF
--- a/regel.sh
+++ b/regel.sh
@@ -291,6 +291,7 @@ if (( rseenabled == 1 )); then
 		fi
 	else
 		if (( rseaktiv == 1 )); then
+			echo "Ladung wurde nach Pause durch aktivierten RSE Kontakt fortgesetzt" > ramdisk/lastregelungaktiv
 			echo "$date RSE Kontakt deaktiviert, setze auf alten Lademodus zurück" >> ramdisk/ladestatus.log
 			rselademodus=$(<ramdisk/rseoldlademodus)
 			echo $rselademodus > ramdisk/lademodus

--- a/web/tools/backup.php
+++ b/web/tools/backup.php
@@ -83,7 +83,7 @@
 
 			<h1>Backup erstellen</h1>
 			<div class="alert alert-success">
-				Backup-Datei <?php echo $filename; ?> erfoglreich erstellt.
+				Backup-Datei <?php echo $filename; ?> erfolgreich erstellt.
 			</div>
 
 			<div class="row">


### PR DESCRIPTION
The message "RSE Kontakt aktiv, pausiere Ladung" it not cleared after the ripple control receiver trigger ends, unless another module/script writes a different message to `ramdisk/lastregelungaktiv`. This results in incorrect messaging below the charging graph.

![image](https://user-images.githubusercontent.com/1886500/104849193-c5419a80-58e8-11eb-8e10-303e3c1a20f2.png)

This PR adds a new message to indicate that the interruption by RCR is indeed over. 