### PR TITLE
tasmota an shelly angleichen

### DIFF
--- a/modules/smarthome/tasmota/watt.py
+++ b/modules/smarthome/tasmota/watt.py
@@ -14,13 +14,16 @@ time_string = time.strftime("%m/%d/%Y, %H:%M:%S tasmota watty.py", named_tuple)
 devicenumber=str(sys.argv[1])
 ipadr=str(sys.argv[2])
 uberschuss=int(sys.argv[3])
+relais=0
+try:
+    answer2 = json.loads(str(urllib.request.urlopen("http://"+str(ipadr)+"/cm?cmnd=Status", timeout=3).read().decode("utf-8")))
+    r_status = int(answer2['Status']['POWER'])
+except:
+    r_status = 0
 answer = json.loads(str(urllib.request.urlopen("http://"+str(ipadr)+"/cm?cmnd=Status%208", timeout=3).read().decode("utf-8")))
 aktpower = int(answer['StatusSNS']['ENERGY']['Power'])
-#if ( int(answer['StatusSNS']['ENERGY']['Voltage']) > 50 ):
-if aktpower > 50:
+if (aktpower > 50) or (r_status == 1):
    relais=1
-else:
-   relais=0
 powerc = 0
 answer = '{"power":' + str(aktpower) + ',"powerc":' + str(powerc) + ',"on":' + str(relais) + '} '
 f1 = open('/var/www/html/openWB/ramdisk/smarthome_device_ret' + str(devicenumber), 'w')


### PR DESCRIPTION
Neu wird bei tasmota wie bei Shelly zuerst der On /Off Status abgefragt, bevor auf den Workaround mit der aktuellen Leistungs ausgewichen wird.
Details siehe
https://github.com/snaptec/openWB/issues/1081
