### PR TITLE
avmhomeautomation: Filter non-present devices

### DIFF
--- a/modules/smarthome/avmhomeautomation/avmcommon.py
+++ b/modules/smarthome/avmhomeautomation/avmcommon.py
@@ -204,6 +204,9 @@ class AVMHomeAutomation:
                 name = device.find("name").text
                 ain = device.attrib["identifier"]
                 next_device_infos[name] = {'ain': ain}
+                presentText = device.find("present").text
+                if presentText != '1':
+                    continue
 
                 hkrBlock = device.find("hkr")
                 if hkrBlock != None:


### PR DESCRIPTION
Unplugged devices still have the relevant XML subtrees for powermeter in
the AVM API, but with empty inner text. Filtering out non-present
devices prevents an exception when casting an empty string to float.