### PR TITLE
Fronius Verbraucherzähler

### DIFF
--- a/modules/smarthome/fronius/watt.py
+++ b/modules/smarthome/fronius/watt.py
@@ -1,0 +1,28 @@
+#!/usr/bin/python3
+import sys
+import os
+import time
+import json
+import urllib.request
+
+named_tuple = time.localtime() # getstruct_time
+time_string = time.strftime("%m/%d/%Y, %H:%M:%S fronius watty.py", named_tuple)
+
+devicenumber=str(sys.argv[1])
+ipadr=str(sys.argv[2])
+smid=int(sys.argv[3])
+
+answer = json.loads(str(urllib.request.urlopen("http://"+str(ipadr)+"/solar_api/v1/GetMeterRealtimeData.cgi?Scope=Device&DeviceID="+str(smid), timeout=3).read().decode("utf-8")))
+aktpower = answer['Body']['Data']['PowerReal_P_Sum']*-1
+powerc = answer['Body']['Data']['EnergyReal_WAC_Sum_Consumed']
+
+#if aktpower > 50:
+#    relais = 1
+#else:
+#    relais = 0
+
+answer = '{"power":' + str(aktpower) + ',"powerc":' + str(powerc)  + '} '
+#answer = '{"power":' + str(aktpower) + ',"powerc":' + str(powerc) + ',"on":' + str(relais) + '} '
+f1 = open('/var/www/html/openWB/ramdisk/smarthome_device_ret' + str(devicenumber), 'w')
+json.dump(answer,f1)
+f1.close()

--- a/modules/smarthome/fronius/watt.py
+++ b/modules/smarthome/fronius/watt.py
@@ -9,8 +9,8 @@ named_tuple = time.localtime() # getstruct_time
 time_string = time.strftime("%m/%d/%Y, %H:%M:%S fronius watty.py", named_tuple)
 
 devicenumber=str(sys.argv[1])
-ipadr=str(sys.argv[2])
-smid=int(sys.argv[3])
+ipadr=str(sys.argv[2])        #IP-ADresse des Fronius Wechselrichters, mit dem der Zähler kommuniziert
+smid=int(sys.argv[3])         #ID des Zählers im Wechselrichter (Hauptzähler 0, weitere fortlaufend)
 
 answer = json.loads(str(urllib.request.urlopen("http://"+str(ipadr)+"/solar_api/v1/GetMeterRealtimeData.cgi?Scope=Device&DeviceID="+str(smid), timeout=3).read().decode("utf-8")))
 aktpower = answer['Body']['Data']['PowerReal_P_Sum']*-1

--- a/modules/smarthome/fronius/watt.py
+++ b/modules/smarthome/fronius/watt.py
@@ -13,10 +13,12 @@ ipadr=str(sys.argv[2])        #IP-ADresse des Fronius Wechselrichters, mit dem d
 smid=int(sys.argv[3])         #ID des Zählers im Wechselrichter (Hauptzähler 0, weitere fortlaufend)
 
 answer = json.loads(str(urllib.request.urlopen("http://"+str(ipadr)+"/solar_api/v1/GetMeterRealtimeData.cgi?Scope=Device&DeviceID="+str(smid), timeout=3).read().decode("utf-8")))
-aktpower = answer['Body']['Data']['PowerReal_P_Sum']*-1
+power = answer['Body']['Data']['PowerReal_P_Sum']
 powerc = answer['Body']['Data']['EnergyReal_WAC_Sum_Consumed']
+power = abs(aktpower)
+powerc = abs(powerc)
 
-answer = '{"power":' + str(aktpower) + ',"powerc":' + str(powerc)  + '} '
+answer = '{"power":' + str(power) + ',"powerc":' + str(powerc)  + '} '
 f1 = open('/var/www/html/openWB/ramdisk/smarthome_device_ret' + str(devicenumber), 'w')
 json.dump(answer,f1)
 f1.close()

--- a/modules/smarthome/fronius/watt.py
+++ b/modules/smarthome/fronius/watt.py
@@ -16,13 +16,7 @@ answer = json.loads(str(urllib.request.urlopen("http://"+str(ipadr)+"/solar_api/
 aktpower = answer['Body']['Data']['PowerReal_P_Sum']*-1
 powerc = answer['Body']['Data']['EnergyReal_WAC_Sum_Consumed']
 
-#if aktpower > 50:
-#    relais = 1
-#else:
-#    relais = 0
-
 answer = '{"power":' + str(aktpower) + ',"powerc":' + str(powerc)  + '} '
-#answer = '{"power":' + str(aktpower) + ',"powerc":' + str(powerc) + ',"on":' + str(relais) + '} '
 f1 = open('/var/www/html/openWB/ramdisk/smarthome_device_ret' + str(devicenumber), 'w')
 json.dump(answer,f1)
 f1.close()


### PR DESCRIPTION
Falls ein Verbraucherzähler an einen Fronius Wechselrichter angeschlossen ist, kann dieses Modul die Daten dieses Zählers aus dem Wechselrichter auslesen, um sie im Graph und im Logging abzubilden.
Nützlich um bestehende Installationen einzubinden, z.B. Heizstäbe oder andere Verbraucher.

Fronius Smart Meter -> [Modbus] -> Fronius Wechselrichter -> [json] -> OpenWB

Argumente:
devicenumber: ID des Verbrauchers in der openWB
ipadr: IP-Adresse des Fronius Wechselrichters
smid: ID des Verbraucherzählers im Wechselrichter (normalerweise Hauptzähler 0, weitere fortlaufend)

Rückgabewerte:
power in Watt
powerc in Wattstunden