### PR TITLE
Fix MQTT clients when a port number is specified.

### DIFF
--- a/web/display/cards/setupMqttServices.js
+++ b/web/display/cards/setupMqttServices.js
@@ -266,7 +266,7 @@ var options = {
 };
 
 var clientuid = Math.random().toString(36).replace(/[^a-z]+/g, "").substr(0, 5);
-var client = new Messaging.Client(location.host, 9001, clientuid);
+var client = new Messaging.Client(location.hostname, 9001, clientuid);
 
 $(document).ready(function(){
 	client.connect(options);

--- a/web/display/gauges/live.js
+++ b/web/display/gauges/live.js
@@ -228,7 +228,7 @@ function reloadDisplay() {
 }
 
 var clientuid = Math.random().toString(36).replace(/[^a-z]+/g, '').substr(0, 5);
-var client = new Messaging.Client(location.host, 9001, clientuid);
+var client = new Messaging.Client(location.hostname, 9001, clientuid);
 
 function handlevar(mqttmsg, mqttpayload, mqtttopic, htmldiv) {
 //console.log('new mqttmsg...');

--- a/web/display/minimal/setupMqttServices.js
+++ b/web/display/minimal/setupMqttServices.js
@@ -37,7 +37,7 @@ var options = {
 };
 
 var clientuid = Math.random().toString(36).replace(/[^a-z]+/g, "").substr(0, 5);
-var client = new Messaging.Client(location.host, 9001, clientuid);
+var client = new Messaging.Client(location.hostname, 9001, clientuid);
 
 $(document).ready(function(){
 	client.connect(options);

--- a/web/display/parentwb/setupMqttServices.js
+++ b/web/display/parentwb/setupMqttServices.js
@@ -38,7 +38,7 @@ var options = {
 };
 
 var clientuid = Math.random().toString(36).replace(/[^a-z]+/g, "").substr(0, 5);
-var client = new Messaging.Client(location.host, 9001, clientuid);
+var client = new Messaging.Client(location.hostname, 9001, clientuid);
 
 $(document).ready(function(){
 	client.connect(options);

--- a/web/display/simple/live.js
+++ b/web/display/simple/live.js
@@ -227,7 +227,7 @@ function reloadDisplay() {
 }
 
 var clientuid = Math.random().toString(36).replace(/[^a-z]+/g, '').substr(0, 5);
-var client = new Messaging.Client(location.host, 9001, clientuid);
+var client = new Messaging.Client(location.hostname, 9001, clientuid);
 
 function handlevar(mqttmsg, mqttpayload, mqtttopic, htmldiv) {
 //console.log('new mqttmsg...');

--- a/web/live.js
+++ b/web/live.js
@@ -212,7 +212,7 @@ function getCol(matrix, col){
 }
 
 var clientuid = Math.random().toString(36).replace(/[^a-z]+/g, '').substr(0, 5);
-var client = new Messaging.Client(location.host, 9001, clientuid);
+var client = new Messaging.Client(location.hostname, 9001, clientuid);
 
 function handlevar(mqttmsg, mqttpayload, mqtttopic, htmldiv) {
 //console.log('new mqttmsg...');

--- a/web/logging/chargelog/ladelog.js
+++ b/web/logging/chargelog/ladelog.js
@@ -339,7 +339,7 @@ function getCol(matrix, col){
 // run
 initLadelog();
 
-var client = new Messaging.Client(location.host,9001, clientuid);
+var client = new Messaging.Client(location.hostname,9001, clientuid);
 client.onMessageArrived = function (message) {
 	handlevar(message.destinationName, message.payloadString, thevalues[0], thevalues[1]);
 };

--- a/web/logging/dailychart.js
+++ b/web/logging/dailychart.js
@@ -145,7 +145,7 @@ var thevalues = [
 
 ];
 var clientuid = Math.random().toString(36).replace(/[^a-z]+/g, '').substr(0, 5);
-var client = new Messaging.Client(location.host, 9001, clientuid);
+var client = new Messaging.Client(location.hostname, 9001, clientuid);
 
 function handlevar(mqttmsg, mqttpayload) {
 	if ( mqttmsg.match( /^openWB\/config\/get\/SmartHome\/Devices\/[1-9][0-9]*\/device_name$/i ) ) {

--- a/web/logging/monthlychart.js
+++ b/web/logging/monthlychart.js
@@ -71,7 +71,7 @@ var graphMonth = graphDate.substring(4);
 var daysInMonth = new Date(graphYear, graphMonth, 0).getDate();
 
 var clientuid = Math.random().toString(36).replace(/[^a-z]+/g, '').substr(0, 5);
-var client = new Messaging.Client(location.host, 9001, clientuid);
+var client = new Messaging.Client(location.hostname, 9001, clientuid);
 
 function handlevar(mqttmsg, mqttpayload, mqtttopic, htmldiv) {
 	if ( mqttmsg.match( /^openWB\/config\/get\/SmartHome\/Devices\/[1-9][0-9]*\/device_name$/i ) ) {

--- a/web/logging/yearlychart.js
+++ b/web/logging/yearlychart.js
@@ -69,7 +69,7 @@ var graphNextYear = Number(graphDate) + 1;
 var monthsInYear = 12;
 
 var clientuid = Math.random().toString(36).replace(/[^a-z]+/g, '').substr(0, 5);
-var client = new Messaging.Client(location.host, 9001, clientuid);
+var client = new Messaging.Client(location.hostname, 9001, clientuid);
 
 function handlevar(mqttmsg, mqttpayload, mqtttopic, htmldiv) {
 	if ( mqttmsg.match( /^openWB\/config\/get\/SmartHome\/Devices\/[1-9][0-9]*\/device_name$/i ) ) {

--- a/web/settings/setupMqttServices.js
+++ b/web/settings/setupMqttServices.js
@@ -24,7 +24,7 @@ var options = {
 };
 
 var clientuid = Math.random().toString(36).replace(/[^a-z]+/g, "").substr(0, 5);
-var client = new Messaging.Client(location.host, 9001, clientuid);
+var client = new Messaging.Client(location.hostname, 9001, clientuid);
 
 $(document).ready(function(){
 	client.connect(options);

--- a/web/status/setupMqttServices.js
+++ b/web/status/setupMqttServices.js
@@ -244,7 +244,7 @@ var options = {
 };
 
 var clientuid = Math.random().toString(36).replace(/[^a-z]+/g, "").substr(0, 5);
-var client = new Messaging.Client(location.host, 9001, clientuid);
+var client = new Messaging.Client(location.hostname, 9001, clientuid);
 
 $(document).ready(function(){
 	client.connect(options);

--- a/web/themes/Gauges/setupMqttServices.js
+++ b/web/themes/Gauges/setupMqttServices.js
@@ -352,7 +352,7 @@ var options = {
 };
 
 var clientuid = Math.random().toString(36).replace(/[^a-z]+/g, "").substr(0, 5);
-var client = new Messaging.Client(location.host, 9001, clientuid);
+var client = new Messaging.Client(location.hostname, 9001, clientuid);
 
 $(document).ready(function(){
 	client.connect(options);

--- a/web/themes/colors/setupMqttServices.js
+++ b/web/themes/colors/setupMqttServices.js
@@ -394,7 +394,7 @@ var options = {
 };
 
 var clientuid = Math.random().toString(36).replace(/[^a-z]+/g, "").substr(0, 5);
-var client = new Messaging.Client(location.host, 9001, clientuid);
+var client = new Messaging.Client(location.hostname, 9001, clientuid);
 
 $(document).ready(function () {
 	client.connect(options);

--- a/web/themes/dark/setupMqttServices.js
+++ b/web/themes/dark/setupMqttServices.js
@@ -380,7 +380,7 @@ var options = {
 };
 
 var clientuid = Math.random().toString(36).replace(/[^a-z]+/g, "").substr(0, 5);
-var client = new Messaging.Client(location.host, 9001, clientuid);
+var client = new Messaging.Client(location.hostname, 9001, clientuid);
 
 $(document).ready(function(){
 	client.connect(options);


### PR DESCRIPTION
`location.host` includes the port number, so if one is specified, the resulting address is invalid as another port number is appended (hostname:port:9001). Use `location.hostname` instead.

This also allows to configure httpd to serve from a non-default port.