### PR TITLE
smarthomehandler HTTP / acthor / AVM

### DIFF
--- a/modules/smarthome/acthor/watt.py
+++ b/modules/smarthome/acthor/watt.py
@@ -13,6 +13,8 @@ time_string = time.strftime("%m/%d/%Y, %H:%M:%S acthor watty.py", named_tuple)
 devicenumber=str(sys.argv[1])
 ipadr=str(sys.argv[2])
 uberschuss=int(sys.argv[3])
+atype=str(sys.argv[4])
+instpower=int(sys.argv[5])
 file_string= '/var/www/html/openWB/ramdisk/smarthome_device_' + str(devicenumber) + '_acthor.log'
 file_stringpv= '/var/www/html/openWB/ramdisk/smarthome_device_' + str(devicenumber) + '_pv'
 file_stringcount= '/var/www/html/openWB/ramdisk/smarthome_device_' + str(devicenumber) + '_count'
@@ -29,6 +31,16 @@ if count5 > 6:
 f = open( file_stringcount5 , 'w')
 f.write(str(count5))
 f.close()
+faktor=1.0
+if instpower == 0:
+    instpower = 1000
+if atype == "9s":
+    faktor = 9000/instpower
+else:
+    if atype == "M3":
+        faktor = 6000/instpower
+    else:
+        faktor = 3000/instpower
 if count5==0:
    # pv modus
    pvmodus = 0
@@ -37,7 +49,7 @@ if count5==0:
       pvmodus =int(f.read())
       f.close()
 # letzte Leistungsvorgabe + 1000
-   oldpower = 1000
+   oldpower = int(1000 * faktor)
    if os.path.isfile(file_stringold):
       f = open( file_stringold , 'r')
       oldpower =int(f.read())
@@ -51,10 +63,14 @@ if count5==0:
    count1=count1+1
    # aktuelle Leistung lesen
    client = ModbusTcpClient(ipadr, port=502)
+   #
+   #
    start = 1000
    resp=client.read_holding_registers(start,10,unit=1)
-   #start = 3524 
+   #
+   #start = 3524
    #resp=client.read_input_registers(start,10,unit=1)
+   #
    value1 = resp.registers[0]
    all = format(value1, '04x')
    #aktpower= int(struct.unpack('>h', all.decode('hex'))[0])
@@ -65,13 +81,13 @@ if count5==0:
    # logik
    modbuswrite = 0
    if uberschuss < 0:
-      neupowertarget = aktpower + uberschuss
+      neupowertarget = int((uberschuss + aktpower) * faktor)
    else:
-      neupowertarget = uberschuss + aktpower
+      neupowertarget = int((uberschuss + aktpower) * faktor)
    if neupowertarget < 0:
       neupowertarget = 0
-   if neupowertarget > 10000:
-      neupowertarget = 10000
+   if neupowertarget > int(10000 * faktor):
+      neupowertarget = int(10000 * faktor)
    # status nach handbuch Thor
    #0.. Aus
    #1-8 Geraetestart
@@ -105,7 +121,7 @@ if count5==0:
    #json return power = aktuelle Leistungsaufnahme in Watt, on = 1 pvmodus, powerc = counter in kwh
    #answer = '{"power":225,"on":0} '
    powerc = 0
-   answer = '{"power":' + str(aktpower) + ',"powerc":' + str(powerc) + ',"on":' + str(pvmodus) + '} '   
+   answer = '{"power":' + str(aktpower) + ',"powerc":' + str(powerc) + ',"on":' + str(pvmodus) + '} '
    f1 = open('/var/www/html/openWB/ramdisk/smarthome_device_ret' + str(devicenumber), 'w')
    json.dump(answer,f1)
    f1.close()
@@ -117,7 +133,7 @@ if count5==0:
          f = open( file_string , 'a')
       else:
          f = open( file_string , 'w')
-      print ('%s devicenr %s ipadr %s ueberschuss %6d Akt Leistung  %6d Status %2d' % (time_string,devicenumber,ipadr,uberschuss,aktpower,status),file=f)
+      print ('%s devicenr %s ipadr %s ueberschuss %6d Akt Leistung  %6d Status %2d type %s inst. Leistung %6d Skalierung %.2f' % (time_string,devicenumber,ipadr,uberschuss,aktpower,status,atype,instpower,faktor),file=f)
       print ('%s devicenr %s ipadr %s Neu Leistung %6d pvmodus %1d modbuswrite %1d  ' % (time_string,devicenumber,ipadr,neupower,pvmodus,modbuswrite),file=f)
       f.close()
    # modbus write
@@ -131,5 +147,5 @@ if count5==0:
    f.write(str(count1))
    f.close()
    f = open( file_stringold , 'w')
-   f.write(str(int(neupower + 1000)))
+   f.write(str(int(neupower + int(1000 * faktor))))
    f.close()

--- a/modules/smarthome/http/watt.py
+++ b/modules/smarthome/http/watt.py
@@ -15,6 +15,10 @@ time_string = time.strftime("%m/%d/%Y, %H:%M:%S http watty.py", named_tuple)
 devicenumber=str(sys.argv[1])
 uberschuss=int(sys.argv[3])
 url=str(sys.argv[4])
+try:
+    urlc=str(sys.argv[5])
+except:
+    urlc = "none"
 if not urlparse(url).scheme:
    url = 'http://' + url
 if uberschuss < 0:
@@ -25,7 +29,7 @@ if os.path.isfile(file_string):
    f = open( file_string , 'a')
 else:
    f = open( file_string , 'w')
-print ('%s devicenr %s orig url %s replaced url %s' % (time_string,devicenumber,url,urlrep),file=f)
+print ('%s devicenr %s orig url %s replaced url %s urlc %s' % (time_string,devicenumber,url,urlrep,urlc),file=f)
 f.close()
 aktpowerfl = float(urllib.request.urlopen(urlrep, timeout=5).read().decode("utf-8"))
 aktpower = int(aktpowerfl)
@@ -33,7 +37,12 @@ if aktpower > 50:
     relais = 1
 else:
     relais = 0
-powerc = 0
+if len(urlc) < 6:
+    powerc = 0
+else:
+    if not urlparse(urlc).scheme:
+        urlc = 'http://' + urlc
+    powerc = int(urllib.request.urlopen(urlc, timeout=5).read().decode("utf-8"))
 answer = '{"power":' + str(aktpower) + ',"powerc":' + str(powerc) + ',"on":' + str(relais) + '} '
 f1 = open('/var/www/html/openWB/ramdisk/smarthome_device_ret' + str(devicenumber), 'w')
 json.dump(answer,f1)

--- a/runs/smarthomehandler.py
+++ b/runs/smarthomehandler.py
@@ -190,6 +190,11 @@ def sepwatt(oldwatt,oldwattk,nummer):
             argumentList.append(measureurl)
         except:
             argumentList.append("undef")
+        try:
+            measureurlc = str(config.get('smarthomedevices', 'device_measureurlc_'+str(nummer)))
+            argumentList.append(measureurlc)
+        except:
+            argumentList.append("none")
     else:
        # no known meastyp, so return the old values directly
         logDebug(LOGLEVELERROR, "Leistungsmessung %s %d %s Geraetetyp ist nicht implementiert!" % (meastyp, nummer, str(configuredName)))
@@ -537,15 +542,27 @@ def getdevicevalues():
                 device_ip = str(config.get('smarthomedevices', 'device_ip_'+str(numberOfDevices)))
             except:
                 device_ip = "undef"
+            try:
+                device_acthortype = str(config.get('smarthomedevices', 'device_acthortype_'+str(numberOfDevices)))
+            except:
+                device_acthortype = "undef"
+            try:
+                device_acthorpower = int(config.get('smarthomedevices', 'device_acthorpower_'+str(numberOfDevices)))
+            except:
+                device_acthorpower = 0
             pyname0 = getdir(switchtyp,devicename)
             try:
                 pyname = pyname0 +"/watt.py"
-                if os.path.isfile(pyname) and (canswitch == 1):
+                if os.path.isfile(pyname) and (switchtyp != "none"):
                     argumentList = ['python3', pyname, str(numberOfDevices)]
                     argumentList.append(device_ip)
                     argumentList.append(str(devuberschuss))
-                    argumentList.append(device_leistungurl)
-                    argumentList.append(device_actor)
+                    if (switchtyp == "acthor"):
+                        argumentList.append(device_acthortype)
+                        argumentList.append(str(device_acthorpower))
+                    else:
+                        argumentList.append(device_leistungurl)
+                        argumentList.append(device_actor)
                     argumentList.append(device_username)
                     argumentList.append(device_password)
                     proc=subprocess.Popen(argumentList)
@@ -561,7 +578,7 @@ def getdevicevalues():
                     else:
                         relais=0
                     #Shelly temp sensor
-                    if (switchtyp == "shelly"):
+                    if (switchtyp == "shelly")  and (canswitch == 1):
                         try:
                             anzahltemp = int(config.get('smarthomedevices', 'device_temperatur_configured_'+str(numberOfDevices)))
                             if ( anzahltemp > 0):
@@ -575,7 +592,7 @@ def getdevicevalues():
                         except:
                             pass
                     #mystrom temp sensor
-                    if (switchtyp == "mystrom"):
+                    if (switchtyp == "mystrom")  and (canswitch == 1):
                         temp = str(answer['temp0'])
                         logDebug(LOGLEVELERROR, "(" + str(numberOfDevices) + ") mystrom temp sensor: 1 Grad: " +  temp)
                         DeviceValues.update( {str(numberOfDevices) + "temp0"  : temp })


### PR DESCRIPTION
Neu können für HTTP Geräte in separater Leistungsmessung optional auch Zähler (mittels separater URL) übergeben werden.
Für Acthor werden Typ und installierte Leistung zur Berechnung vom Skalierungsfaktor genommen.
AVM Geräte mit Gerät kann schalten = Nein werden wieder gemessen