### PR TITLE
Update curl call to support spaces in password

### DIFF
--- a/modules/wr_discovergy/main.sh
+++ b/modules/wr_discovergy/main.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-output=$(curl --connect-timeout 5 -s -u $discovergyuser:$discovergypass "https://api.discovergy.com/public/v1/last_reading?meterId=$discovergypvid")
+output=$(curl --connect-timeout 5 -s -u $discovergyuser:"$discovergypass" "https://api.discovergy.com/public/v1/last_reading?meterId=$discovergypvid")
 
 pvwh=$(echo $output | jq .values.energyOut)
 pvwh=$(( pvwh / 10000000 ))


### PR DESCRIPTION
Just added "" to the password variable to support spaces in password.
Tested on command line, outside of openWB.