### PR TITLE
fix fehlende SoC Datei nach Ladestart

### DIFF
--- a/modules/soc_manual/main.sh
+++ b/modules/soc_manual/main.sh
@@ -99,7 +99,7 @@ else
 		socDebugLog "currentMeterDiff: $currentMeterDiff"
 		currentEffectiveMeterDiff=$(echo "scale=5;$currentMeterDiff * $efficiency / 100" | bc)
 		socDebugLog "currentEffectiveMeterDiff: $currentEffectiveMeterDiff ($efficiency %)"
-		currentSocDiff=$(echo "scale=5;100 / $akkug * $currentEffectiveMeterDiff" | bc | sed 's/\..*$//')
+		currentSocDiff=$(echo "scale=5;100 / $akkug * $currentEffectiveMeterDiff" | bc | awk '{printf"%d\n",$1}')
 		socDebugLog "currentSocDiff: $currentSocDiff"
 		newSoc=$(echo "$manualSoc + $currentSocDiff" | bc)
 		if (( newSoc > 100 )); then

--- a/modules/soc_psa/main.sh
+++ b/modules/soc_psa/main.sh
@@ -200,7 +200,7 @@ else	# manual calculation enabled, combining PSA module with manual calc method
 				socDebugLog "currentMeterDiff: $currentMeterDiff"
 				currentEffectiveMeterDiff=$(echo "scale=5;$currentMeterDiff * $efficiency / 100" | bc)
 				socDebugLog "currentEffectiveMeterDiff: $currentEffectiveMeterDiff ($efficiency %)"
-				currentSocDiff=$(echo "scale=5;100 / $akkug * $currentEffectiveMeterDiff" | bc | sed 's/\..*$//')
+				currentSocDiff=$(echo "scale=5;100 / $akkug * $currentEffectiveMeterDiff" | bc | awk '{printf"%d\n",$1}')
 				socDebugLog "currentSocDiff: $currentSocDiff"
 				newSoc=$(echo "$manualSoc + $currentSocDiff" | bc)
 				if (( newSoc > 100 )); then


### PR DESCRIPTION
Bei Verwendung des man/calc und PSA+man/calc SoC Moduls wurde die SoC Datei erst geschrieben nachdem der SoC um einen Zähler erhöht wurde. Dies führt zu Lücken im Logging. 
Der bisher verwendete Weg über sed kommt mit Zahlen kleiner 1 nicht klar da diese nur als '.123' ausgegeben werden, nicht als '0.123'. Der Weg über awk löst dieses Problem.