### PR TITLE
fix backup and debug.log

### DIFF
--- a/runs/atreboot.sh
+++ b/runs/atreboot.sh
@@ -12,6 +12,8 @@ echo "loading config"
 . /var/www/html/openWB/runs/updateConfig.sh
 
 sleep 5
+mkdir -p /var/www/html/openWB/web/backup
+touch /var/www/html/openWB/web/backup/.donotdelete
 sudo chown -R www-data:www-data /var/www/html/openWB/web/backup
 sudo chown -R www-data:www-data /var/www/html/openWB/web/tools/upload
 sudo chmod 777 /var/www/html/openWB/openwb.conf

--- a/runs/cleanup.sh
+++ b/runs/cleanup.sh
@@ -1,4 +1,6 @@
 #!/bin/bash
-
-find /var/www/html/openWB/ramdisk/* -name "*.log" -type f -exec /var/www/html/openWB/runs/cleanupf.sh {} \;
-
+if [ ! -f /var/www/html/openWB/ramdisk/debuguser ]; then
+	find /var/www/html/openWB/ramdisk/* -name "*.log" -type f -exec /var/www/html/openWB/runs/cleanupf.sh {} \;
+else
+	echo "Skipping logfile cleanup as senddebug.sh is collecting data." >> /var/www/html/openWB/ramdisk/openwb.log
+fi

--- a/runs/senddebug.sh
+++ b/runs/senddebug.sh
@@ -32,12 +32,14 @@ for currentConfig in /etc/mosquitto/conf.d/99-bridge-*; do
 done
 
 echo "############################ config ##############" >> $debugFile
-grep -F -v -e soc_id_passwort -e leaf -e myopel_clientidlp2 -e soc_eq_client_secret_lp1 -e psa_clientsecretlp1 -e psa_clientsecretlp2 -e tibbertoken -e soc_eq_client_secret_lp2 -e myopel_clientsecretlp2 -e myopel_clientidlp1 -e myopel_clientsecretlp1 -e i3 -e zoeuser -e zoepass -e zoelp2 -e tesla -e socpass -e soc2pass -e passlp1 -e passlp2 -e carnet -e settingspw -e wrsunwayspw -e cloudpw -e wr_piko2_pass -e zerong -e discovergy -e audi -e smartme -e bydhvpass -e lgessv1pass -e myrenault -e bluelink -e soc_vag_passwort -e soc_id_vin /var/www/html/openWB/openwb.conf >> $debugFile
+grep -F -v -e soc_id_passwort -e leaf -e myopel_clientidlp2 -e soc_eq_client_secret_lp1 -e psa_clientsecretlp1 -e psa_clientsecretlp2 -e tibbertoken -e soc_eq_client_secret_lp2 -e myopel_clientsecretlp2 -e myopel_clientidlp1 -e myopel_clientsecretlp1 -e i3 -e zoeuser -e zoepass -e zoelp2 -e tesla -e socpass -e soc2pass -e passlp1 -e passlp2 -e carnet -e settingspw -e wrsunwayspw -e cloudpw -e wr_piko2_pass -e zerong -e discovergy -e audi -e smartme -e bydhvpass -e lgessv1pass -e myrenault -e bluelink -e soc_vag_passwort -e soc_id_vin -e soc_tronity_client_id_lp1 -e soc_tronity_client_id_lp2 -e soc_tronity_client_secret_lp1 -e soc_tronity_client_secret_lp2 -e soc_tronity_vehicle_id_lp1 -e soc_tronity_vehicle_id_lp2 /var/www/html/openWB/openwb.conf >> $debugFile
 
 timeout 1 mosquitto_sub -v -t openWB/# >> $debugFile
 echo "############################ smarthome.log ##############" >> $debugFile
 echo "$(cat /var/www/html/openWB/ramdisk/smarthome.log)" >> $debugFile
 
+echo "############################ file and directory listing ##############" >> $debugFile
+ls -lRa /var/www/html/openWB/* >> $debugFile
 
 curl --upload $debugFile https://openwb.de/tools/debug.php
 


### PR DESCRIPTION
- do not cleanup logfiles if senddebuglog is running (prevents incomplete debug files)
- create backup folder at reboot
- do not send tronity auth data in debuglog