### PR TITLE
Smarthomedevices Laufzeit im Gui

### DIFF
--- a/web/themes/dark/processAllMqttMsg.js
+++ b/web/themes/dark/processAllMqttMsg.js
@@ -1029,7 +1029,9 @@ function processSmartHomeDevicesMessages(mqttmsg, mqttpayload) {
 			actualPower += ' Min';
 		} else {
 			rest = (actualPower % 3600 / 60).toFixed(0);
-			ganz = (actualPower / 3600).toFixed(0);
+			var ganznot = (actualPower / 3600)
+			// nachkomma weg
+			ganz = (ganznot - (ganznot % 1)).toFixed(0);
 			actualPower = ganz + ' H ' + rest +' Min';
 		}
 		element.text(actualPower);


### PR DESCRIPTION
Berechnung der Laufzeit von Smarthomedevices fürs Gui korrigiert (Rundung ausgeschaltet)
Nur im Dark Thema, Standard referenziert auf Dark