### PR TITLE
fix autolock: respect waitUntilFinished setting

### DIFF
--- a/processautolock.sh
+++ b/processautolock.sh
@@ -89,9 +89,9 @@ fi
 
 function checkDisableLp {
 	powerVarName="powerLp${chargePoint}"
-	if [ "${!powerVarName}" -lt "200" ]; then
-		# charge point not charging, so disable charge point
-		mqttTopic="openWB/set/lp$chargePoint/ChargePointEnabled"
+	if [ "$waitUntilFinished" = "off" ] || [ "${!powerVarName}" -lt "200" ]; then
+		# autolock is not configured to wait until finished or charge point not charging, so disable charge point
+		mqttTopic="openWB/set/lp/$chargePoint/ChargePointEnabled"
 		mosquitto_pub -r -t $mqttTopic -m 0
 		# and set flag "autolock performed"
 		mqttTopic="openWB/set/lp/$chargePoint/AutolockStatus"


### PR DESCRIPTION
Setting was read from openwb.conf but never used. Autolock always waited for current charging to stop before locking charge point.