### PR TITLE
Korrektur Leistungsaufnahme abschaltbar

### DIFF
--- a/runs/smarthomehandler.py
+++ b/runs/smarthomehandler.py
@@ -611,7 +611,9 @@ def getdevicevalues():
                         logDebug(LOGLEVELDEBUG, "Device " + str(switchtyp) + str(numberOfDevices) + str(devicename) + " File not found: " + str(pyname))
                 # Separate Leistungs messung ?
                 (watt,wattk) = sepwatt(wattstart,wattkstart,numberOfDevices)
-                if abschalt == 1:
+                # nur abschaltbar wenn openwb in pv modus gesetzt hat
+                # elwa Warmwassersicherstellung Problem
+                if (abschalt == 1) and (relais == 1):
                     totalwatt = totalwatt + watt
                 else:
                     totalwattot = totalwattot + watt


### PR DESCRIPTION
Nur  Device (mit bei Autoladen ausstellen = Ja) die von Openwb aktiviert oder in Pv Modus gesetzt wurden bei der Berechnung der Leistungsaufnahme abschaltbar berücksichtigen