### PR TITLE
Fix two glitches in standard socket deactivation

### DIFF
--- a/rfidtag.sh
+++ b/rfidtag.sh
@@ -257,9 +257,10 @@ checkTagValidForSocket() {
 
 			if [ -f $SocketActivationFile ]; then
 				# we have activate status ...
-				local active=$(<$SocketActivationFile)
-				if (( active > 0 )); then
-					# ... and it's already active --> request DEactivation
+				local requested=$(<$SocketActivationFile)
+				local active=$(<ramdisk/socketActivated)
+				if (( requested > 0 )) || (( active > 0 )); then
+					# ... and it's already requested or active --> request DEactivation
 					echo 2 > $SocketActivationFile
 				else
 					# ... and it's not active --> request Activation

--- a/slavemode.sh
+++ b/slavemode.sh
@@ -46,10 +46,11 @@ openwbisslave() {
 
 		# handle de-activation request by socket or EV RFID scan
 		if (( SocketActivationRequested >= 2 )); then
-			openwbDebugLog "MAIN" 0 "Slave Mode Socket: Socket DEactivation requested by socket or EV RFID tag scan. Socket will now be turned off."
-			sudo python runs/standardSocket.py off
 			if (( SocketActivated == 0)) || (( SocketApproved == 0 )); then
 			  echo 0 > $SocketRequestedFile
+			else
+				openwbDebugLog "MAIN" 0 "Slave Mode Socket: Socket DEactivation requested by socket or EV RFID tag scan. Socket will now be turned off."
+				sudo python runs/standardSocket.py off
 			fi
 
 		# handle disapprove of active socket

--- a/slavemode.sh
+++ b/slavemode.sh
@@ -48,7 +48,9 @@ openwbisslave() {
 		if (( SocketActivationRequested >= 2 )); then
 			openwbDebugLog "MAIN" 0 "Slave Mode Socket: Socket DEactivation requested by socket or EV RFID tag scan. Socket will now be turned off."
 			sudo python runs/standardSocket.py off
-			echo 0 > $SocketRequestedFile
+			if (( SocketActivated == 0)) || (( SocketApproved == 0 )); then
+			  echo 0 > $SocketRequestedFile
+			fi
 
 		# handle disapprove of active socket
 		elif (( SocketActivated > 0 )) && (( SocketApproved == 0 )); then


### PR DESCRIPTION
Fix two minor issues with "standard socket":

* Standard socket deactivation was executed so fast that deactivation indication didn't reach controller
* Standard socket couldn't be deactivated using a valid socket RFID tag