### PR TITLE
Update pycarwings2.py

### DIFF
--- a/modules/soc_leaf/pycarwings2.py
+++ b/modules/soc_leaf/pycarwings2.py
@@ -118,7 +118,7 @@ class Session(object):
         else:
             params["custom_sessionid"] = ""
 
-        req = Request('POST', url=BASE_URL + endpoint, data=params).prepare()
+        req = Request('POST', url=BASE_URL + endpoint, data=params, headers={"User-Agent": "pycarwings2/2.10"}).prepare()
 
         log.debug("invoking carwings API: %s" % req.url)
         log.debug("params: %s" % json.dumps(


### PR DESCRIPTION
Seit Nov 2020 braucht es wohl einen user-agent Header in der Request (siehe https://github.com/filcole/pycarwings2/pull/24).
Ist der einzige Unterschied zur in OpenWB verwendeten Funktion. Sollte also auch für OpenWB das Problem lösen.
Bitte in eine der nächsten Releases einfließen lassen.