### PR TITLE
sommerzeit umstellungsproblem

### DIFF
--- a/runs/smarthomehandler.py
+++ b/runs/smarthomehandler.py
@@ -937,7 +937,7 @@ def resetmaxeinschaltdauerfunc():
                 resetmaxeinschaltdauer=1
         except:
             resetmaxeinschaltdauer=0
-    if (int(hour) == 2):
+    if (int(hour) == 1):
         resetmaxeinschaltdauer=0
 
 client = mqtt.Client("openWB-mqttsmarthome")


### PR DESCRIPTION
Die Tagescounter für alle devices werden einmalig um 0:00 zurückgestellt, zugleich wird ein Flag gesetzt das die Aktion für heute durchgeführt wurde. Ebenso wird genau um 2:00  dieses Flag zurückgesetzt, so dass am beginn vom nächsten Tag das zurücksetzten wieder erfolgen kann,. Da mit dem Wechsel auf Sommerzeit die Uhr von 2:00 auf 3:00 vorspringt, wurde das Flag per gestern nicht zurückgesetzt, so dass die Tageszähler heute falsch  sind. Das zurücksetzten vom Flag wird neu um 1:00 gemacht