### PR TITLE
Update curl call to support password with spaces

### DIFF
--- a/modules/bezug_discovergy/main.sh
+++ b/modules/bezug_discovergy/main.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-output=$(curl --connect-timeout 3 -s -u $discovergyuser:$discovergypass "https://api.discovergy.com/public/v1/last_reading?meterId=$discovergyevuid")
+output=$(curl --connect-timeout 3 -s -u $discovergyuser:"$discovergypass" "https://api.discovergy.com/public/v1/last_reading?meterId=$discovergyevuid")
 
 einspeisungwh=$(echo $output | jq .values.energyOut)
 einspeisungwh=$(( einspeisungwh / 10000000 ))


### PR DESCRIPTION
Just added "" to the password variable to support spaces in password.
Tested on command line, outside of openWB.