### PR TITLE
Starte Ladung in NurPV trotz Speichervorrang, wenn x%SoC überschritten

### DIFF
--- a/nurpv.sh
+++ b/nurpv.sh
@@ -102,6 +102,16 @@ nurpvlademodus(){
 			openwbDebugLog "CHARGESTAT" 0 "alle Ladepunkte, Lademodus NurPV. Ladung gestoppt"
 		fi
 		openwbDebugLog "MAIN" 1 "Überschuss $uberschuss; mindestens $mindestuberschussphasen"
+		if [[ $speichervorhanden == "1" ]]; then
+			if (( speicherleistung > 0 )); then
+				if (( speichersoc > speichersocnurpv )); then
+					uberschuss=$((uberschuss + speicherleistung + speicherwattnurpv))
+					openwbDebugLog "PV" 0 "SpeicherSoc ($speichersoc) über konfiguriertem Wert ($speichersocnurpv), neuer Überschusswert: $uberschuss"
+				else
+					openwbDebugLog "PV" 0 "SpeicherSoc ($speichersoc) unter konfiguriertem Wert ($speichersocnurpv), neuer/alter Überschusswert: $uberschuss"
+				fi
+			fi
+		fi
 		if (( mindestuberschussphasen <= uberschuss )); then
 			openwbDebugLog "PV" 0 "Überschuss $uberschuss ist größer als nötiger Überschuss, Wert: $mindestuberschussphasen"
 			pvecounter=$(cat /var/www/html/openWB/ramdisk/pvecounter)


### PR DESCRIPTION
Der Parameter wird aktuell nur genutzt, um auch aus dem Speicher zu laden, sofern man oberhalb des eingestellten SoC ist und bereits im NurPV-Modus lädt. Hierzu müsste der Speicher dann einmal voll geladen werden, damit der Überschuss ausreicht, um NurPV zu starten. Anschließend würde man wieder aus dem Speicher laden, bis x%SoC runter.  
Mit dieser Änderung würde NurPV direkt starten, wenn x%SoC überschritten ist.