### PR TITLE
mystrom switches und  temp sensoren im smarthomehandler

### DIFF
--- a/modules/smarthome/mystrom/off.py
+++ b/modules/smarthome/mystrom/off.py
@@ -1,0 +1,17 @@
+#!/usr/bin/python3
+import sys
+import os
+import time
+import json
+import getopt
+import socket
+import struct
+import codecs
+import binascii
+import urllib.request
+named_tuple = time.localtime() # getstruct_time
+time_string = time.strftime("%m/%d/%Y, %H:%M:%S mystrom off.py", named_tuple)
+devicenumber=str(sys.argv[1])
+ipadr=str(sys.argv[2])
+uberschuss=int(sys.argv[3])
+urllib.request.urlopen("http://"+str(ipadr)+"/relay?state=0", timeout=3)

--- a/modules/smarthome/mystrom/on.py
+++ b/modules/smarthome/mystrom/on.py
@@ -1,0 +1,17 @@
+#!/usr/bin/python3
+import sys
+import os
+import time
+import json
+import getopt
+import socket
+import struct
+import codecs
+import binascii
+import urllib.request
+named_tuple = time.localtime() # getstruct_time
+time_string = time.strftime("%m/%d/%Y, %H:%M:%S mystrom on.py", named_tuple)
+devicenumber=str(sys.argv[1])
+ipadr=str(sys.argv[2])
+uberschuss=int(sys.argv[3])
+urllib.request.urlopen("http://"+str(ipadr)+"/relay?state=1", timeout=3)

--- a/modules/smarthome/mystrom/watt.py
+++ b/modules/smarthome/mystrom/watt.py
@@ -1,0 +1,30 @@
+#!/usr/bin/python3
+import sys
+import os
+import time
+import json
+import getopt
+import socket
+import struct
+import codecs
+import binascii
+import urllib.request
+named_tuple = time.localtime() # getstruct_time
+time_string = time.strftime("%m/%d/%Y, %H:%M:%S mystrom watty.py", named_tuple)
+devicenumber=str(sys.argv[1])
+ipadr=str(sys.argv[2])
+uberschuss=int(sys.argv[3])
+answer = json.loads(str(urllib.request.urlopen("http://"+str(ipadr)+"/report", timeout=3).read().decode("utf-8")))
+aktpower =  int(answer['power'])
+relaiss = str(answer['relay'])
+if (relaiss.lower() == "true"):
+    relais = 1
+else:
+    relais = 0
+templong=str(float(answer['temperature']))
+temp=templong[0:5]
+powerc = 0
+answer = '{"power":' + str(aktpower) + ',"powerc":' + str(powerc) + ',"on":' + str(relais)  + ',"temp0":' + str(temp) + '} '
+f1 = open('/var/www/html/openWB/ramdisk/smarthome_device_ret' + str(devicenumber), 'w')
+json.dump(answer,f1)
+f1.close()

--- a/modules/smarthome/shelly/watt.py
+++ b/modules/smarthome/shelly/watt.py
@@ -30,7 +30,16 @@ answer = json.loads(str(urllib.request.urlopen("http://"+str(ipadr)+"/status", t
 aktpower = totalPowerFromShellyJson(answer)
 relais = int(answer['relays'][0]['ison'])
 powerc = 0
-answer = '{"power":' + str(aktpower) + ',"powerc":' + str(powerc) + ',"on":' + str(relais) + '} '
+temp0 = '0.0'
+temp1 = '0.0'
+temp2 = '0.0'
+try:
+    temp0 = str(answer['ext_temperature'][0]['tC'])
+    temp1 = str(answer['ext_temperature'][1]['tC'])
+    temp2 = str(answer['ext_temperature'][2]['tC'])
+except:
+    pass
+answer = '{"power":' + str(aktpower) + ',"powerc":' + str(powerc) + ',"on":' + str(relais) + ',"temp0":' + str(temp0) + ',"temp1":' + str(temp1) + ',"temp2":' + str(temp2) + '} '
 f1 = open('/var/www/html/openWB/ramdisk/smarthome_device_ret' + str(devicenumber), 'w')
 json.dump(answer,f1)
 f1.close()

--- a/runs/atreboot.sh
+++ b/runs/atreboot.sh
@@ -131,7 +131,7 @@ if ps ax |grep -v grep |grep "python3 /var/www/html/openWB/runs/smarthomehandler
 then
 	sudo kill $(ps aux |grep '[s]marthomehandler.py' | awk '{print $2}')
 fi
-python3 /var/www/html/openWB/runs/smarthomehandler.py >> /var/www/html/openWB/ramdisk/smarthomehandler.log 2>&1 & 
+python3 /var/www/html/openWB/runs/smarthomehandler.py >> /var/www/html/openWB/ramdisk/smarthomehandler.log 2>&1 &
 # restart mqttsub handler
 echo "mqtt handler..."
 if ps ax |grep -v grep |grep "python3 /var/www/html/openWB/runs/mqttsub.py" > /dev/null
@@ -388,3 +388,9 @@ echo 0 > /var/www/html/openWB/ramdisk/bootinprogress
 echo 0 > /var/www/html/openWB/ramdisk/updateinprogress
 mosquitto_pub -t openWB/system/updateInProgress -r -m "0"
 mosquitto_pub -t openWB/system/reloadDisplay -m "1"
+mosquitto_pub -r -t openWB/SmartHome/Devices/1/TemperatureSensor0 -m ""
+mosquitto_pub -r -t openWB/SmartHome/Devices/1/TemperatureSensor1 -m ""
+mosquitto_pub -r -t openWB/SmartHome/Devices/1/TemperatureSensor2 -m ""
+mosquitto_pub -r -t openWB/SmartHome/Devices/2/TemperatureSensor0 -m ""
+mosquitto_pub -r -t openWB/SmartHome/Devices/2/TemperatureSensor1 -m ""
+mosquitto_pub -r -t openWB/SmartHome/Devices/2/TemperatureSensor2 -m ""


### PR DESCRIPTION
Unterstützung von mystrom Steckdosen (analog shelly)
Die Temperatursensoren Shelly (optional 1 bis 3) und Mystrom (immer 1) laufen wieder.
Diese Temperaturen werden nur angezeigt, wenn unter Smarthomedevice 1 oder 2 definiert.