### PR TITLE
avmhomeautomation: Allow voltage to be unavailable

### DIFF
--- a/modules/smarthome/avmhomeautomation/avmcommon.py
+++ b/modules/smarthome/avmhomeautomation/avmcommon.py
@@ -219,7 +219,9 @@ class AVMHomeAutomation:
                     # AVM returns mW, convert to W here
                     next_device_infos[name]['power'] = float(powermeterBlock.find("power").text)/1000.0
                     # AVM returns mV, convert to V here
-                    next_device_infos[name]['voltage'] = float(powermeterBlock.find("voltage").text)/1000.0
+                    voltageInfo = powermeterBlock.find("voltage")
+                    if voltageInfo != None:
+                        next_device_infos[name]['voltage'] = float(voltageInfo.text)/1000.0
                     # AVM returns Wh
                     next_device_infos[name]['energy'] = powermeterBlock.find("energy").text 
 


### PR DESCRIPTION
FritzOS versions before 6.98 do not include voltage values in
the getdevicelistinfos API call we use in this module.