### PR TITLE
Check for presence of WLAN before try to config it

### DIFF
--- a/runs/cron5min.sh
+++ b/runs/cron5min.sh
@@ -253,14 +253,18 @@ else
 	ethstate=$(</sys/class/net/eth0/carrier)
 	if (( ethstate == 1 )); then
 		sudo ifconfig eth0:0 192.168.193.5 netmask 255.255.255.0 up
-		sudo ifconfig wlan0:0 192.168.193.6 netmask 255.255.255.0 down
-		wlanstate=$(</sys/class/net/wlan0/carrier)
-		if (( wlanstate == 1 )); then
-			sudo systemctl stop hostapd
-			sudo systemctl stop dnsmasq
+		if [ -d /sys/class/net/wlan0 ]; then
+			sudo ifconfig wlan0:0 192.168.193.6 netmask 255.255.255.0 down
+			wlanstate=$(</sys/class/net/wlan0/carrier)
+			if (( wlanstate == 1 )); then
+				sudo systemctl stop hostapd
+				sudo systemctl stop dnsmasq
+			fi
 		fi
 	else
-		sudo ifconfig wlan0:0 192.168.193.6 netmask 255.255.255.0 up
+		if [ -d /sys/class/net/wlan0 ]; then
+			sudo ifconfig wlan0:0 192.168.193.6 netmask 255.255.255.0 up
+		fi
 		sudo ifconfig eth0:0 192.168.193.5 netmask 255.255.255.0 down
 	fi
 fi


### PR DESCRIPTION
If WLAN (and Bluetooth) is disabled (e.g. to reduce power consumption a bit) using `/boot/config.txt` entries
```
dtoverlay=pi3-disable-wifi
dtoverlay=pi3-disable-bt
```
the `cron5min.sh` issues errors like
```
SIOCSIFADDR: Kein passendes Gerät gefunden
wlan0:0: ERROR while getting interface flags: Kein passendes Gerät gefunden
SIOCSIFNETMASK: Kein passendes Gerät gefunden
wlan0:0: ERROR while getting interface flags: Kein passendes Gerät gefunden
/var/www/html/openWB/runs/cron5min.sh: Zeile 257: /sys/class/net/wlan0/carrier: Datei oder Verzeichnis nicht gefunden
```

While it's probably not the default setting of openWB, it might be helpful for manual installations w/o WLAN and it really shouldn't cause any harm for the default case (2 additional "if" conditions every 5 minutes).