### PR TITLE
Soc_EQ Fix Logfile

### DIFF
--- a/modules/soc_eq/main.sh
+++ b/modules/soc_eq/main.sh
@@ -4,7 +4,7 @@ OPENWBBASEDIR=$(cd `dirname $0`/../../ && pwd)
 RAMDISKDIR="$OPENWBBASEDIR/ramdisk"
 MODULEDIR=$(cd `dirname $0` && pwd)
 DMOD="EVSOC"
-LOGFILE="$RAMDISKDIR/soc.log"
+MYLOGFILE="$RAMDISKDIR/soc.log"
 CHARGEPOINT=$1
 myPid=$$
 socDebug=$debug
@@ -57,7 +57,7 @@ if (( soctimer < tmpintervall )); then
 else
   openwbDebugLog ${DMOD} 1 "Lp$CHARGEPOINT: Requesting SoC"
   echo 0 > $soctimerfile
-  $MODULEDIR/soc.py $soc_eq_client_id $soc_eq_client_secret $soc_eq_vin $soc_file $CHARGEPOINT >>$LOGFILE
+  $MODULEDIR/soc.py $soc_eq_client_id $soc_eq_client_secret $soc_eq_vin $soc_file $CHARGEPOINT >>$MYLOGFILE
   ret=$?
   openwbDebugLog ${DMOD} 1 "Lp$CHARGEPOINT: Py Return: ${ret}"
   openwbModulePublishState "EVSOC" "${ret}" "Code: ${ret}" "$CHARGEPOINT"


### PR DESCRIPTION
With the change to global function openwbDebugLog, the variable LOGFILE was overloaded so the standard soc output from the python module was written to openwb.log instead of soc.log. 