### PR TITLE
WLAN Konfig Enhancement

### DIFF
--- a/web/tools/wlan/wlan.php
+++ b/web/tools/wlan/wlan.php
@@ -49,7 +49,7 @@
 			$output = shell_exec($command); 
 			echo $output;
 		?>
-		<form action="tools/wlan/wlan1.php" method="post">
+		<form action="tools/wlan/wlan1.php" method="post" autocomplete="off">
 		<br><br>
 		<h5> Neuverbinden mit</h5>
 		<p> Wlan SSID: <input id="wssid" type="text" name="wssid" /></p>

--- a/web/tools/wlan/wlan1.php
+++ b/web/tools/wlan/wlan1.php
@@ -1,7 +1,7 @@
 <?php
 
-file_put_contents('/var/www/html/openWB/ramdisk/wlanwssid',$_POST[wssid]);
-file_put_contents('/var/www/html/openWB/ramdisk/wlanwpassword',$_POST[wpassword]);
+file_put_contents('/var/www/html/openWB/ramdisk/wlanwssid',trim($_POST[wssid]));
+file_put_contents('/var/www/html/openWB/ramdisk/wlanwpassword',trim($_POST[wpassword]));
 echo "Gespeichert, verbinde mit Wlan...";
 exec('sudo /bin/bash /var/www/html/openWB/web/tools/wlan/wlan1.sh');
 


### PR DESCRIPTION
Set autocomplete for ssid and wifi password to off so Browser doesn't save Password in local formular cache.
Trim SSID and Password to avoid whitespaces at beginning or end if copying via clipboard