### PR TITLE
Erzwinge JS reload

### DIFF
--- a/web/themes/EvenDarker/theme.html
+++ b/web/themes/EvenDarker/theme.html
@@ -1305,7 +1305,7 @@
 				// respective Chart.js definition live
 				'themes/dark/livechart.js?ver=20201218',
 				// respective Chart.js definition
-				'themes/dark/electricityPriceChart.js?ver=20210120',
+				'themes/dark/electricityPriceChart.js?ver=20210210',
 				// functions performing mqtt and start mqtt-service
 				'themes/dark/setupMqttServices.js?ver=20210129',
 			];

--- a/web/themes/Gauges/theme.html
+++ b/web/themes/Gauges/theme.html
@@ -1696,7 +1696,7 @@
 				// respective Chart.js definition live
 				'themes/Gauges/livechart.js?ver=20201218',
 				// respective Chart.js definition pricechart
-				'themes/dark/electricityPriceChart.js?ver=20210208',
+				'themes/dark/electricityPriceChart.js?ver=20210210',
 				// functions performing mqtt and start mqtt-service
 				'themes/Gauges/setupMqttServices.js?ver=20210129'
 			];

--- a/web/themes/dark/theme.html
+++ b/web/themes/dark/theme.html
@@ -1303,7 +1303,7 @@
 				// respective Chart.js definition live
 				'themes/dark/livechart.js?ver=20201218',
 				// respective Chart.js definition
-				'themes/dark/electricityPriceChart.js?ver=20210120',
+				'themes/dark/electricityPriceChart.js?ver=20210210',
 				// functions performing mqtt and start mqtt-service
 				'themes/dark/setupMqttServices.js?ver=20210129',
 			];


### PR DESCRIPTION
Geänderte JS-Datei scheint (warum auch immer) von einigen Browsern trotz anderem Query-String nicht immer neu geladen zu werden, sondern kommt teilweise noch aus dem Cache. Im PR wurde der String geändert, um zu sehen, ob das Problem bestehen bleibt.