### PR TITLE
Möglichkeit mehrere MQTT-Brücken einzurichten

### DIFF
--- a/web/settings/mqtt.php
+++ b/web/settings/mqtt.php
@@ -48,14 +48,13 @@
 		?>
 		<div id="nav"></div> <!-- placeholder for navbar -->
 		<div role="main" class="container" style="margin-top:20px">
-			<h1>MQTT-Brücke</h1>
 			<?php
 				$files = glob('/etc/mosquitto/conf.d/99-bridge-*.conf*');
-				if (count($files) == 0) {
-					array_push($files, "");
-				}
+                $filesCount = count($files);
+                // give the user the option to configure more than one bridge
+				array_push($files, "");
 
-				$firstLoopDone = false;
+				$loopCount = 0;
 				foreach($files as $currentFile)
 				{
 					$currentBridge = preg_replace('/^99-bridge-(.+)\.conf/', '${1}', $currentFile);
@@ -129,9 +128,10 @@
 						}
 					}
 
-					if ($firstLoopDone) echo "<hr>";
+					if ($loopCount != 0) echo "<hr>";
 			?>
-			<form action="./tools/savemqtt.php" method="POST">
+			<h1> <?php if($loopCount != $filesCount) echo "MQTT-Brücke $connectionName"; else echo "Neue MQTT-Brücke"; ?></h1>
+            <form action="./tools/savemqtt.php" method="POST">
 				<!-- previous bridge name, needed for renaming a bridge -->
 				<input type="hidden" readonly="readonly" name="bridge" value="<?php echo($connectionName); ?>">
 
@@ -168,7 +168,7 @@
 							<div class="col">
 								<input class="form-control" type="text" size="35" name="ConnectionName" id="ConnectionName" pattern="^[a-zA-Z0-9]+$" value="<?php echo $connectionName; ?>">
 								<span class="form-text small">Der Name darf nur aus Buchstaben und Zahlen bestehen, keine Sonderzeichen oder Umlaute.</span>
-								<?php if($debugold >= 1) echo "<small>in Datei '$currentFile'</small>"; ?>
+								<?php if($debugold >= 1) echo "<small>Config-File befindet sich in Datei '$currentFile'</small>"; ?>
 							</div>
 						</div>
 						<div class="form-row mb-1">
@@ -325,7 +325,7 @@
 
 			</form>
 			<?php
-					$firstLoopDone = true;
+					$loopCount++;
 				}
 			?>
 

--- a/web/settings/mqtt.php
+++ b/web/settings/mqtt.php
@@ -51,7 +51,7 @@
 			<?php
 				$files = glob('/etc/mosquitto/conf.d/99-bridge-*.conf*');
 				$filesCount = count($files);
-                		// give the user the option to configure more than one bridge
+				// give the user the option to configure more than one bridge
 				array_push($files, "");
 
 				$loopCount = 0;
@@ -130,8 +130,8 @@
 
 					if ($loopCount != 0) echo "<hr>";
 			?>
-			<h1> <?php if($loopCount != $filesCount) echo "MQTT-Brücke $connectionName"; else echo "Neue MQTT-Brücke"; ?></h1>
-           		<form action="./tools/savemqtt.php" method="POST">
+			<h1> <?php if($loopCount != $filesCount) echo "MQTT-Brücke \"$connectionName\""; else echo "Neue MQTT-Brücke"; ?></h1>
+			<form action="./tools/savemqtt.php" method="POST">
 				<!-- previous bridge name, needed for renaming a bridge -->
 				<input type="hidden" readonly="readonly" name="bridge" value="<?php echo($connectionName); ?>">
 

--- a/web/settings/mqtt.php
+++ b/web/settings/mqtt.php
@@ -50,8 +50,8 @@
 		<div role="main" class="container" style="margin-top:20px">
 			<?php
 				$files = glob('/etc/mosquitto/conf.d/99-bridge-*.conf*');
-                $filesCount = count($files);
-                // give the user the option to configure more than one bridge
+                		$filesCount = count($files);
+                		// give the user the option to configure more than one bridge
 				array_push($files, "");
 
 				$loopCount = 0;
@@ -131,7 +131,7 @@
 					if ($loopCount != 0) echo "<hr>";
 			?>
 			<h1> <?php if($loopCount != $filesCount) echo "MQTT-Brücke $connectionName"; else echo "Neue MQTT-Brücke"; ?></h1>
-            <form action="./tools/savemqtt.php" method="POST">
+           		<form action="./tools/savemqtt.php" method="POST">
 				<!-- previous bridge name, needed for renaming a bridge -->
 				<input type="hidden" readonly="readonly" name="bridge" value="<?php echo($connectionName); ?>">
 

--- a/web/settings/mqtt.php
+++ b/web/settings/mqtt.php
@@ -50,7 +50,7 @@
 		<div role="main" class="container" style="margin-top:20px">
 			<?php
 				$files = glob('/etc/mosquitto/conf.d/99-bridge-*.conf*');
-                		$filesCount = count($files);
+				$filesCount = count($files);
                 		// give the user the option to configure more than one bridge
 				array_push($files, "");
 

--- a/web/tools/savemqtt.php
+++ b/web/tools/savemqtt.php
@@ -26,7 +26,7 @@ function debugPrint($message){
 }
 
 function cleanAndExit($message){
-    // delete bridges-to-delete file, so that a bridge can't be deleted accidentally
+    	// delete bridges-to-delete file, so that a bridge can't be deleted accidentally
 	$fileToClean = "/var/www/html/openWB/ramdisk/99-bridgesToDelete";
 	if(is_writable($fileToClean)){
 		debugPrint("deleting $fileToClean");

--- a/web/tools/savemqtt.php
+++ b/web/tools/savemqtt.php
@@ -26,7 +26,7 @@ function debugPrint($message){
 }
 
 function cleanAndExit($message){
-    	// delete bridges-to-delete file, so that a bridge can't be deleted accidentally
+	// delete bridges-to-delete file, so that a bridge can't be deleted accidentally
 	$fileToClean = "/var/www/html/openWB/ramdisk/99-bridgesToDelete";
 	if(is_writable($fileToClean)){
 		debugPrint("deleting $fileToClean");

--- a/web/tools/savemqtt.php
+++ b/web/tools/savemqtt.php
@@ -25,6 +25,16 @@ function debugPrint($message){
 	}
 }
 
+function cleanAndExit($message){
+    // delete bridges-to-delete file, so that a bridge can't be deleted accidentally
+	$fileToClean = "/var/www/html/openWB/ramdisk/99-bridgesToDelete";
+	if(is_writable($fileToClean)){
+		debugPrint("deleting $fileToClean");
+		unlink($fileToClean);
+	}
+	exit($message);
+}
+
 if( $debug ){ ?>
 		<h3>Request parameters:</h3>
 		<pre>
@@ -36,8 +46,7 @@ if( $debug ){ ?>
 // validate bridge name and check if it had already been configured and
 // if it has already been configured, whether it has been enabled or disabled
 //
-parse_str($_SERVER['QUERY_STRING'], $queryArray);
-$previousBridgeName = $queryArray['bridge'];
+$previousBridgeName = $_POST['bridge'];
 
 debugPrint("Previous bridge name: '$previousBridgeName'");
 
@@ -45,11 +54,11 @@ $bridgeToConfig = $_POST['ConnectionName'];
 
 if ($bridgeToConfig == "eindeutiger-verbindungs-bezeichner")
 {
-	exit("Bitte eine eindeutige Bezeichnung f&uuml;r die Verbindung vergeben.<br/>Verwende die &quot;Zur&uuml;ck&quot;-Funktion des Webbrowsers um zur&uuml;ck zum Formular zu kommen.");
+	cleanAndExit("Bitte eine eindeutige Bezeichnung f&uuml;r die Verbindung vergeben.<br/>Verwende die &quot;Zur&uuml;ck&quot;-Funktion des Webbrowsers um zur&uuml;ck zum Formular zu kommen.");
 }
 
 if(!preg_match('/^[a-zA-Z0-9]+$/', $bridgeToConfig)) {
-	exit("Der Bezeichener f&uuml;r die Bridge ('" . htmlentities($bridgeToConfig) . "') enth&auml;t ung&uuml;tige Zeichen. Nur a-z, A-Z, 0-9 sind erlaubt.<br/>Verwende die &quot;Zur&uuml;ck&quot;-Funktion des Webbrowsers um zur&uuml;ck zum Formular zu kommen.");
+	cleanAndExit("Der Bezeichener f&uuml;r die Bridge ('" . htmlentities($bridgeToConfig) . "') enth&auml;t ung&uuml;tige Zeichen. Nur a-z, A-Z, 0-9 sind erlaubt.<br/>Verwende die &quot;Zur&uuml;ck&quot;-Funktion des Webbrowsers um zur&uuml;ck zum Formular zu kommen.");
 }
 
 debugPrint("Bridge to configure: '$bridgeToConfig'");
@@ -67,7 +76,7 @@ if ($previousBridgeName != $bridgeToConfig) {
 	foreach($files as $currentFile) {
 		if (strpos($currentFile, $previousBridgeName) !== false) {
 			//// print "Renaming bridge: Adding '$currentFile' to delete list<br/>";
-			file_put_contents("/var/www/html/openWB/ramdisk/99-bridgesToDelete", $currentFile, FILE_APPEND);
+			file_put_contents("/var/www/html/openWB/ramdisk/99-bridgesToDelete", "$currentFile\n", FILE_APPEND);
 		}
 	}
 }
@@ -88,7 +97,7 @@ $len = strlen($bridgeFileName);
 foreach($files as $currentFile) {
 	if (strpos($currentFile, $bridgeFileName) !== false) {
 		debugPrint("Deleting: $currentFile");
-		file_put_contents("/var/www/html/openWB/ramdisk/99-bridgesToDelete", $currentFile, FILE_APPEND);
+    file_put_contents("/var/www/html/openWB/ramdisk/99-bridgesToDelete", "$currentFile\n", FILE_APPEND);
 	}
 }
 
@@ -117,16 +126,16 @@ debugPrint("Bridge file name for new config: '$fileToUseForNewConfig'");
 
 $remoteHost = $_POST['RemoteAddress'];
 if ($remoteHost == "entfernter.mqtt.host:8883") {
-	exit("Bitte die Adresse und den Port des entfernten MQTT-Servers setzen.<br/>Verwende die &quot;Zur&uuml;ck&quot;-Funktion des Webbrowsers um zur&uuml;ck zum Formular zu kommen.");
+	cleanAndExit("Bitte die Adresse und den Port des entfernten MQTT-Servers setzen.<br/>Verwende die &quot;Zur&uuml;ck&quot;-Funktion des Webbrowsers um zur&uuml;ck zum Formular zu kommen.");
 }
 if(!preg_match('/^([a-zA-Z0-9][a-zA-Z0-9.-]+):([1-9][0-9]*)$/', $remoteHost, $matches)) {
-	exit("Der Bezeichener f&uuml;r den Namen oder die IP Adresse des entfernten MQTT-Servers ('" . htmlentities($remoteHost) . "') enth&auml;t ung&uuml;tige Zeichen. Nur a-z, A-Z, 0-9 und Punkt sind vor dem Doppelpunkt erlaubt. Nach dem Doppelpunkt sind nur noch Ziffern 0-9 erlaubt.<br/>Verwende die &quot;Zur&uuml;ck&quot;-Funktion des Webbrowsers um zur&uuml;ck zum Formular zu kommen.");
+	cleanAndExit("Der Bezeichener f&uuml;r den Namen oder die IP Adresse des entfernten MQTT-Servers ('" . htmlentities($remoteHost) . "') enth&auml;t ung&uuml;tige Zeichen. Nur a-z, A-Z, 0-9 und Punkt sind vor dem Doppelpunkt erlaubt. Nach dem Doppelpunkt sind nur noch Ziffern 0-9 erlaubt.<br/>Verwende die &quot;Zur&uuml;ck&quot;-Funktion des Webbrowsers um zur&uuml;ck zum Formular zu kommen.");
 }
 
 $hostOrAddress = $matches[1];
 $port = $matches[2];
 if (!isset($hostOrAddress) || empty($hostOrAddress)) {
-	exit ("Die Address oder der Namen des entfernten MQTT-Servers ('" . htmlentities($hostOrAddress) . "') ist ung&uuml;tig oder nicht vorhanden.<br/>Verwende die &quot;Zur&uuml;ck&quot;-Funktion des Webbrowsers um zur&uuml;ck zum Formular zu kommen.");
+	cleanAndExit ("Die Address oder der Namen des entfernten MQTT-Servers ('" . htmlentities($hostOrAddress) . "') ist ung&uuml;tig oder nicht vorhanden.<br/>Verwende die &quot;Zur&uuml;ck&quot;-Funktion des Webbrowsers um zur&uuml;ck zum Formular zu kommen.");
 }
 
 if (!isset($port) || empty($port)) {
@@ -137,38 +146,38 @@ debugPrint("HostOrAddress '$hostOrAddress', Port '$port'");
 
 $remoteUser = $_POST['RemoteUser'];
 if ($remoteUser == "nutzername-auf-dem-entfernten-host") {
-	exit("Bitte einen Benutzernamen f&uuml;r den entfernten MQTT-Servers setzen.<br/>Verwende die &quot;Zur&uuml;ck&quot;-Funktion des Webbrowsers um zur&uuml;ck zum Formular zu kommen.");
+	cleanAndExit("Bitte einen Benutzernamen f&uuml;r den entfernten MQTT-Servers setzen.<br/>Verwende die &quot;Zur&uuml;ck&quot;-Funktion des Webbrowsers um zur&uuml;ck zum Formular zu kommen.");
 }
 if(!preg_match('/^([a-zA-Z0-9_\-+.]+)$/', $remoteUser)) {
-	exit("Der Bezeichener f&uuml;r den Benutzer auf dem entfernten MQTT-Servers ('" . htmlentities($remoteUser) . "') enth&auml;t ung&uuml;tige Zeichen. Nur a-z, A-Z, 0-9, Punkt, Unterstrich, Minus und Plus sind erlaubt.<br/>Verwende die &quot;Zur&uuml;ck&quot;-Funktion des Webbrowsers um zur&uuml;ck zum Formular zu kommen.");
+	cleanAndExit("Der Bezeichener f&uuml;r den Benutzer auf dem entfernten MQTT-Servers ('" . htmlentities($remoteUser) . "') enth&auml;t ung&uuml;tige Zeichen. Nur a-z, A-Z, 0-9, Punkt, Unterstrich, Minus und Plus sind erlaubt.<br/>Verwende die &quot;Zur&uuml;ck&quot;-Funktion des Webbrowsers um zur&uuml;ck zum Formular zu kommen.");
 }
 
 debugPrint("RemoteUser: '$remoteUser'");
 
 $remotePass = $_POST['RemotePass'];
 if(!isset($remotePass) || empty($remotePass)) {
-	exit("Ung&uuml;tiges Pa&szlig;wort: Nicht vorhanden oder leer.<br/>Verwende die &quot;Zur&uuml;ck&quot;-Funktion des Webbrowsers um zur&uuml;ck zum Formular zu kommen.");
+	cleanAndExit("Ung&uuml;tiges Pa&szlig;wort: Nicht vorhanden oder leer.<br/>Verwende die &quot;Zur&uuml;ck&quot;-Funktion des Webbrowsers um zur&uuml;ck zum Formular zu kommen.");
 }
 
 debugPrint("RemotePass: <em>&gt;vorhanden&lt;</em>");
 
 $remotePrefix = $_POST['RemotePrefix'];
 if(!preg_match('/^[a-zA-Z0-9_\-\/]+$/', $remotePrefix)) {
-	exit("Der Bezeichener f&uuml;r den Topic-Pr&auml;fix auf dem entfernten MQTT-Server ('" . htmlentities($remotePrefix) . "') enth&auml;t ung&uuml;tige Zeichen. Nur a-z, A-Z, 0-9, Unterstrich, Schr&auml;gstrich und Minus sind erlaubt.<br/>Verwende die &quot;Zur&uuml;ck&quot;-Funktion des Webbrowsers um zur&uuml;ck zum Formular zu kommen.");
+	cleanAndExit("Der Bezeichener f&uuml;r den Topic-Pr&auml;fix auf dem entfernten MQTT-Server ('" . htmlentities($remotePrefix) . "') enth&auml;t ung&uuml;tige Zeichen. Nur a-z, A-Z, 0-9, Unterstrich, Schr&auml;gstrich und Minus sind erlaubt.<br/>Verwende die &quot;Zur&uuml;ck&quot;-Funktion des Webbrowsers um zur&uuml;ck zum Formular zu kommen.");
 }
 
 debugPrint("RemotePrefix: $remotePrefix");
 
 $mqttProtocol = $_POST['mqttProtocol'];
 if(!preg_match('/^(mqttv31|mqttv311)$/', $mqttProtocol)) {
-	exit("Interner Fehler: Ung&uuml;tiges MQTT Protokoll '" . htmlentities($mqttProtocol) . "'");
+	cleanAndExit("Interner Fehler: Ung&uuml;tiges MQTT Protokoll '" . htmlentities($mqttProtocol) . "'");
 }
 
 debugPrint("MQTT protocol: '$mqttProtocol'");
 
 $tlsProtocol = $_POST['tlsProtocol'];
 if(!preg_match('/^(tlsv1.2|tlsv1.3)$/', $tlsProtocol)) {
-	exit("Interner Fehler: Ung&uuml;tiges TLS Protokoll '" . htmlentities($tlsProtocol) . "'");
+	cleanAndExit("Interner Fehler: Ung&uuml;tiges TLS Protokoll '" . htmlentities($tlsProtocol) . "'");
 }
 
 $exportStatus = isset($_POST['exportStatus']) && ($_POST['exportStatus'] == 1);
@@ -176,7 +185,7 @@ $exportGraph = isset($_POST['exportGraph']) && ($_POST['exportGraph'] == 1);
 $subscribeConfigs = isset($_POST['subscribeConfigs']) && ($_POST['subscribeConfigs'] == 1);
 
 if (!$exportStatus && !$exportGraph && !$subscribeConfigs) {
-	exit("Es macht keinen Sinn eine MQTT-Br&uuml;cke zu konfigurieren welche weder Daten publiziert noch Konfigurationen empf&auml;ngt.<br/>Bitte mindestens eine Checkbox bei 'Zum entfernten Server weiterleiten' oder 'Konfiguration der openWB durch entfernten Server erm&ouml;glichen' aktivieren.<br/>Verwende die &quot;Zur&uuml;ck&quot;-Funktion des Webbrowsers um zur&uuml;ck zum Formular zu kommen.");
+	cleanAndExit("Es macht keinen Sinn eine MQTT-Br&uuml;cke zu konfigurieren welche weder Daten publiziert noch Konfigurationen empf&auml;ngt.<br/>Bitte mindestens eine Checkbox bei 'Zum entfernten Server weiterleiten' oder 'Konfiguration der openWB durch entfernten Server erm&ouml;glichen' aktivieren.<br/>Verwende die &quot;Zur&uuml;ck&quot;-Funktion des Webbrowsers um zur&uuml;ck zum Formular zu kommen.");
 }
 
 //
@@ -184,7 +193,7 @@ if (!$exportStatus && !$exportGraph && !$subscribeConfigs) {
 //
 $configFile = fopen($fileToUseForNewConfig, 'w');
 if (!$configFile) {
-	exit("Interner Fehler: Kann die Konfigurationsdatei f&uuml;r die Br&uuml;cke nicht erzeugen.");
+	cleanAndExit("Interner Fehler: Kann die Konfigurationsdatei f&uuml;r die Br&uuml;cke nicht erzeugen.");
 }
 
 debugPrint("Openend '$fileToUseForNewConfig' and now writing configuration to it");

--- a/web/tools/savemqtt.php
+++ b/web/tools/savemqtt.php
@@ -97,7 +97,7 @@ $len = strlen($bridgeFileName);
 foreach($files as $currentFile) {
 	if (strpos($currentFile, $bridgeFileName) !== false) {
 		debugPrint("Deleting: $currentFile");
-    file_put_contents("/var/www/html/openWB/ramdisk/99-bridgesToDelete", "$currentFile\n", FILE_APPEND);
+		file_put_contents("/var/www/html/openWB/ramdisk/99-bridgesToDelete", "$currentFile\n", FILE_APPEND);
 	}
 }
 


### PR DESCRIPTION
Der Code war ja eigentlich größtenteils schon darauf ausgelegt mit mehreren Brücken zu arbeiten, hat man das bewusst entfernt?

Die Änderung zeigt jetzt einfach immer eine Eingabemaske für eine neue Brücke an, egal wie viele Brücken schon konfiguriert sind.

Das CleanAndExit war nötig, falls:
- Der User Brücke A ungültig ändert und eine Fehlermeldung bekommt
- Der User dann zurück geht auf die Einstellungsseite
- Der User jetzt Brücke B gültig bearbeitet
--> beide Brücken sind gelöscht worden