### PR TITLE
samrthomehandler wartet beim boot und maxbatterypower aus ramdisk

### DIFF
--- a/runs/atreboot.sh
+++ b/runs/atreboot.sh
@@ -131,8 +131,7 @@ if ps ax |grep -v grep |grep "python3 /var/www/html/openWB/runs/smarthomehandler
 then
 	sudo kill $(ps aux |grep '[s]marthomehandler.py' | awk '{print $2}')
 fi
-python3 /var/www/html/openWB/runs/smarthomehandler.py &
-
+python3 /var/www/html/openWB/runs/smarthomehandler.py >> /var/www/html/openWB/ramdisk/smarthomehandler.log 2>&1 & 
 # restart mqttsub handler
 echo "mqtt handler..."
 if ps ax |grep -v grep |grep "python3 /var/www/html/openWB/runs/mqttsub.py" > /dev/null

--- a/runs/initRamdisk.sh
+++ b/runs/initRamdisk.sh
@@ -580,5 +580,12 @@ initRamdisk(){
 
 	sudo chmod 777 $RamdiskPath/*
 
+	# read values from mosquitto and store them to ramdisk for smarthomehandler.py
+  ra='^-?[0-9]+$'
+  importtemp=$(timeout 4 mosquitto_sub -t openWB/config/get/SmartHome/maxBatteryPower)
+	if ! [[ $importtemp =~ $ra ]] ; then
+		importtemp="0"
+  fi
+  echo $importtemp > $RamdiskPath/smarthomehandlermaxbatterypower
 	echo "Ramdisk init done."
 }


### PR DESCRIPTION
atreboot.sh
Der Smarthomehandler wird immer mit output umleitung (in smarthomehandler.log) gestartet
initRamdisk.sh
vom Gui/MQTT wird der maxBatterypower Wert vom Smarthome nur in dem MQTT openWB/config/get/SmartHome/maxBatteryPower gespeichert.
Der Smarthoemhandlery.py erwartet diesen auf der Ramdisk in ramdisk/smarthomehandlermaxbatterypower.
Bei einem Reboot / Neustart der openwb wird diese Variable ramdisk/smarthomehandlermaxbatterypower mit dem MQTT Wert ersetzt (das gleicher Verfahren ist auch in der loadvars für mehrere Simcount Variablen im Einsatz:
2021-02-05 18:06:31: loadvars read openWB/evu/WHImported_temp from mosquito 28578202616 (LV0)
2021-02-05 18:06:35: loadvars read openWB/evu/WHExport_temp from mosquito -8691007530 (LV0)
2021-02-05 18:06:39: loadvars read openWB/pv/WHImported_temp from mosquito 0 (LV0)
2021-02-05 18:06:43: loadvars read openWB/pv/WHExport_temp from mosquito -40987179326 (LV0)
2021-02-05 18:06:47: loadvars read openWB/housebattery/WHImported_temp from mosquito 11932255942 (LV0)
2021-02-05 18:06:51: loadvars read openWB/housebattery/WHImported_temp from mosquito 11932255942 (LV0)
2021-02-05 18:06:51: loadvars read openWB/housebattery/WHExport_temp from mosquito -81293226 (LV0)
2021-02-05 18:06:55: loadvars read openWB/housebattery/WHExport_temp from mosquito -81293226 (LV0)

Smarthomehandler.py
Wartet neu bis das der Reboot / update abgeschlossen ist
liest neu den maxspeicher von der Ramdisk ein