### PR TITLE
Keba mit Modbusansteuerung

### DIFF
--- a/modules/keballlp1/check502.py
+++ b/modules/keballlp1/check502.py
@@ -1,0 +1,33 @@
+#!/usr/bin/python3
+import sys
+import os
+import time
+import getopt
+import socket
+named_tuple = time.localtime() # getstruct_time
+time_string = time.strftime("%m/%d/%Y, %H:%M:%S check502.py", named_tuple)
+ipaddress = str(sys.argv[1])
+file_string= '/var/www/html/openWB/ramdisk/port_502_' + ipaddress
+try:
+    f = open( file_string , 'r')
+    port =int(f.read())
+    f.close()
+except:
+    port = 9
+if (port == 1) or (port == 0):
+    pass
+else:
+    a_socket = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+    location = (ipaddress, 502)
+    result_of_check = a_socket.connect_ex(location)
+    f = open( file_string , 'w')
+    if result_of_check == 0:
+        f.write(str(1))
+        print ('%s devicenr %s Port 502 is open ' % (time_string,ipaddress))
+        #print(ipaddress," Port 502 is open")
+    else:
+        f.write(str(0))
+        print ('%s devicenr %s Port 502 is not open ' % (time_string,ipaddress))
+        #print(ipaddress," Port 502 is not open")
+    a_socket.close()
+    f.close()

--- a/modules/keballlp1/info.py
+++ b/modules/keballlp1/info.py
@@ -1,0 +1,145 @@
+#!/usr/bin/python3
+import sys
+import os
+import time
+import json
+import getopt
+import socket
+import struct
+import codecs
+import binascii
+from pymodbus.client.sync import ModbusTcpClient
+from pymodbus.constants import Endian
+from pymodbus.payload import BinaryPayloadDecoder
+named_tuple = time.localtime() # getstruct_time
+time_string = time.strftime("%m/%d/%Y, %H:%M:%S keba info.py", named_tuple)
+lpnumber=int(sys.argv[1])
+ipaddress=str(sys.argv[2])
+client = ModbusTcpClient(ipaddress, port=502)
+# total energy 1036
+resp= client.read_holding_registers(1036,2,unit=255)
+if (lpnumber ==1):
+    f = open('/var/www/html/openWB/ramdisk/llkwh', 'w')
+else:
+    f = open('/var/www/html/openWB/ramdisk/llkwhs1', 'w')
+decoder = BinaryPayloadDecoder.fromRegisters(resp.registers,byteorder=Endian.Big,wordorder=Endian.Big)
+final2 = float( decoder.decode_32bit_uint()) / 10000
+final3 = "%.3f" % final2
+f.write(str(final3))
+f.close()
+# active power 1020
+resp= client.read_holding_registers(1020,2,unit=255)
+if (lpnumber ==1):
+    f = open('/var/www/html/openWB/ramdisk/llaktuell', 'w')
+else:
+    f = open('/var/www/html/openWB/ramdisk/llaktuells1', 'w')
+decoder = BinaryPayloadDecoder.fromRegisters(resp.registers,byteorder=Endian.Big,wordorder=Endian.Big)
+final2 = float( decoder.decode_32bit_uint()) / 1000
+final3 = "%.f" % final2
+f.write(str(final3))
+f.close()
+# voltage l1 1040
+resp= client.read_holding_registers(1040,2,unit=255)
+if (lpnumber ==1):
+    f = open('/var/www/html/openWB/ramdisk/llv1', 'w')
+else:
+    f = open('/var/www/html/openWB/ramdisk/llvs11', 'w')
+decoder = BinaryPayloadDecoder.fromRegisters(resp.registers,byteorder=Endian.Big,wordorder=Endian.Big)
+final2 = float( decoder.decode_32bit_uint())
+final3 = "%.f" % final2
+f.write(str(final3))
+f.close()
+# voltage l2 1042
+resp= client.read_holding_registers(1042,2,unit=255)
+if (lpnumber ==1):
+    f = open('/var/www/html/openWB/ramdisk/llv2', 'w')
+else:
+    f = open('/var/www/html/openWB/ramdisk/llvs12', 'w')
+decoder = BinaryPayloadDecoder.fromRegisters(resp.registers,byteorder=Endian.Big,wordorder=Endian.Big)
+final2 = float( decoder.decode_32bit_uint())
+final3 = "%.f" % final2
+f.write(str(final3))
+f.close()
+# voltage l3 1044
+resp= client.read_holding_registers(1044,2,unit=255)
+if (lpnumber ==1):
+    f = open('/var/www/html/openWB/ramdisk/llv3', 'w')
+else:
+    f = open('/var/www/html/openWB/ramdisk/llvs13', 'w')
+decoder = BinaryPayloadDecoder.fromRegisters(resp.registers,byteorder=Endian.Big,wordorder=Endian.Big)
+final2 = float( decoder.decode_32bit_uint())
+final3 = "%.f" % final2
+f.write(str(final3))
+f.close()
+# amp l1 1008
+resp= client.read_holding_registers(1008,2,unit=255)
+if (lpnumber ==1):
+    f = open('/var/www/html/openWB/ramdisk/lla1', 'w')
+else:
+    f = open('/var/www/html/openWB/ramdisk/llas11', 'w')
+decoder = BinaryPayloadDecoder.fromRegisters(resp.registers,byteorder=Endian.Big,wordorder=Endian.Big)
+final2 = float( decoder.decode_32bit_uint()) / 1000
+final3 = "%.2f" % final2
+f.write(str(final3))
+f.close()
+# amp l2 1010
+resp= client.read_holding_registers(1010,2,unit=255)
+if (lpnumber ==1):
+    f = open('/var/www/html/openWB/ramdisk/lla2', 'w')
+else:
+    f = open('/var/www/html/openWB/ramdisk/llas12', 'w')
+decoder = BinaryPayloadDecoder.fromRegisters(resp.registers,byteorder=Endian.Big,wordorder=Endian.Big)
+final2 = float( decoder.decode_32bit_uint()) / 1000
+final3 = "%.2f" % final2
+f.write(str(final3))
+f.close()
+# amp l3 1012
+resp= client.read_holding_registers(1012,2,unit=255)
+if (lpnumber ==1):
+    f = open('/var/www/html/openWB/ramdisk/lla3', 'w')
+else:
+    f = open('/var/www/html/openWB/ramdisk/llas13', 'w')
+decoder = BinaryPayloadDecoder.fromRegisters(resp.registers,byteorder=Endian.Big,wordorder=Endian.Big)
+final2 = float( decoder.decode_32bit_uint()) / 1000
+final3 = "%.2f" % final2
+f.write(str(final3))
+f.close()
+# charging state 1000
+resp= client.read_holding_registers(1000,2,unit=255)
+if (lpnumber ==1):
+    f = open('/var/www/html/openWB/ramdisk/chargestat', 'w')
+else:
+    f = open('/var/www/html/openWB/ramdisk/chargestats1', 'w')
+decoder = BinaryPayloadDecoder.fromRegisters(resp.registers,byteorder=Endian.Big,wordorder=Endian.Big)
+final2 = float( decoder.decode_32bit_uint())
+final3 = "%.f" % final2
+if (final3 == "3"):
+    f.write(str(1))
+else:
+    f.write(str(0))
+f.close()
+# cabel state 1004
+resp= client.read_holding_registers(1004,2,unit=255)
+if (lpnumber ==1):
+    f = open('/var/www/html/openWB/ramdisk/plugstat', 'w')
+else:
+    f = open('/var/www/html/openWB/ramdisk/plugstats1', 'w')
+decoder = BinaryPayloadDecoder.fromRegisters(resp.registers,byteorder=Endian.Big,wordorder=Endian.Big)
+final2 = float( decoder.decode_32bit_uint())
+final3 = "%.f" % final2
+if (final3 == "7"):
+    f.write(str(1))
+else:
+    f.write(str(0))
+f.close()
+# maxcurr state 1100
+resp= client.read_holding_registers(1100,2,unit=255)
+if (lpnumber ==1):
+    f = open('/var/www/html/openWB/ramdisk/kebamaxlp1', 'w')
+else:
+    f = open('/var/www/html/openWB/ramdisk/kebamaxlp2', 'w')
+decoder = BinaryPayloadDecoder.fromRegisters(resp.registers,byteorder=Endian.Big,wordorder=Endian.Big)
+final2 = float( decoder.decode_32bit_uint()) / 1000
+final3 = "%.f" % final2
+f.write(str(final3))
+f.close()

--- a/modules/keballlp1/main.sh
+++ b/modules/keballlp1/main.sh
@@ -1,108 +1,114 @@
 #!/bin/bash
-rekwh='^[-+]?[0-9]+\.?[0-9]*$'
-re='^-?[0-9]+$'
-counter=0
-while [[ -e /var/www/html/openWB/ramdisk/kebasync && $counter < 4 ]]; do
-sleep 1
-counter=$((counter + 1))
-done
-echo 0 > /var/www/html/openWB/ramdisk/kebasync
-if [[ $counter == "4" ]] ; then
-	  dtime=$(date +"%T")
-   echo " $dtime keba1 sleep overrun "
+sudo python3 /var/www/html/openWB/modules/keballlp1/check502.py $kebaiplp1 >> /var/www/html/openWB/ramdisk/port.log 2>&1
+modbus=$(</var/www/html/openWB/ramdisk/port_502_$kebaiplp1 )
+if [[ $modbus == "0" ]] ; then
+		#echo " modbus aus" 
+		rekwh='^[-+]?[0-9]+\.?[0-9]*$'
+		re='^-?[0-9]+$'
+		counter=0
+		while [[ -e /var/www/html/openWB/ramdisk/kebasync && $counter < 4 ]]; do
+		sleep 1
+		counter=$((counter + 1))
+		done
+		echo 0 > /var/www/html/openWB/ramdisk/kebasync
+		if [[ $counter == "4" ]] ; then
+			  dtime=$(date +"%T")
+		   echo " $dtime keba1 sleep overrun "
+		fi
+		dtime=$(date +"%T")
+		#echo " $dtime keba1 status $kebaiplp1 "
+		nc -ul 7090 >/var/www/html/openWB/ramdisk/keballlp1 &
+		pidnc=$!
+		disown
+
+		echo -n "report 3" | socat - UDP-DATAGRAM:$kebaiplp1:7090
+		sleep 1
+		outputte1=$(tr -d '\0' </var/www/html/openWB/ramdisk/keballlp1)
+		echo $outputte1 > /var/www/html/openWB/ramdisk/keballlp1r3
+		output=$(echo $outputte1 |  tr -d '\n' | sed 's/\}.*/\}/')
+		echo $output > /var/www/html/openWB/ramdisk/keballlp1r3x
+		echo -n > /var/www/html/openWB/ramdisk/keballlp1
+		#read plug and chargingstatus
+		echo -n "report 2" | socat - UDP-DATAGRAM:$kebaiplp1:7090
+		sleep 1
+		outputte1=$(tr -d '\0' </var/www/html/openWB/ramdisk/keballlp1)
+		echo $outputte1 > /var/www/html/openWB/ramdisk/keballlp1r2
+		output1=$(echo $outputte1 | tr -d '\n' | sed 's/\}.*/\}/')
+		echo $output1 > /var/www/html/openWB/ramdisk/keballlp1r2x
+		kill $pidnc
+		rm /var/www/html/openWB/ramdisk/keballlp1
+		rm /var/www/html/openWB/ramdisk/kebasync
+		rep3=$(echo $output | jq '.ID')
+		rep2=$(echo $output1 | jq '.ID')
+		rep3="${rep3%\"}"
+		rep3="${rep3#\"}"
+		rep2="${rep2%\"}"
+		rep2="${rep2#\"}"
+
+		if [[ $rep3 == "3" ]] ; then
+		   watt=$(echo $output | jq '.P')
+		   watt=$(echo "($watt / 1000)/1" |bc)
+		   if [[ $watt =~ $rekwh ]] ; then
+			     echo $watt > /var/www/html/openWB/ramdisk/llaktuell
+		   fi
+
+		   lla1=$(echo $output | jq '.I1')
+		   lla1=$(echo "scale=2;$lla1 / 1000" |bc)
+		   lla2=$(echo $output | jq '.I2')
+		   lla2=$(echo "scale=2;$lla2 / 1000" |bc)
+		   lla3=$(echo $output | jq '.I3')
+		   lla3=$(echo "scale=2;$lla3 / 1000" |bc)
+		   if [[ $lla1 =~ $rekwh ]] ; then
+		     	 echo $lla1 > /var/www/html/openWB/ramdisk/lla1
+		   fi
+		   if [[ $lla2 =~ $rekwh ]] ; then
+			     echo $lla2 > /var/www/html/openWB/ramdisk/lla2
+		   fi
+		   if [[ $lla3 =~ $rekwh ]] ; then
+			     echo $lla3 > /var/www/html/openWB/ramdisk/lla3
+		   fi
+		   llv1=$(echo $output | jq '.U1')
+		   llv2=$(echo $output | jq '.U2')
+		   llv3=$(echo $output | jq '.U3')
+		   if [[ $llv1 =~ $re ]] ; then
+			     echo $llv1 > /var/www/html/openWB/ramdisk/llv1
+		   fi
+		   if [[ $llv2 =~ $re ]] ; then
+			     echo $llv2 > /var/www/html/openWB/ramdisk/llv2
+		   fi
+		   if [[ $llv3 =~ $re ]] ; then
+			     echo $llv3 > /var/www/html/openWB/ramdisk/llv3
+		   fi
+		   chargedwh=$(echo $output | jq '."E pres"')
+		#  totalwh=$(echo $output | jq '."E total"')
+		#  llwh=$(echo $chargedwh + $totalwh | bc)
+
+		   llwh=$(echo $output | jq '."E total"')
+		   llkwh=$(echo "scale=3;$llwh / 10000" | bc -l)
+		   if [[ $llkwh =~ $rekwh ]] ; then
+		      	echo $llkwh > /var/www/html/openWB/ramdisk/llkwh
+		   fi
+		fi
+		if [[ $rep2 == "2" ]] ; then
+		   newplug=$(echo $output1 | jq '.Plug')
+		   newstatus=$(echo $output1 | jq '.State')
+		#echo $output1 > /var/www/html/openWB/ramdisk/kebaoutput1
+		#Plug Status 3 Kabel ist eingesteckt an der Ladestation, kein Auto
+		#Plug Status 7 Kabel ist eingesteckt Ladestation und Auto verriegelt.
+		#Status 2 ready for charging
+		#Status 3 charging
+		   if [[ $newplug == "7" ]] ; then
+		      echo 1 > /var/www/html/openWB/ramdisk/plugstat
+		   else
+		      echo 0 > /var/www/html/openWB/ramdisk/plugstat
+		   fi
+		   if [[ $newstatus == "3" ]] ; then
+		      echo 1 > /var/www/html/openWB/ramdisk/chargestat
+		   else
+		      echo 0 > /var/www/html/openWB/ramdisk/chargestat
+		   fi
+		fi
+else
+  #modbus ein
+	sudo python3 /var/www/html/openWB/modules/keballlp1/info.py 1 $kebaiplp1 >> /var/www/html/openWB/ramdisk/port.log 2>&1
 fi
-dtime=$(date +"%T")
-#echo " $dtime keba1 status $kebaiplp1 "
-nc -ul 7090 >/var/www/html/openWB/ramdisk/keballlp1 &
-pidnc=$!
-disown
-
-echo -n "report 3" | socat - UDP-DATAGRAM:$kebaiplp1:7090
-sleep 1
-outputte1=$(tr -d '\0' </var/www/html/openWB/ramdisk/keballlp1)
-echo $outputte1 > /var/www/html/openWB/ramdisk/keballlp1r3
-output=$(echo $outputte1 |  tr -d '\n' | sed 's/\}.*/\}/')
-echo $output > /var/www/html/openWB/ramdisk/keballlp1r3x
-echo -n > /var/www/html/openWB/ramdisk/keballlp1
-#read plug and chargingstatus
-echo -n "report 2" | socat - UDP-DATAGRAM:$kebaiplp1:7090
-sleep 1
-outputte1=$(tr -d '\0' </var/www/html/openWB/ramdisk/keballlp1)
-echo $outputte1 > /var/www/html/openWB/ramdisk/keballlp1r2
-output1=$(echo $outputte1 | tr -d '\n' | sed 's/\}.*/\}/')
-echo $output1 > /var/www/html/openWB/ramdisk/keballlp1r2x
-kill $pidnc
-rm /var/www/html/openWB/ramdisk/keballlp1
-rm /var/www/html/openWB/ramdisk/kebasync
-rep3=$(echo $output | jq '.ID') 
-rep2=$(echo $output1 | jq '.ID') 
-rep3="${rep3%\"}"
-rep3="${rep3#\"}"
-rep2="${rep2%\"}"
-rep2="${rep2#\"}"
-
-if [[ $rep3 == "3" ]] ; then
-   watt=$(echo $output | jq '.P') 
-   watt=$(echo "($watt / 1000)/1" |bc)
-   if [[ $watt =~ $rekwh ]] ; then
-	     echo $watt > /var/www/html/openWB/ramdisk/llaktuell
-   fi
-
-   lla1=$(echo $output | jq '.I1') 
-   lla1=$(echo "scale=2;$lla1 / 1000" |bc)
-   lla2=$(echo $output | jq '.I2') 
-   lla2=$(echo "scale=2;$lla2 / 1000" |bc)
-   lla3=$(echo $output | jq '.I3') 
-   lla3=$(echo "scale=2;$lla3 / 1000" |bc)
-   if [[ $lla1 =~ $rekwh ]] ; then
-     	 echo $lla1 > /var/www/html/openWB/ramdisk/lla1
-   fi
-   if [[ $lla2 =~ $rekwh ]] ; then
-	     echo $lla2 > /var/www/html/openWB/ramdisk/lla2
-   fi
-   if [[ $lla3 =~ $rekwh ]] ; then
-	     echo $lla3 > /var/www/html/openWB/ramdisk/lla3
-   fi
-   llv1=$(echo $output | jq '.U1') 
-   llv2=$(echo $output | jq '.U2') 
-   llv3=$(echo $output | jq '.U3') 
-   if [[ $llv1 =~ $re ]] ; then
-	     echo $llv1 > /var/www/html/openWB/ramdisk/llv1
-   fi
-   if [[ $llv2 =~ $re ]] ; then
-	     echo $llv2 > /var/www/html/openWB/ramdisk/llv2
-   fi
-   if [[ $llv3 =~ $re ]] ; then
-	     echo $llv3 > /var/www/html/openWB/ramdisk/llv3
-   fi
-   chargedwh=$(echo $output | jq '."E pres"') 
-#  totalwh=$(echo $output | jq '."E total"') 
-#  llwh=$(echo $chargedwh + $totalwh | bc) 
-
-   llwh=$(echo $output | jq '."E total"') 
-   llkwh=$(echo "scale=3;$llwh / 10000" | bc -l)
-   if [[ $llkwh =~ $rekwh ]] ; then
-      	echo $llkwh > /var/www/html/openWB/ramdisk/llkwh
-   fi
-fi
-if [[ $rep2 == "2" ]] ; then
-   newplug=$(echo $output1 | jq '.Plug')
-   newstatus=$(echo $output1 | jq '.State')
-#echo $output1 > /var/www/html/openWB/ramdisk/kebaoutput1
-#Plug Status 3 Kabel ist eingesteckt an der Ladestation, kein Auto
-#Plug Status 7 Kabel ist eingesteckt Ladestation und Auto verriegelt. 
-#Status 2 ready for charging
-#Status 3 charging
-   if [[ $newplug == "7" ]] ; then
-      echo 1 > /var/www/html/openWB/ramdisk/plugstat
-   else          
-      echo 0 > /var/www/html/openWB/ramdisk/plugstat
-   fi
-   if [[ $newstatus == "3" ]] ; then
-      echo 1 > /var/www/html/openWB/ramdisk/chargestat
-   else          
-      echo 0 > /var/www/html/openWB/ramdisk/chargestat
-   fi
-fi
-
-

--- a/modules/keballlp1/setcurrkeba.py
+++ b/modules/keballlp1/setcurrkeba.py
@@ -1,0 +1,47 @@
+#!/usr/bin/python3
+import sys
+import os
+import time
+import json
+import getopt
+import socket
+import struct
+import codecs
+import binascii
+from pymodbus.client.sync import ModbusTcpClient
+from pymodbus.constants import Endian
+from pymodbus.payload import BinaryPayloadDecoder
+named_tuple = time.localtime() # getstruct_time
+time_string = time.strftime("%m/%d/%Y, %H:%M:%S keba setcurr.py", named_tuple)
+file_string= '/var/www/html/openWB/ramdisk/keba_setcurr.log'
+if os.path.isfile(file_string):
+    f = open( file_string , 'a')
+else:
+    f = open( file_string , 'w')
+ipaddress=str(sys.argv[1])
+newcurr=int(sys.argv[2])
+client = ModbusTcpClient(ipaddress, port=502)
+# maxcurr state 1100
+resp= client.read_holding_registers(1100,2,unit=255)
+decoder = BinaryPayloadDecoder.fromRegisters(resp.registers,byteorder=Endian.Big,wordorder=Endian.Big)
+final = float( decoder.decode_32bit_uint()) / 1000
+#value1 = resp.registers[0]
+#value2 = resp.registers[1]
+#all = format(value1, '04x') + format(value2, '04x')
+#final = float(struct.unpack('>i', all.decode('hex'))[0]) / 1000
+oldcurr = int("%.f" % final)
+if (oldcurr != newcurr):
+    if (newcurr == 0):
+        # disable station
+        print ('%s oldcurr %.f, newcurr %.f, ipadr %s disable station' % (time_string,oldcurr,newcurr,ipaddress),file=f)
+        rq = client.write_register(5014,0,unit=255)
+    else:
+        if (oldcurr == 0):
+            # enable station
+            print ('%s oldcurr %.f, newcurr %.f, ipadr %s enable station' % (time_string,oldcurr,newcurr,ipaddress),file=f)
+            rq = client.write_register(5014,1,unit=255)
+        # setting new curr
+        print ('%s oldcurr %.f, newcurr %.f, ipadr %s setting new curr' % (time_string,oldcurr,newcurr,ipaddress),file=f)
+        newcurrt = newcurr * 1000
+        rq = client.write_register(5004,newcurrt,unit=255)
+f.close()

--- a/modules/keballlp2/main.sh
+++ b/modules/keballlp2/main.sh
@@ -1,111 +1,112 @@
 #!/bin/bash
-rekwh='^[-+]?[0-9]+\.?[0-9]*$'
-re='^-?[0-9]+$'
-#sleep 3
-counter=0
-while [[ -e /var/www/html/openWB/ramdisk/kebasync && $counter < 4 ]]; do
-sleep 1
-counter=$((counter + 1))
-done
-echo 0 > /var/www/html/openWB/ramdisk/kebasync
-if [[ $counter == "4" ]] ; then
-	  dtime=$(date +"%T")
-   echo " $dtime keba2 sleep overrun "
+sudo python3 /var/www/html/openWB/modules/keballlp1/check502.py $kebaiplp2 >> /var/www/html/openWB/ramdisk/port.log 2>&1
+modbus=$(</var/www/html/openWB/ramdisk/port_502_$kebaiplp2 )
+if [[ $modbus == "0" ]] ; then
+	rekwh='^[-+]?[0-9]+\.?[0-9]*$'
+	re='^-?[0-9]+$'
+	#sleep 3
+	counter=0
+	while [[ -e /var/www/html/openWB/ramdisk/kebasync && $counter < 4 ]]; do
+	sleep 1
+	counter=$((counter + 1))
+	done
+	echo 0 > /var/www/html/openWB/ramdisk/kebasync
+	if [[ $counter == "4" ]] ; then
+		  dtime=$(date +"%T")
+	   echo " $dtime keba2 sleep overrun "
+	fi
+	echo 0 > /var/www/html/openWB/ramdisk/kebasync
+	dtime=$(date +"%T")
+	#echo " $dtime keba2 status $kebaiplp2 "
+	nc -ul 7090 >/var/www/html/openWB/ramdisk/keballlp2 &
+	pidnc=$!
+	disown
+	echo -n "report 3" | socat - UDP-DATAGRAM:$kebaiplp2:7090
+	sleep 1
+	outputte1=$(tr -d '\0' </var/www/html/openWB/ramdisk/keballlp2)
+	echo $outputte1 > /var/www/html/openWB/ramdisk/keballlp2r3
+	output=$(echo $outputte1 | tr -d '\n' | sed 's/\}.*/\}/')
+	echo $output > /var/www/html/openWB/ramdisk/keballlp2r3x
+	echo -n > /var/www/html/openWB/ramdisk/keballlp2
+	#read plug and chargingstatus
+	echo -n "report 2" | socat - UDP-DATAGRAM:$kebaiplp2:7090
+	sleep 1
+	outputte1=$(tr -d '\0' </var/www/html/openWB/ramdisk/keballlp2)
+	echo $outputte1 > /var/www/html/openWB/ramdisk/keballlp2r2
+	output1=$(echo $outputte1 | tr -d '\n' | sed 's/\}.*/\}/')
+	echo $output1 > /var/www/html/openWB/ramdisk/keballlp2r2x
+	#
+	kill $pidnc
+	rm /var/www/html/openWB/ramdisk/keballlp2
+	rm /var/www/html/openWB/ramdisk/kebasync
+	rep3=$(echo $output | jq '.ID')
+	rep2=$(echo $output1 | jq '.ID')
+	rep3="${rep3%\"}"
+	rep3="${rep3#\"}"
+	rep2="${rep2%\"}"
+	rep2="${rep2#\"}"
+
+	if [[ $rep3 == "3" ]] ; then
+	   watt=$(echo $output | jq '.P')
+	   watt=$(echo "($watt / 1000)/1" |bc)
+	   if [[ $watt =~ $rekwh ]] ; then
+		     echo $watt > /var/www/html/openWB/ramdisk/llaktuells1
+	    fi
+
+	    lla1=$(echo $output | jq '.I1')
+	    lla1=$(echo "scale=2;$lla1 / 1000" |bc)
+	    lla2=$(echo $output | jq '.I2')
+	    lla2=$(echo "scale=2;$lla2 / 1000" |bc)
+	    lla3=$(echo $output | jq '.I3')
+	    lla3=$(echo "scale=2;$lla3 / 1000" |bc)
+	    if [[ $lla1 =~ $rekwh ]] ; then
+		      echo $lla1 > /var/www/html/openWB/ramdisk/llas11
+	    fi
+	    if [[ $lla2 =~ $rekwh ]] ; then
+		      echo $lla2 > /var/www/html/openWB/ramdisk/llas12
+	    fi
+	    if [[ $lla3 =~ $rekwh ]] ; then
+		      echo $lla3 > /var/www/html/openWB/ramdisk/llas13
+	     fi
+	    llv1=$(echo $output | jq '.U1')
+	    llv2=$(echo $output | jq '.U2')
+	    llv3=$(echo $output | jq '.U3')
+	    if [[ $llv1 =~ $re ]] ; then
+		      echo $llv1 > /var/www/html/openWB/ramdisk/llvs11
+	    fi
+	    if [[ $llv2 =~ $re ]] ; then
+		      echo $llv2 > /var/www/html/openWB/ramdisk/llvs12
+	    fi
+	    if [[ $llv3 =~ $re ]] ; then
+		      echo $llv3 > /var/www/html/openWB/ramdisk/llvs13
+	    fi
+	    chargedwh=$(echo $output | jq '."E pres"')
+	#   totalwh=$(echo $output | jq '."E total"')
+	#   llwh=$(echo $chargedwh + $totalwh | bc)
+	    llwh=$(echo $output | jq '."E total"')
+	    llkwh=$(echo "scale=3;$llwh / 10000" | bc -l)
+	    if [[ $llkwh =~ $rekwh ]] ; then
+	       	echo $llkwh > /var/www/html/openWB/ramdisk/llkwhs1
+	    fi
+	fi
+	if [[ $rep2 == "2" ]] ; then
+	   newplug=$(echo $output1 | jq '.Plug')
+	   newstatus=$(echo $output1 | jq '.State')
+	#Plug Status 3 Kabel ist eingesteckt an der Ladestation, kein Auto
+	#Plug Status 7 Kabel ist eingesteckt Ladestation und Auto verriegelt.
+	#Status 2 ready for charging
+	#Status 3 charging
+	   if [[ $newplug == "7" ]] ; then
+	      echo 1 > /var/www/html/openWB/ramdisk/plugstats1
+	   else
+	      echo 0 > /var/www/html/openWB/ramdisk/plugstats1
+	   fi
+	   if [[ $newstatus == "3" ]] ; then
+	      echo 1 > /var/www/html/openWB/ramdisk/chargestats1
+	   else
+	      echo 0 > /var/www/html/openWB/ramdisk/chargestats1
+	   fi
+	fi
+else
+	sudo python3 /var/www/html/openWB/modules/keballlp1/info.py 2 $kebaiplp2 >> /var/www/html/openWB/ramdisk/port.log 2>&1
 fi
-echo 0 > /var/www/html/openWB/ramdisk/kebasync
-dtime=$(date +"%T")
-#echo " $dtime keba2 status $kebaiplp2 "
-nc -ul 7090 >/var/www/html/openWB/ramdisk/keballlp2 &
-pidnc=$!
-disown
-echo -n "report 3" | socat - UDP-DATAGRAM:$kebaiplp2:7090
-sleep 1
-outputte1=$(tr -d '\0' </var/www/html/openWB/ramdisk/keballlp2)
-echo $outputte1 > /var/www/html/openWB/ramdisk/keballlp2r3
-output=$(echo $outputte1 | tr -d '\n' | sed 's/\}.*/\}/')
-echo $output > /var/www/html/openWB/ramdisk/keballlp2r3x
-echo -n > /var/www/html/openWB/ramdisk/keballlp2
-#read plug and chargingstatus
-echo -n "report 2" | socat - UDP-DATAGRAM:$kebaiplp2:7090
-sleep 1
-outputte1=$(tr -d '\0' </var/www/html/openWB/ramdisk/keballlp2)
-echo $outputte1 > /var/www/html/openWB/ramdisk/keballlp2r2
-output1=$(echo $outputte1 | tr -d '\n' | sed 's/\}.*/\}/')
-echo $output1 > /var/www/html/openWB/ramdisk/keballlp2r2x
-#
-kill $pidnc
-rm /var/www/html/openWB/ramdisk/keballlp2
-rm /var/www/html/openWB/ramdisk/kebasync
-rep3=$(echo $output | jq '.ID') 
-rep2=$(echo $output1 | jq '.ID') 
-rep3="${rep3%\"}"
-rep3="${rep3#\"}"
-rep2="${rep2%\"}"
-rep2="${rep2#\"}"
-
-if [[ $rep3 == "3" ]] ; then
-   watt=$(echo $output | jq '.P') 
-   watt=$(echo "($watt / 1000)/1" |bc)
-   if [[ $watt =~ $rekwh ]] ; then
-	     echo $watt > /var/www/html/openWB/ramdisk/llaktuells1
-    fi
-
-    lla1=$(echo $output | jq '.I1') 
-    lla1=$(echo "scale=2;$lla1 / 1000" |bc)
-    lla2=$(echo $output | jq '.I2') 
-    lla2=$(echo "scale=2;$lla2 / 1000" |bc)
-    lla3=$(echo $output | jq '.I3') 
-    lla3=$(echo "scale=2;$lla3 / 1000" |bc)
-    if [[ $lla1 =~ $rekwh ]] ; then
-	      echo $lla1 > /var/www/html/openWB/ramdisk/llas11
-    fi
-    if [[ $lla2 =~ $rekwh ]] ; then
-	      echo $lla2 > /var/www/html/openWB/ramdisk/llas12
-    fi
-    if [[ $lla3 =~ $rekwh ]] ; then
-	      echo $lla3 > /var/www/html/openWB/ramdisk/llas13
-     fi
-    llv1=$(echo $output | jq '.U1') 
-    llv2=$(echo $output | jq '.U2') 
-    llv3=$(echo $output | jq '.U3') 
-    if [[ $llv1 =~ $re ]] ; then
-	      echo $llv1 > /var/www/html/openWB/ramdisk/llvs11
-    fi
-    if [[ $llv2 =~ $re ]] ; then
-	      echo $llv2 > /var/www/html/openWB/ramdisk/llvs12
-    fi
-    if [[ $llv3 =~ $re ]] ; then
-	      echo $llv3 > /var/www/html/openWB/ramdisk/llvs13
-    fi
-    chargedwh=$(echo $output | jq '."E pres"') 
-#   totalwh=$(echo $output | jq '."E total"') 
-#   llwh=$(echo $chargedwh + $totalwh | bc)
-    llwh=$(echo $output | jq '."E total"') 
-    llkwh=$(echo "scale=3;$llwh / 10000" | bc -l)
-    if [[ $llkwh =~ $rekwh ]] ; then
-       	echo $llkwh > /var/www/html/openWB/ramdisk/llkwhs1
-    fi
-fi
-if [[ $rep2 == "2" ]] ; then
-   newplug=$(echo $output1 | jq '.Plug')
-   newstatus=$(echo $output1 | jq '.State')
-#Plug Status 3 Kabel ist eingesteckt an der Ladestation, kein Auto
-#Plug Status 7 Kabel ist eingesteckt Ladestation und Auto verriegelt. 
-#Status 2 ready for charging
-#Status 3 charging
-   if [[ $newplug == "7" ]] ; then
-      echo 1 > /var/www/html/openWB/ramdisk/plugstats1
-   else          
-      echo 0 > /var/www/html/openWB/ramdisk/plugstats1
-   fi
-   if [[ $newstatus == "3" ]] ; then
-      echo 1 > /var/www/html/openWB/ramdisk/chargestats1
-   else          
-      echo 0 > /var/www/html/openWB/ramdisk/chargestats1
-   fi
-fi
-
-
-
-
-

--- a/runs/set-current.sh
+++ b/runs/set-current.sh
@@ -42,7 +42,7 @@ lp8enabled=$(<ramdisk/lp8enabled)
 #####
 #
 # functions
-# 
+#
 #####
 # function for setting the current - dac
 # Parameters:
@@ -51,8 +51,8 @@ lp8enabled=$(<ramdisk/lp8enabled)
 function setChargingCurrentDAC () {
 	current=$1
 	dacregister=$2
-	# set desired charging current 
-	# INFO: needs new dac.py to accept current and use translation table 
+	# set desired charging current
+	# INFO: needs new dac.py to accept current and use translation table
 	sudo python /var/www/html/openWB/runs/dac.py $current $dacregister
 }
 
@@ -128,7 +128,7 @@ function setChargingCurrentThirdeth () {
 # function for setting the current - WiFi
 # Parameters:
 # 1: current
-# 2: evsewifitimeoutlp1 
+# 2: evsewifitimeoutlp1
 # 3: evsewifiiplp1
 function setChargingCurrentWifi () {
 	if [[ $evsecon == "simpleevsewifi" ]]; then
@@ -171,7 +171,7 @@ function setChargingCurrenthttp () {
 # function for setting the current - go-e charger
 # Parameters:
 # 1: current
-# 2: goetimeoutlp1 
+# 2: goetimeoutlp1
 # 3: goeiplp1
 function setChargingCurrentgoe () {
 	if [[ $evsecon == "goe" ]]; then
@@ -206,13 +206,21 @@ function setChargingCurrentgoe () {
 # 2: goeiplp1
 function setChargingCurrentkeba () {
 	if [[ $evsecon == "keba" ]]; then
-		kebacurr=$(( current * 1000 ))
-		if [[ $current -eq 0 ]]; then
-			echo -n "ena 0" | socat - UDP-DATAGRAM:$kebaiplp1:7090
+		sudo python3 /var/www/html/openWB/modules/keballlp1/check502.py $kebaiplp1 >> /var/www/html/openWB/ramdisk/port.log 2>&1
+		modbus=$(</var/www/html/openWB/ramdisk/port_502_$kebaiplp1 )
+		if [[ $modbus == "0" ]] ; then
+			#modbus 0 means udp interface
+			kebacurr=$(( current * 1000 ))
+			if [[ $current -eq 0 ]]; then
+				echo -n "ena 0" | socat - UDP-DATAGRAM:$kebaiplp1:7090
+			else
+				echo -n "ena 1" | socat - UDP-DATAGRAM:$kebaiplp1:7090
+				echo -n "curr $kebacurr" | socat - UDP-DATAGRAM:$kebaiplp1:7090
+				echo -n "display 1 10 10 0 S$current" | socat - UDP-DATAGRAM:$kebaiplp1:7090
+			fi
 		else
-			echo -n "ena 1" | socat - UDP-DATAGRAM:$kebaiplp1:7090
-			echo -n "curr $kebacurr" | socat - UDP-DATAGRAM:$kebaiplp1:7090	
-			echo -n "display 1 10 10 0 S$current" | socat - UDP-DATAGRAM:$kebaiplp1:7090	
+			#modbus 1 means modbus interface 
+			sudo python3 /var/www/html/openWB/modules/keballlp1/setcurrkeba.py $kebaiplp1 $current >> /var/www/html/openWB/ramdisk/port.log 2>&1
 		fi
 	fi
 }
@@ -274,7 +282,7 @@ function setChargingCurrent () {
 			fi
 		fi
 
-		setChargingCurrentModbus $current $modbusevsesource $modbusevseid 
+		setChargingCurrentModbus $current $modbusevsesource $modbusevseid
 	fi
 
 	if [[ $evsecon == "simpleevsewifi" ]]; then
@@ -284,14 +292,14 @@ function setChargingCurrent () {
 		setChargingCurrentgoe $current $goetimeoutlp1 $goeiplp1
 	fi
 	if [[ $evsecon == "slaveeth" ]]; then
-		setChargingCurrentSlaveeth $current 
+		setChargingCurrentSlaveeth $current
 	fi
 	if [[ $evsecon == "thirdeth" ]]; then
-		setChargingCurrentThirdeth $current 
+		setChargingCurrentThirdeth $current
 	fi
 
 	if [[ $evsecon == "masterethframer" ]]; then
-		setChargingCurrentMasterethframer $current 
+		setChargingCurrentMasterethframer $current
 	fi
 	if [[ $evsecon == "nrgkick" ]]; then
 		setChargingCurrentnrgkick $current $nrgkicktimeoutlp1 $nrgkickiplp1 $nrgkickmaclp1 $nrgkickpwlp1
@@ -309,14 +317,14 @@ function setChargingCurrent () {
 
 #####
 #
-# main routine 
+# main routine
 #
 #####
 
 # input validation
 let current=$1
-if [[ current -lt 0 ]] | [[ current -gt 32 ]]; then 
-	if [[ $debug == "2" ]]; then 
+if [[ current -lt 0 ]] | [[ current -gt 32 ]]; then
+	if [[ $debug == "2" ]]; then
 		echo "ungültiger Wert für Ladestrom" > /var/www/html/openWB/web/lade.log
 	fi
 	exit 1
@@ -330,17 +338,17 @@ if !([[ $2 == "all" ]] || [[ $2 == "m" ]] || [[ $2 == "s1" ]] || [[ $2 == "s2" ]
 fi
 
 # value below threshold
-if [[ current -lt 6 ]]; then 
-	if [[ $debug == "2" ]]; then 
+if [[ current -lt 6 ]]; then
+	if [[ $debug == "2" ]]; then
 		echo "Ladestrom < 6A, setze auf 0A"
 	fi
 	current=0
 	lstate=0
 else
 	lstate=1
-fi 
+fi
 
-# set desired charging current 
+# set desired charging current
 
 if [[ $debug == "2" ]]; then
 	echo "setze ladung auf $current" >> /var/www/html/openWB/web/lade.log
@@ -470,7 +478,7 @@ fi
 
 # set charging current - third charging point
 if [[ $lastmanagements2 == "1" ]]; then
-	if [[ $points == "all" ]] || [[ $points == "s2" ]]; then 
+	if [[ $points == "all" ]] || [[ $points == "s2" ]]; then
 		evsecon=$evsecons2
 		dacregister=$dacregisters2
 		modbusevsesource=$evsesources2
@@ -519,7 +527,7 @@ if [[ $lastmanagementlp4 == "1" ]]; then
 	fi
 fi
 if [[ $lastmanagementlp5 == "1" ]]; then
-	if [[ $points == "all" ]] || [[ $points == "lp5" ]]; then 
+	if [[ $points == "all" ]] || [[ $points == "lp5" ]]; then
 		evsecon=$evseconlp5
 		evseip=$evseiplp5
 		ipevseid=$evseidlp5
@@ -540,7 +548,7 @@ if [[ $lastmanagementlp5 == "1" ]]; then
 	fi
 fi
 if [[ $lastmanagementlp6 == "1" ]]; then
-	if [[ $points == "all" ]] || [[ $points == "lp6" ]]; then 
+	if [[ $points == "all" ]] || [[ $points == "lp6" ]]; then
 		evsecon=$evseconlp6
 		evseip=$evseiplp6
 		ipevseid=$evseidlp6
@@ -561,7 +569,7 @@ if [[ $lastmanagementlp6 == "1" ]]; then
 	fi
 fi
 if [[ $lastmanagementlp7 == "1" ]]; then
-	if [[ $points == "all" ]] || [[ $points == "lp7" ]]; then 
+	if [[ $points == "all" ]] || [[ $points == "lp7" ]]; then
 		evsecon=$evseconlp7
 		evseip=$evseiplp7
 		ipevseid=$evseidlp7
@@ -582,7 +590,7 @@ if [[ $lastmanagementlp7 == "1" ]]; then
 	fi
 fi
 if [[ $lastmanagementlp8 == "1" ]]; then
-	if [[ $points == "all" ]] || [[ $points == "lp8" ]]; then 
+	if [[ $points == "all" ]] || [[ $points == "lp8" ]]; then
 		evsecon=$evseconlp8
 		evseip=$evseiplp8
 		ipevseid=$evseidlp8


### PR DESCRIPTION
Sofern Keba Ladestation mit der Firmware-Update V3.10.27 (keba -c ) oder Firmware-Update  V1.12 (keba-x) ausgerüstet sind, können diese neu über Modbus Schnittstelle angesteuert werden. Openwb überprüft beim ersten Zugriff (pro OpenWB Boot) auf die Keba Wallbox, ob der Port 502 auf ist. Wenn das der Fall ist, wird die Keba nur mit Modbus angesteuert / ausgelesen. Sofern der Port 502 nicht auf ist, wird die Keba mit der alten UDP Schnittstelle angesteuert. Parameter im GUI braucht es keine. Das ganze wurde mit zwei Keba  Wallboxen getestet.
Das Kommando zur Anzeige der Sollvorgabe (z.b. S8) wird im Modbus Protokoll nicht unterstützt.