### PR TITLE
Solarwatt Modules use wrong variable for URL

### DIFF
--- a/modules/bezug_solarwatt/main.sh
+++ b/modules/bezug_solarwatt/main.sh
@@ -4,7 +4,8 @@
 
 
 
-sresponse=$(curl --connect-timeout 3 -s "http://$speichersolarwattip/rest/kiwigrid/wizard/devices")
+#sresponse=$(curl --connect-timeout 3 -s "http://$speichersolarwattip/rest/kiwigrid/wizard/devices")
+sresponse=$(curl --connect-timeout 3 -s "http://${speicher1_ip}/rest/kiwigrid/wizard/devices")
 
 #bezugwh=$(echo $sresponse | jq '.result.items | .[] | select(.tagValues.WorkConsumedFromGrid.value != null) | .tagValues.WorkConsumedFromGrid.value' | sed 's/\..*$//')
 #echo $bezugwh > /var/www/html/openWB/ramdisk/bezugkwh

--- a/modules/speicher_solarwatt/main.sh
+++ b/modules/speicher_solarwatt/main.sh
@@ -1,7 +1,12 @@
 #!/bin/bash
-#!/bin/bash
 
-sresponse=$(curl --connect-timeout 3 -s "http://$speichersolarwattip/rest/kiwigrid/wizard/devices")
+DMOD="MAIN"
+Debug=$debug
+
+openwbDebugLog ${DMOD} 1 "URL: ${speicher1_ip}/rest/kiwigrid/wizard/devices"
+sresponse=$(curl --connect-timeout 5 -s "http://${speicher1_ip}/rest/kiwigrid/wizard/devices")
+#sresponse=$(curl --connect-timeout 5 -s "http://192.168.178.64/rest/kiwigrid/wizard/devices")
+openwbDebugLog ${DMOD} 1 "Resp: $?"
 #pvwh=$(echo $sresponse | jq '.result.items | .[0].tagValues.WorkProduced.value')
 #echo "PV erzeugt $pvwh"
 #pvwatt=$(echo $sresponse | jq '.result.items | .[0].tagValues.PowerProduced.value')
@@ -16,12 +21,17 @@ sresponse=$(curl --connect-timeout 3 -s "http://$speichersolarwattip/rest/kiwigr
 #echo "Ins Netz eingespeist Gesamt $einspeisungwh" 
 
 speichere=$(echo $sresponse | jq '.result.items | .[] | select(.tagValues.PowerConsumedFromStorage.value != null) | .tagValues.PowerConsumedFromStorage.value' | sed 's/\..*$//') 
+openwbDebugLog ${DMOD} 1 "Speichere: ${speichere}"
 speicherein=$(echo $sresponse | jq '.result.items | .[] | select(.tagValues.PowerOutFromStorage.value != null) | .tagValues.PowerOutFromStorage.value' | sed 's/\..*$//') 
+openwbDebugLog ${DMOD} 1 "Speicherein: ${speicherein}"
 speicheri=$(echo $sresponse | jq '.result.items | .[] | select(.tagValues.PowerBuffered.value != null) | .tagValues.PowerBuffered.value' | sed 's/\..*$//') 
+openwbDebugLog ${DMOD} 1 "Speicheri: ${speicheri}"
 #speicherleistung=$((speichere + speicherin - speicheri)) 
 speicherleistung=$(echo "scale=0; ($speichere + $speicherin - $speicheri) *-1" | bc) 
+openwbDebugLog ${DMOD} 1 "Speicherleistung: ${speicherleistung}"
 echo $speicherleistung > /var/www/html/openWB/ramdisk/speicherleistung 
 #echo "Batterieladung/entladung $speicherleistung" 
 speichersoc=$(echo $sresponse | jq '.result.items | .[] | select(.tagValues.StateOfCharge.value != null) | .tagValues.StateOfCharge.value' | sed 's/\..*$//') 
+openwbDebugLog ${DMOD} 1 "SpeicherSoC: ${speichersoc}"
 #echo "Batterieladezustand $speichersoc" 
 echo $speichersoc > /var/www/html/openWB/ramdisk/speichersoc 

--- a/modules/wr_solarwatt/main.sh
+++ b/modules/wr_solarwatt/main.sh
@@ -1,8 +1,7 @@
 #!/bin/bash
 
-#!/bin/bash
-
-sresponse=$(curl --connect-timeout 3 -s "http://$speichersolarwattip/rest/kiwigrid/wizard/devices")
+#sresponse=$(curl --connect-timeout 3 -s "http://$speichersolarwattip/rest/kiwigrid/wizard/devices")
+sresponse=$(curl --connect-timeout 3 -s "http://${speicher1_ip}/rest/kiwigrid/wizard/devices")
 
 #pvwh=$(echo $sresponse | jq '.result.items | .[] | select(.tagValues.WorkProduced.value != null) | .tagValues.WorkProduced.value' | sed 's/\..*$//')
 #echo "PV erzeugt $pvwh"


### PR DESCRIPTION
Web Module for Speicherconfiguration configures speicher1_ip as IP for the information gathering. Modules reference speichersolarwatt which is not set up.