### PR TITLE
Mercedes EQ SoC Module change to single callback URL for max 9 Chargepoints

### DIFF
--- a/modules/soc_eq/auth.py
+++ b/modules/soc_eq/auth.py
@@ -24,16 +24,12 @@ def printHtml(message):
 
 print("<html>")
 
-printHtml("LP: " + ChargePoint)
-
-if ChargePoint == "lp1":
-	ChargePoint = "1"
-elif ChargePoint == "lp2":
-	ChargePoint = "2"
-printHtml("LP: " + ChargePoint)
 client_id = ""
 client_secret = ""
 callback = ""
+
+#get last Character to identify the Chargepoint
+ChargePoint = ChargePoint[-1]
 
 #get SoC module config from openWB cofig
 fd = open('/var/www/html/openWB/openwb.conf','r')

--- a/modules/soc_eq/auth.py
+++ b/modules/soc_eq/auth.py
@@ -24,6 +24,13 @@ def printHtml(message):
 
 print("<html>")
 
+printHtml("LP: " + ChargePoint)
+
+if ChargePoint == "lp1":
+	ChargePoint = "1"
+elif ChargePoint == "lp2":
+	ChargePoint = "2"
+printHtml("LP: " + ChargePoint)
 client_id = ""
 client_secret = ""
 callback = ""
@@ -56,6 +63,8 @@ tok_url  = "https://id.mercedes-benz.com/as/token.oauth2"
 data = {'grant_type': 'authorization_code', 'code': str(code), 'redirect_uri': callback}
 #call API to get Access/Refresh tokens
 act = requests.post(tok_url, data=data, verify=True, allow_redirects=False, auth=(client_id, client_secret))
+
+printDebug(act.url,1)
 
 if act.status_code == 200:
   #valid Response

--- a/modules/soc_eq/callback_lp.php
+++ b/modules/soc_eq/callback_lp.php
@@ -1,0 +1,6 @@
+<?php
+   //Callback procedure for mercedes SoC API LP1 
+   if( $_GET["code"] ) {
+      system( "/var/www/html/openWB/modules/soc_eq/auth.py " . $_GET['state'] . " " . $_GET['code']) ;
+   }
+?>

--- a/web/settings/modulconfiglp.php
+++ b/web/settings/modulconfiglp.php
@@ -1352,7 +1352,7 @@
 										<div class="col">
 											<span class="form-text small">
 												<b>Wichtig: Nach dem Eintragen der Werte müssen diese gespeichert werden und danach einmalig der folgende Link aufgerufen werden:
-												<a href="<?php echo "https://id.mercedes-benz.com/as/authorization.oauth2?response_type=code&client_id=" . $soc_eq_client_id_lp1old . "&redirect_uri=" . $soc_eq_cb_lp1old . "&scope=mb:vehicle:mbdata:evstatus%20offline_access"?>" target="_blank">HIER bei Mercedes Me anmelden</a></b>
+												<a href="<?php echo "https://id.mercedes-benz.com/as/authorization.oauth2?response_type=code&state=lp1&client_id=" . $soc_eq_client_id_lp1old . "&redirect_uri=" . $soc_eq_cb_lp1old . "&scope=mb:vehicle:mbdata:evstatus%20offline_access"?>" target="_blank">HIER bei Mercedes Me anmelden</a></b>
 											</span>
 										</div>
 									</div>
@@ -2643,7 +2643,7 @@
 										<label class="col-md-4 col-form-label"></label>
 										<div class="col">
 											<span class="form-text small"><b>Wichtig: Nach dem Eintragen der Werte müssen diese gespeichert werden und danach einmalig der folgende Link aufgerufen werden<br/>
-											<a href="<?php echo "https://id.mercedes-benz.com/as/authorization.oauth2?response_type=code&client_id=" . $soc_eq_client_id_lp2old . "&redirect_uri=" . $soc_eq_cb_lp2old . "&scope=mb:vehicle:mbdata:evstatus%20offline_access"?>" target="_blank">HIER bei Mercedes Me anmelden</a></b>
+											<a href="<?php echo "https://id.mercedes-benz.com/as/authorization.oauth2?response_type=code&state=lp2&client_id=" . $soc_eq_client_id_lp2old . "&redirect_uri=" . $soc_eq_cb_lp2old . "&scope=mb:vehicle:mbdata:evstatus%20offline_access"?>" target="_blank">HIER bei Mercedes Me anmelden</a></b>
 											</span>
 										</div>
 									</div>


### PR DESCRIPTION
Optimizazion to use a single callback URL for every chargepoint.
Make use of state field in OAuth API to set the chargepoint lp1, lp2, may be extended up to 9 chargepoints as I use only the last character of state field!