### PR TITLE
fix cloudconfig auth headers

### DIFF
--- a/web/settings/cloudregistrate.php
+++ b/web/settings/cloudregistrate.php
@@ -80,6 +80,10 @@
 		curl_setopt($ch, CURLOPT_POST, 1);
 		curl_setopt($ch, CURLOPT_POSTFIELDS, $postString);
 		curl_setopt($ch, CURLOPT_RETURNTRANSFER, true);
+		# Add auth info if required
+		if( isset($_SERVER['AUTH_TYPE']) && $_SERVER['AUTH_TYPE'] == 'Basic'){
+			curl_setopt($ch, CURLOPT_USERPWD, $_SERVER['PHP_AUTH_USER'] . ":" . $_SERVER['PHP_AUTH_PW']);
+		}
 		# Get the response
 		$response = curl_exec($ch);
 		curl_close($ch);


### PR DESCRIPTION
creating a cloud bridge failed if settings are password protected due to missing auth headers