### PR TITLE
Fix: For the calculation of the house consumption, the AC side output…

### DIFF
--- a/modules/bezug_kostalpiko/main.sh
+++ b/modules/bezug_kostalpiko/main.sh
@@ -2,7 +2,7 @@
 
 #Auslesen eines Kostal Piko WR über die integrierte API des WR mit angeschlossenem Eigenverbrauchssensor.
 
-pvwatttmp=$(curl --connect-timeout 3 -s $wrkostalpikoip/api/dxs.json?dxsEntries=33556736'&'dxsEntries=251658753'&'dxsEntries=83887106'&'dxsEntries=83887362'&'dxsEntries=83887618)
+pvwatttmp=$(curl --connect-timeout 3 -s $wrkostalpikoip/api/dxs.json?dxsEntries=67109120'&'dxsEntries=251658753'&'dxsEntries=83887106'&'dxsEntries=83887362'&'dxsEntries=83887618)
 
 #aktuelle Ausgangsleistung am WR [W]
 pvwatt=$(echo $pvwatttmp | jq '.dxsEntries[0].value' | sed 's/\..*$//')


### PR DESCRIPTION
… power must be used instead of the DC side input power

Ich hatte das Problem, dass in openWB der Hausverbrauch nicht mit dem Hausverbrauch des Wechselrichter Sensors entsprach. Der Wert war um 100-200 W daneben.
Der Fehler war: Zur Berechnung des Hausverbrauchs (Überschuss bzw. Bezug) wurde fälschlicherweise die DC-Eingangsleistung statt der AC-Ausgangsleistung verwendet (so wird es auch im Modul wr_kostalpiko für die Variable pvwatt gemacht).
So stimmen die Werte bis auf Kommawerte/Rundung mit denen der Statusseite überein.

Ich habe keinen Speicher und kann daher nicht testen, ob dxsEntries=67109120 auch bei installiertem Speicher die AC-Ausgangsleistung liefert.