### PR TITLE
Victron WR Skript befaehigen auch andere Mppt und alle AC gekoppelten PV Wechselrichter auszulesen

### DIFF
--- a/modules/wr2_victron/victron.py
+++ b/modules/wr2_victron/victron.py
@@ -1,3 +1,4 @@
+
 #!/usr/bin/python
 import sys
 import os
@@ -9,20 +10,57 @@ import struct
 import binascii
 from pymodbus.constants import Endian
 from pymodbus.payload import BinaryPayloadDecoder
+from pymodbus.client.sync import ModbusTcpClient
 ipaddress = str(sys.argv[1])
 mid = int(sys.argv[2])
-from pymodbus.client.sync import ModbusTcpClient
 client = ModbusTcpClient(ipaddress, port=502)
 connection = client.connect()
 
+#PV-AC-coupled on output L1
+resp = client.read_holding_registers(808, 1, unit=mid)
+decoder = BinaryPayloadDecoder.fromRegisters(resp.registers, byteorder=Endian.Big, wordorder=Endian.Big)
+ac_output_L1_str = str(decoder.decode_16bit_uint())
+ac_output_L1 = int(ac_output_L1_str) * -1
 
-#mppt watt
-resp= client.read_holding_registers(789,1,unit=mid)
-decoder = BinaryPayloadDecoder.fromRegisters(resp.registers,byteorder=Endian.Big,wordorder=Endian.Big)
-mpp_watt1 = str(decoder.decode_16bit_uint())
-mpp_watt2 = int(mpp_watt1) / 10 * -1
+#PV-AC-coupled on output L2
+resp = client.read_holding_registers(809, 1, unit=mid)
+decoder = BinaryPayloadDecoder.fromRegisters(resp.registers, byteorder=Endian.Big, wordorder=Endian.Big)
+ac_output_L2_str = str(decoder.decode_16bit_uint())
+ac_output_L2 = int(ac_output_L2_str) * -1
+
+#PV-AC-coupled on output L3
+resp = client.read_holding_registers(810, 1, unit=mid)
+decoder = BinaryPayloadDecoder.fromRegisters(resp.registers, byteorder=Endian.Big, wordorder=Endian.Big)
+ac_output_L3_str = str(decoder.decode_16bit_uint())
+ac_output_L3 = int(ac_output_L3_str) * -1
+
+#PV-AC-coupled on input L1
+resp = client.read_holding_registers(811, 1, unit=mid)
+decoder = BinaryPayloadDecoder.fromRegisters(resp.registers, byteorder=Endian.Big, wordorder=Endian.Big)
+ac_input_L1_str = str(decoder.decode_16bit_uint())
+ac_input_L1 = int(ac_input_L1_str) * -1
+
+#PV-AC-coupled on input L2
+resp = client.read_holding_registers(812, 1, unit=mid)
+decoder = BinaryPayloadDecoder.fromRegisters(resp.registers, byteorder=Endian.Big, wordorder=Endian.Big)
+ac_input_L2_str = str(decoder.decode_16bit_uint())
+ac_input_L2 = int(ac_input_L2_str) * -1
+
+#PV-AC-coupled on input L3
+resp = client.read_holding_registers(813, 1, unit=mid)
+decoder = BinaryPayloadDecoder.fromRegisters(resp.registers, byteorder=Endian.Big, wordorder=Endian.Big)
+ac_input_L3_str = str(decoder.decode_16bit_uint())
+ac_input_L3 = int(ac_input_L3_str) * -1
+
+#System PV - DC-coupled power
+resp = client.read_holding_registers(850, 1, unit=mid)
+decoder = BinaryPayloadDecoder.fromRegisters(resp.registers, byteorder=Endian.Big, wordorder=Endian.Big)
+dc_power_str = str(decoder.decode_16bit_uint())
+dc_power = int(dc_power_str) * -1
+
+watt = ac_output_L1 + ac_output_L2 + ac_output_L3 + ac_input_L1 + ac_input_L2 + ac_input_L3 + dc_power
 f = open('/var/www/html/openWB/ramdisk/pv2watt', 'w')
-f.write(str(mpp_watt2))
+f.write(str(watt))
 f.close()
 
 client.close()


### PR DESCRIPTION
Statt einzelnen Laderegler VictronMPPT abzufragen wird die Gesamtleistung DC gekoppleter VictronMPPTs abgefragt. 
Zusätzlich werden ALLE AC-gekoppelten PV Wechselrichter welche über Zähler oder Kommunikation (Fronius/SMA) angeschlossen sind aus dem VenusOS gelesen.
Damit kann OpenWB Victron Module jetzt die gesamte PV Erzeugung eines VenusOS auslesen.