### PR TITLE
Falsche Vorbelegung im Smarthomehandler korrigiert

### DIFF
--- a/runs/smarthomehandler.py
+++ b/runs/smarthomehandler.py
@@ -578,7 +578,7 @@ def conditions(nummer):
     try:
         speichersocbeforestop = int(config.get('smarthomedevices', 'device_speichersocbeforestop_'+str(nummer)))
     except:
-        speichersocbeforestop = 0
+        speichersocbeforestop = 100
     try:
         speichersocbeforestart = int(config.get('smarthomedevices', 'device_speichersocbeforestart_'+str(nummer)))
     except:


### PR DESCRIPTION
Sofen in einer Openwb Installation kein Speicher vorhanden ist, wird der pro Smarthomedevice vorhandene speichersocbeforestop falsch vorbelegt (heute 0, sollte 100 sein)