### PR TITLE
Update PSA SoC

### DIFF
--- a/runs/updateConfig.sh
+++ b/runs/updateConfig.sh
@@ -1764,6 +1764,12 @@ updateConfig(){
 		echo "psa_clientidlp2=ID" >> $ConfigFile
 		echo "psa_clientsecretlp2=Secret" >> $ConfigFile
 	fi
+	if ! grep -Fq "psa_intervallp1=" $ConfigFile; then
+		echo "psa_intervallp1=10" >> $ConfigFile
+	fi
+	if ! grep -Fq "psa_intervallp2=" $ConfigFile; then
+		echo "psa_intervallp2=10" >> $ConfigFile
+	fi
 	if ! grep -Fq "soc_eq_client_id_lp1=" $ConfigFile; then
 		echo "soc_eq_client_id_lp1=ID" >> $ConfigFile
 		echo "soc_eq_client_secret_lp1=Secret" >> $ConfigFile

--- a/web/settings/modulconfiglp.php
+++ b/web/settings/modulconfiglp.php
@@ -1555,6 +1555,15 @@
 										</div>
 									</div>
 									<div class="form-row mb-1">
+										<label for="psa_intervallp1" class="col-md-4 col-form-label">Abfrageintervall</label>
+										<div class="col">
+											<input class="form-control" type="number" min="1" step="1" name="psa_intervallp1" id="psa_intervallp1" value="<?php echo $psa_intervallp1old ?>">
+											<span class="form-text small">
+												Wie oft abgefragt wird. Angabe in Minuten.
+											</span>
+										</div>
+									</div>
+									<div class="form-row mb-1">
 									<label class="col-md-4 col-form-label">Kombiniere PSA SoC Modul und manuelle Berechnung</label>
 										<div class="col">
 											<div class="btn-group btn-group-toggle btn-block" data-toggle="buttons">
@@ -3092,6 +3101,15 @@
 										<label for="psa_clientsecretlp2" class="col-md-4 col-form-label">Client-Secret</label>
 										<div class="col">
 											<input class="form-control" type="text" name="psa_clientsecretlp2" id="psa_clientsecretlp2" value="<?php echo $psa_clientsecretlp2old ?>">
+										</div>
+									</div>
+									<div class="form-row mb-1">
+										<label for="psa_intervallp2" class="col-md-4 col-form-label">Abfrageintervall</label>
+										<div class="col">
+											<input class="form-control" type="number" min="1" step="1" name="psa_intervallp2" id="psa_intervallp2" value="<?php echo $psa_intervallp2old ?>">
+											<span class="form-text small">
+												Wie oft abgefragt wird. Angabe in Minuten.
+											</span>
 										</div>
 									</div>
 									<div class="form-row mb-1">


### PR DESCRIPTION
- Dauerschleife der Onlineabfrage beseitigt, wenn der Abruf beim Ladestart fehlschlägt
- Der abgerufene SoC wird verworfen, wenn er gleich dem SoC vor Ladestart ist und der Wagen angesteckt ist (verhindert ein zurückfallen auf Startwert der Ladung, wenn falsche Werte geliefert werden)
- Der online abgerufene SoC wird auch übernommen, wenn er bis zu 90s älter ist als der bekannte SoC (verhindert, dass der Wert obwohl er korrekt ist nicht übernommen wird, wenn es eine geringe Uhrzeitabweichung zwischen Server und openWB gibt)
-Onlineabfrageintervall konfigurierbar