### PR TITLE
SO_EQ umbau auf openwbDebugLog

### DIFF
--- a/modules/bezug_json/main.sh
+++ b/modules/bezug_json/main.sh
@@ -3,52 +3,40 @@
 OPENWBBASEDIR=$(cd `dirname $0`/../../ && pwd)
 RAMDISKDIR="$OPENWBBASEDIR/ramdisk"
 MODULEDIR=$(cd `dirname $0` && pwd)
-MODULE="EVU"
+#DMOD="EVU"
+DMOD="MAIN"
 LOGFILE="$RAMDISKDIR/openWB.log"
 Debug=$debug
-myPid=$$
 
 
 #For development only
 #Debug=1
 
-DebugLog(){
-        if (( Debug > 0 )); then
-                timestamp=`date +"%Y-%m-%d %H:%M:%S"`
-                if (( Debug == 2 )); then
-                      echo "$timestamp: ${MODULE}: PID:$myPid: $@" >> $LOGFILE
-                else
-                      echo "$timestamp: ${MODULE}: $@" >> $LOGFILE
-                fi
-        fi
-}
 
-
-DebugLog "${bezugjsonwatt}"
-DebugLog "${bezugjsonkwh}"
-DebugLog "${einspeisungjsonkwh}"
+openwbDebugLog ${DMOD} 1 "${bezugjsonwatt}"
+openwbDebugLog ${DMOD} 1 "${bezugjsonkwh}"
+openwbDebugLog ${DMOD} 1 "${einspeisungjsonkwh}"
 
 answer=$(curl --connect-timeout 5 -s $bezugjsonurl)
 evuwatt=$(echo $answer | jq -r "$bezugjsonwatt" | sed 's/\..*$//')
 echo ${evuwatt}
-DebugLog "Watt: ${evuwatt}"
+openwbDebugLog  ${DMOD} 0 "Watt: ${evuwatt}"
 echo $evuwatt > /var/www/html/openWB/ramdisk/wattbezug
 
 if [ ! -z "${bezugjsonkwh}" ]; then
     evuikwh=$(echo $answer | jq -r "$bezugjsonkwh")
-    DebugLog "BezugkWh: ${evuikwh}"
 else
     evuikwh=0
-    DebugLog "BezugkWh: ${evuikwh}"
 fi
+
+openwbDebugLog ${DMOD} 0 "BezugkWh: ${evuikwh}"
 echo $evuikwh > /var/www/html/openWB/ramdisk/bezugkwh
 
 if [ ! -z "${einspeisungjsonkwh}" ]; then
     evuekwh=$(echo $answer | jq -r "$einspeisungjsonkwh")
-    DebugLog "EinspeiskWh: ${evuekwh}"
 else
     evuekwh=0
-    DebugLog "EinspeiskWh: ${evuekwh}"
 fi
+openwbDebugLog ${DMOD} 0 "EinspeiskWh: ${evuekwh}"
 echo $evuekwh > /var/www/html/openWB/ramdisk/einspeisungkwh
 

--- a/modules/soc_eq/main.sh
+++ b/modules/soc_eq/main.sh
@@ -3,6 +3,7 @@
 OPENWBBASEDIR=$(cd `dirname $0`/../../ && pwd)
 RAMDISKDIR="$OPENWBBASEDIR/ramdisk"
 MODULEDIR=$(cd `dirname $0` && pwd)
+DMOD="EVSOC"
 LOGFILE="$RAMDISKDIR/soc.log"
 CHARGEPOINT=$1
 myPid=$$
@@ -34,16 +35,6 @@ case $CHARGEPOINT in
 		;;
 esac
 
-socDebugLog(){
-	if (( socDebug > 0 )); then
-		timestamp=`date +"%Y-%m-%d %H:%M:%S"`
-		if (( socDebug == 2 )); then
-                      echo "$timestamp: Lp$CHARGEPOINT: PID:$myPid: $@" >> $LOGFILE
-                else
-		      echo "$timestamp: Lp$CHARGEPOINT: $@" >> $LOGFILE
-                fi
-	fi
-}
 
 soctimer=$(<$soctimerfile)
 ladeleistung=$(<$ladeleistungfile)
@@ -60,14 +51,14 @@ fi
 
 
 if (( soctimer < tmpintervall )); then
-	socDebugLog "Nothing to do yet. Incrementing timer. ${soctimer} < ${tmpintervall}"
+	openwbDebugLog ${DMOD} 1 "Lp$CHARGEPOINT: Nothing to do yet. Incrementing timer. ${soctimer} < ${tmpintervall}"
 	soctimer=$((soctimer+1))
 	echo $soctimer > $soctimerfile
 else
-  socDebugLog "Requesting SoC"
+  openwbDebugLog ${DMOD} 1 "Lp$CHARGEPOINT: Requesting SoC"
   echo 0 > $soctimerfile
   $MODULEDIR/soc.py $soc_eq_client_id $soc_eq_client_secret $soc_eq_vin $soc_file $CHARGEPOINT >>$LOGFILE
   ret=$?
-  socDebugLog "Py Return: ${ret}"
+  openwbDebugLog ${DMOD} 1 "Lp$CHARGEPOINT: Py Return: ${ret}"
   openwbModulePublishState "EVSOC" "${ret}" "Code: ${ret}" "$CHARGEPOINT"
 fi

--- a/modules/speicher_json/main.sh
+++ b/modules/speicher_json/main.sh
@@ -3,40 +3,26 @@
 OPENWBBASEDIR=$(cd `dirname $0`/../../ && pwd)
 RAMDISKDIR="$OPENWBBASEDIR/ramdisk"
 MODULEDIR=$(cd `dirname $0` && pwd)
-MODULE="BATT"
+#DMOD="BATT"
+DMOD="MAIN"
 #LOGFILE="$RAMDISKDIR/speicher.log"
-LOGFILE="$RAMDISKDIR/openWB.log"
+#LOGFILE="$RAMDISKDIR/openWB.log"
 Debug=$debug
-myPid=$$
 
 #For Development only
 #Debug=1
 
-DebugLog(){
-        if (( Debug > 0 )); then
-                timestamp=`date +"%Y-%m-%d %H:%M:%S"`
-                if (( Debug == 2 )); then
-                      echo "$timestamp: ${MODULE}: PID:$myPid: $@" >> $LOGFILE
-                else
-                      echo "$timestamp: ${MODULE}: $@" >> $LOGFILE
-                fi
-        fi
-}
-
-
-
 answer=$(curl --connect-timeout 5 -s $battjsonurl)
 speicherleistung=$(echo $answer | jq -r "$battjsonwatt" | sed 's/\..*$//')
-DebugLog "BattLeistung: ${speicherleistung}"
+openwbDebugLog ${DMOD} 1 "BattLeistung: ${speicherleistung}"
 echo ${speicherleistung}
 echo $speicherleistung > /var/www/html/openWB/ramdisk/speicherleistung
 
 if [ ! -z "$battjsonsoc" ]; then
     battsoc=$(echo $answer | jq -r "$battjsonsoc")
-    DebugLog "BattSoC: ${battsoc}"
 else
     battsoc=0
-    DebugLog "BattSoC: ${battsoc}"
 fi
 
+openwbDebugLog ${DMOD} 1 "BattSoC: ${battsoc}"
 echo $battsoc > /var/www/html/openWB/ramdisk/speichersoc

--- a/modules/wr_json/main.sh
+++ b/modules/wr_json/main.sh
@@ -3,26 +3,14 @@
 OPENWBBASEDIR=$(cd `dirname $0`/../../ && pwd)
 RAMDISKDIR="$OPENWBBASEDIR/ramdisk"
 MODULEDIR=$(cd `dirname $0` && pwd)
-MODULE="PV"
+DMOD="PV"
+#DMOD="MAIN"
 #LOGFILE="$RAMDISKDIR/pv_wr.log"
-LOGFILE="$RAMDISKDIR/openWB.log"
+#LOGFILE="$RAMDISKDIR/openWB.log"
 Debug=$debug
-myPid=$$
 
 #For Development only
 #Debug=1
-
-DebugLog(){
-        if (( Debug > 0 )); then
-                timestamp=`date +"%Y-%m-%d %H:%M:%S"`
-                if (( Debug == 2 )); then
-                      echo "$timestamp: ${MODULE}: PID:$myPid: $@" >> $LOGFILE
-                else
-                      echo "$timestamp: ${MODULE}: $@" >> $LOGFILE
-                fi
-        fi
-}
-
 
 
 answer=$(curl --connect-timeout 5 -s $wrjsonurl)
@@ -30,15 +18,15 @@ pvwatt=$(echo $answer | jq -r "$wrjsonwatt" | sed 's/\..*$//')
 	if (( $pvwatt > 5 )); then
 		pvwatt=$(echo "$pvwatt*-1" |bc)
 	fi	
-DebugLog "PVWatt: ${pvwatt}"
+openwbDebugLog ${DMOD} 1 "PVWatt: ${pvwatt}"
 echo ${pvwatt}
 echo $pvwatt > /var/www/html/openWB/ramdisk/pvwatt
 
 if [ ! -z "$wrjsonkwh" ]; then
     pvkwh=$(echo $answer | jq -r "$wrjsonkwh")
-    DebugLog "PVkWh: ${pvkwh}"
 else
     pvkwh=0
-    DebugLog "PVkWh: ${pvkwh}"
 fi
+
+openwbDebugLog ${DMOD} 1 "PVkWh: ${pvkwh}"
 echo $pvkwh > /var/www/html/openWB/ramdisk/pvkwh


### PR DESCRIPTION
Anpassung der Debug Funktionen auf die helperfunction

@benderl : kannst du dir erklären, warum die Ausgaben des caller bei den beiden LPs unterschiedlich ist?

2021-02-14 16:11:34: Lp2: Nothing to do yet. Incrementing timer. 0 < 6 (LV1) at 54 main /var/www/html/openWB/modules/soc_eq/main.sh
2021-02-14 16:11:36: Lp1: Nothing to do yet. Incrementing timer. 0 < 6 (LV1) at 54 main modules/soc_eq/main.sh
2021-02-14 16:11:44: Lp2: Nothing to do yet. Incrementing timer. 1 < 6 (LV1) at 54 main /var/www/html/openWB/modules/soc_eq/main.sh
2021-02-14 16:11:46: Lp1: Nothing to do yet. Incrementing timer. 1 < 6 (LV1) at 54 main modules/soc_eq/main.sh
2021-02-14 16:11:53: Lp2: Nothing to do yet. Incrementing timer. 2 < 6 (LV1) at 54 main /var/www/html/openWB/modules/soc_eq/main.sh
2021-02-14 16:11:55: Lp1: Nothing to do yet. Incrementing timer. 2 < 6 (LV1) at 54 main modules/soc_eq/main.sh
2021-02-14 16:12:03: Lp2: Nothing to do yet. Incrementing timer. 3 < 6 (LV1) at 54 main /var/www/html/openWB/modules/soc_eq/main.sh
2021-02-14 16:12:05: Lp1: Nothing to do yet. Incrementing timer. 3 < 6 (LV1) at 54 main modules/soc_eq/main.sh
2021-02-14 16:12:13: Lp2: Nothing to do yet. Incrementing timer. 4 < 6 (LV1) at 54 main /var/www/html/openWB/modules/soc_eq/main.sh
2021-02-14 16:12:15: Lp1: Nothing to do yet. Incrementing timer. 4 < 6 (LV1) at 54 main modules/soc_eq/main.sh
2021-02-14 16:12:23: Lp2: Nothing to do yet. Incrementing timer. 5 < 6 (LV1) at 54 main /var/www/html/openWB/modules/soc_eq/main.sh
2021-02-14 16:12:26: Lp1: Nothing to do yet. Incrementing timer. 5 < 6 (LV1) at 54 main modules/soc_eq/main.sh
