### PR TITLE
ermöglicht das Senden der aktuellen PV-Leistung als Float

### DIFF
--- a/runs/mqttsub.py
+++ b/runs/mqttsub.py
@@ -1115,9 +1115,9 @@ def on_message(client, userdata, msg):
         if (msg.topic == "openWB/set/pv/1/W"):
             if (float(msg.payload) >= -10000000 and float(msg.payload) <= 100000000):
                 if (float(msg.payload) > 1):
-                    pvwatt=int(msg.payload.decode("utf-8")) * -1
+                    pvwatt=int(float(msg.payload.decode("utf-8"))) * -1
                 else:
-                    pvwatt=int(msg.payload.decode("utf-8"))
+                    pvwatt=int(float(msg.payload.decode("utf-8")))
                 f = open('/var/www/html/openWB/ramdisk/pvwatt', 'w')
                 f.write(str(pvwatt))
                 f.close()


### PR DESCRIPTION
SBFSpot sendet die PACTot als Float, Python kann aber aus einem Float-String nicht direkt ein Int machen.
Workaround ist die Dekodierung der Message nach Float, dann nach Int.
Beispiele:

```
>int('12345')
12345
>float('12345.0')
12345.0
>float('12345')
12345.0
>int(12345.0)
12345
>float(12345)
12345.0
>int('12345.0')
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
ValueError: invalid literal for int() with base 10: '12345.0'
>int(float('12345.0'))
12345
```