### PR TITLE
Update atreboot.sh as ladelog directory is missing

### DIFF
--- a/runs/atreboot.sh
+++ b/runs/atreboot.sh
@@ -608,6 +608,7 @@ done
 ln -s /var/log/openWB.log /var/www/html/openWB/ramdisk/openWB.log
 mkdir -p /var/www/html/openWB/web/logging/data/daily
 mkdir -p /var/www/html/openWB/web/logging/data/monthly
+mkdir -p /var/www/html/openWB/web/logging/data/ladelog
 sudo chmod -R 777 /var/www/html/openWB/web/logging/data/
 if ! grep -Fq "wr1extprod=" /var/www/html/openWB/openwb.conf
 then


### PR DESCRIPTION
I believe the following needs to be inserted as the ladelog is not working without this folder.