### PR TITLE
Read and MQTT publish meter serial numbers

### DIFF
--- a/modules/mpm3pmll/readall.py
+++ b/modules/mpm3pmll/readall.py
@@ -1,6 +1,7 @@
 #!/usr/bin/python
 import sys
 import os
+import os.path
 import time
 import getopt
 import socket
@@ -63,10 +64,10 @@ except:
 try:
     if ( sdmid < 100 ):
         resp = client.read_input_registers(0x0002,4, unit=sdmid)
-        value1 = resp.registers[0] 
-        value2 = resp.registers[1] 
+        value1 = resp.registers[0]
+        value2 = resp.registers[1]
         all = format(value1, '04x') + format(value2, '04x')
-        ikwh = int(struct.unpack('>i', all.decode('hex'))[0]) 
+        ikwh = int(struct.unpack('>i', all.decode('hex'))[0])
         #resp = client.read_input_registers(0x0002,2, unit=sdmid)
         #ikwh = resp.registers[1]
         ikwh = float(ikwh) /100
@@ -96,8 +97,8 @@ try:
         f.close()
 
         resp = client.read_input_registers(0x26,2, unit=sdmid)
-        value1 = resp.registers[0] 
-        value2 = resp.registers[1] 
+        value1 = resp.registers[0]
+        value2 = resp.registers[1]
         all = format(value1, '04x') + format(value2, '04x')
         final = int(struct.unpack('>i', all.decode('hex'))[0]) / 100
         if final < 15:
@@ -127,10 +128,10 @@ try:
         f.write(str(voltage))
         f.close()
         resp = client.read_input_registers(0x2c,4, unit=sdmid)
-        value1 = resp.registers[0] 
-        value2 = resp.registers[1] 
+        value1 = resp.registers[0]
+        value2 = resp.registers[1]
         all = format(value1, '04x') + format(value2, '04x')
-        hz = int(struct.unpack('>i', all.decode('hex'))[0]) 
+        hz = int(struct.unpack('>i', all.decode('hex'))[0])
         hz = round((float(hz) / 100), 2)
         f = open('/var/www/html/openWB/ramdisk/llhz', 'w')
         f.write(str(hz))
@@ -181,7 +182,7 @@ try:
         voltage = float("%.1f" % voltage)
         f = open('/var/www/html/openWB/ramdisk/llv2', 'w')
         f.write(str(voltage))
-        f.close() 
+        f.close()
         resp = client.read_input_registers(0x04,2, unit=sdmid)
         voltage = struct.unpack('>f',struct.pack('>HH',*resp.registers))[0]
         voltage = float("%.1f" % voltage)
@@ -219,15 +220,30 @@ try:
         f = open('/var/www/html/openWB/ramdisk/llpf3', 'w')
         f.write(str(pf3))
         f.close()
+
+        if not os.path.isfile("/var/www/html/openWB/ramdisk/lp1Serial"):
+            print("Trying to read meter serial number once from meter at address " + str(seradd) + ", ID " + str(sdmid))
+            try:
+                resp = client.read_holding_registers(0xFC00,2, unit=sdmid)
+                sn = struct.unpack('>I',struct.pack('>HH',*resp.registers))[0]
+                f = open('/var/www/html/openWB/ramdisk/lp1Serial', 'w')
+                f.write(str(sn))
+                f.close()
+            except:
+                print("Meter serial number of meter at address " + str(seradd) + ", ID " + str(sdmid) + " is not available")
+                f = open('/var/www/html/openWB/ramdisk/lp1Serial', 'w')
+                f.write("0")
+                f.close()
+
     elif sdmid > 200:
         #llkwh
         resp = client.read_holding_registers(0x5000,4, unit=sdmid)
-        value1 = resp.registers[0] 
+        value1 = resp.registers[0]
         value2 = resp.registers[1]
-        value3 = resp.registers[2] 
+        value3 = resp.registers[2]
         value4 = resp.registers[3]
         all = format(value3, '04x') + format(value4, '04x')
-        ikwh = int(struct.unpack('>i', all.decode('hex'))[0]) 
+        ikwh = int(struct.unpack('>i', all.decode('hex'))[0])
         #resp = client.read_input_registers(0x0002,2, unit=sdmid)
         #ikwh = resp.registers[3]
         ikwh = float(ikwh)/100
@@ -275,8 +291,8 @@ try:
 
         #Gesamt watt
         resp = client.read_holding_registers(0x5B14,2, unit=sdmid)
-        value1 = resp.registers[0] 
-        value2 = resp.registers[1] 
+        value1 = resp.registers[0]
+        value2 = resp.registers[1]
         all = format(value1, '04x') + format(value2, '04x')
         final = int(struct.unpack('>i', all.decode('hex'))[0]) / 100
         #if final < 15:
@@ -294,5 +310,5 @@ except:
     f = open('/var/www/html/openWB/ramdisk/llmodulconfig', 'w')
     f.write(str('failure'))
     f.close()
-    #openwbModulePublishState "LP" 0 "Kein Fehler" 1 
+    #openwbModulePublishState "LP" 0 "Kein Fehler" 1
 

--- a/modules/mpm3pmll/readmpm3pm.py
+++ b/modules/mpm3pmll/readmpm3pm.py
@@ -1,6 +1,7 @@
 #!/usr/bin/python
 import sys
 import os
+import os.path
 import time
 import getopt
 import socket
@@ -16,10 +17,10 @@ client = ModbusSerialClient(method = "rtu", port=seradd, baudrate=9600,
 sdmid = int(sys.argv[2])
 if ( sdmid < 100 ):
     resp = client.read_input_registers(0x0002,4, unit=sdmid)
-    value1 = resp.registers[0] 
-    value2 = resp.registers[1] 
+    value1 = resp.registers[0]
+    value2 = resp.registers[1]
     all = format(value1, '04x') + format(value2, '04x')
-    ikwh = int(struct.unpack('>i', all.decode('hex'))[0]) 
+    ikwh = int(struct.unpack('>i', all.decode('hex'))[0])
     #resp = client.read_input_registers(0x0002,2, unit=sdmid)
     #ikwh = resp.registers[1]
     ikwh = float(ikwh) /100
@@ -49,8 +50,8 @@ if ( sdmid < 100 ):
     f.close()
 
     resp = client.read_input_registers(0x26,2, unit=sdmid)
-    value1 = resp.registers[0] 
-    value2 = resp.registers[1] 
+    value1 = resp.registers[0]
+    value2 = resp.registers[1]
     all = format(value1, '04x') + format(value2, '04x')
     final = int(struct.unpack('>i', all.decode('hex'))[0]) / 100
     if final < 15:
@@ -80,10 +81,10 @@ if ( sdmid < 100 ):
     f.write(str(voltage))
     f.close()
     resp = client.read_input_registers(0x2c,4, unit=sdmid)
-    value1 = resp.registers[0] 
-    value2 = resp.registers[1] 
+    value1 = resp.registers[0]
+    value2 = resp.registers[1]
     all = format(value1, '04x') + format(value2, '04x')
-    hz = int(struct.unpack('>i', all.decode('hex'))[0]) 
+    hz = int(struct.unpack('>i', all.decode('hex'))[0])
     hz = round((float(hz) / 100), 2)
     f = open('/var/www/html/openWB/ramdisk/llhz', 'w')
     f.write(str(hz))
@@ -134,7 +135,7 @@ else:
     voltage = float("%.1f" % voltage)
     f = open('/var/www/html/openWB/ramdisk/llv2', 'w')
     f.write(str(voltage))
-    f.close() 
+    f.close()
     resp = client.read_input_registers(0x04,2, unit=sdmid)
     voltage = struct.unpack('>f',struct.pack('>HH',*resp.registers))[0]
     voltage = float("%.1f" % voltage)
@@ -172,3 +173,18 @@ else:
     f = open('/var/www/html/openWB/ramdisk/llpf3', 'w')
     f.write(str(pf3))
     f.close()
+
+    if not os.path.isfile("/var/www/html/openWB/ramdisk/lp1Serial"):
+        print("Trying to read meter serial number once from meter at address " + str(seradd) + ", ID " + str(sdmid))
+        try:
+            resp = client.read_holding_registers(0xFC00,2, unit=sdmid)
+            sn = struct.unpack('>I',struct.pack('>HH',*resp.registers))[0]
+            f = open('/var/www/html/openWB/ramdisk/lp1Serial', 'w')
+            f.write(str(sn))
+            f.close()
+        except:
+            print("Meter serial number of meter at address " + str(seradd) + ", ID " + str(sdmid) + " is not available")
+            f = open('/var/www/html/openWB/ramdisk/lp1Serial', 'w')
+            f.write("0")
+            f.close()
+

--- a/modules/sdm120modbusSocket/readsdm.py
+++ b/modules/sdm120modbusSocket/readsdm.py
@@ -52,3 +52,17 @@ socketkwh = float("%.3f" % socketkwh[0])
 f = open('/var/www/html/openWB/ramdisk/socketkwh', 'w')
 f.write(str(socketkwh))
 f.close()
+
+if not os.path.isfile("/var/www/html/openWB/ramdisk/socketSerial"):
+    print("Trying to read socket meter serial number once from meter at address " + str(seradd) + ", ID " + str(sdmid))
+    try:
+        resp = client.read_holding_registers(0xFC00,2, unit=sdmid)
+        sn = struct.unpack('>I',struct.pack('>HH',*resp.registers))[0]
+        f = open('/var/www/html/openWB/ramdisk/socketSerial', 'w')
+        f.write(str(sn))
+        f.close()
+    except:
+        print("Socket meter serial number of meter at address " + str(seradd) + ", ID " + str(sdmid) + " is not available")
+        f = open('/var/www/html/openWB/ramdisk/socketSerial', 'w')
+        f.write("0")
+        f.close()

--- a/runs/pubmqtt.sh
+++ b/runs/pubmqtt.sh
@@ -57,6 +57,7 @@ mqttvar["evu/WhExported"]=einspeisungkwh
 mqttvar["evu/WhImported"]=bezugkwh
 mqttvar["housebattery/WhExported"]=speicherekwh
 mqttvar["housebattery/WhImported"]=speicherikwh
+mqttvar["lp/1/SerialNumber"]=lp1Serial
 mqttvar["lp/1/PfPhase1"]=llpf1
 mqttvar["lp/1/PfPhase2"]=llpf2
 mqttvar["lp/1/PfPhase3"]=llpf3
@@ -245,6 +246,7 @@ if [[ "$standardSocketInstalled" == "1" ]]; then
 	mqttvar["socket/W"]=socketp
 	mqttvar["socket/kWhCounter"]=socketkwh
 	mqttvar["socket/Pf"]=socketpf
+	mqttvar["socket/SerialNumber"]=socketSerial
 fi
 
 for i in $(seq 1 8);

--- a/runs/pubmqtt.sh
+++ b/runs/pubmqtt.sh
@@ -57,7 +57,7 @@ mqttvar["evu/WhExported"]=einspeisungkwh
 mqttvar["evu/WhImported"]=bezugkwh
 mqttvar["housebattery/WhExported"]=speicherekwh
 mqttvar["housebattery/WhImported"]=speicherikwh
-mqttvar["lp/1/SerialNumber"]=lp1Serial
+mqttvar["lp/1/MeterSerialNumber"]=lp1Serial
 mqttvar["lp/1/PfPhase1"]=llpf1
 mqttvar["lp/1/PfPhase2"]=llpf2
 mqttvar["lp/1/PfPhase3"]=llpf3
@@ -246,7 +246,7 @@ if [[ "$standardSocketInstalled" == "1" ]]; then
 	mqttvar["socket/W"]=socketp
 	mqttvar["socket/kWhCounter"]=socketkwh
 	mqttvar["socket/Pf"]=socketpf
-	mqttvar["socket/SerialNumber"]=socketSerial
+	mqttvar["socket/MeterSerialNumber"]=socketSerial
 fi
 
 for i in $(seq 1 8);


### PR DESCRIPTION
Target topics:
`openWB/lp/1/MeterSerialNumber`
`openWB/socket/MeterSerialNumber`

Currently supported for SDM120 and SDM630.
Are there any other meters that support S/N read via Modbus (afaik Lovato and MPM3PM don't)?

For now implemented for LP1 and standard socket.
Due to lack of hardware I cannot test for LP2-8 but
I can implement for those LPs if somebody can take the testing. So feel free to comment if you want me to adapt LP2-8, too as part of this PR.