### PR TITLE
Avoid hardcoding 127.0.0.1:80

### DIFF
--- a/loadvars.sh
+++ b/loadvars.sh
@@ -1208,9 +1208,13 @@ loadvars(){
 		rfid
 	fi
 
-	dailychargelp1=$(curl -s -X POST -d "dailychargelp1call=loadfile" http://127.0.0.1:/openWB/web/tools/dailychargelp1.php | jq -r .text)
-	dailychargelp2=$(curl -s -X POST -d "dailychargelp2call=loadfile" http://127.0.0.1:/openWB/web/tools/dailychargelp2.php | jq -r .text)
-	dailychargelp3=$(curl -s -X POST -d "dailychargelp3call=loadfile" http://127.0.0.1:/openWB/web/tools/dailychargelp3.php | jq -r .text)
+	csvfile="/var/www/html/openWB/web/logging/data/daily/$(date +%Y%m%d).csv"
+	first=$(head -n 1 "$csvfile")
+	last=$(tail -n 1 "$csvfile")
+	dailychargelp1=$(echo "$(echo "$first" | cut -d , -f 5) $(echo "$last" | cut -d , -f 5)" | awk '{printf "%0.2f", ($2 - $1)/1000}')
+	dailychargelp2=$(echo "$(echo "$first" | cut -d , -f 6) $(echo "$last" | cut -d , -f 6)" | awk '{printf "%0.2f", ($2 - $1)/1000}')
+	dailychargelp3=$(echo "$(echo "$first" | cut -d , -f 7) $(echo "$last" | cut -d , -f 7)" | awk '{printf "%0.2f", ($2 - $1)/1000}')
+
 	restzeitlp1=$(<ramdisk/restzeitlp1)
 	restzeitlp2=$(<ramdisk/restzeitlp2)
 	restzeitlp3=$(<ramdisk/restzeitlp3)


### PR DESCRIPTION
Retrieve dailychargelp[1-3] by reading the CSV file from `loadvars.sh` instead of POSTing to 127.0.0.1:80 which doesn't work if httpd is serving from a different port.