### PR TITLE
Bugfix: SoC-Limit für Ladepunkt 2 kann nicht aktiviert werden

### DIFF
--- a/web/settings/navbar.html
+++ b/web/settings/navbar.html
@@ -32,7 +32,7 @@
 					<div class="dropdown-menu">
 						<a class="dropdown-item" id="navGeneralLadeeinstellungen" href="./settings/generalchargeconfig.html">Übergreifendes</a>
 						<a class="dropdown-item" id="navSofortLadeeinstellungen" href="./settings/sofortconfig.php">Sofortladen</a>
-						<a class="dropdown-item" id="navPVLadeeinstellungen" href="./settings/pvconfig.html">PV & Min+PV</a>
+						<a class="dropdown-item" id="navPVLadeeinstellungen" href="./settings/pvconfig.php">PV & Min+PV</a>
 						<!-- <a class="dropdown-item" id="navNachtladen" href="./settings/nachtladenconfig.html">Nachtladen</a> -->
 					</div>
 				</li>

--- a/web/settings/processAllMqttMsg.js
+++ b/web/settings/processAllMqttMsg.js
@@ -24,8 +24,8 @@ function processMessages(mqttmsg, mqttpayload) {
      * sets input fields, range sliders and button-groups to values by mqtt
      * @param {string} mqttmsg - the complete mqtt topic
      * @param {string} mqttpayload - the value for the topic
-     * @requires function:setInputValue - is declared in pvconfig.html
-     * @requires function:setToggleBtnGroup  - is declared in pvconfig.html
+     * @requires function:setInputValue - is declared in pvconfig.php
+     * @requires function:setToggleBtnGroup  - is declared in pvconfig.php
      */
     // console.log("new message: "+mqttmsg+": "+mqttpayload);
     checkAllSaved(mqttmsg, mqttpayload);

--- a/web/settings/pvconfig.php
+++ b/web/settings/pvconfig.php
@@ -297,95 +297,56 @@
 								</div>
 							</div>
 						</div>
-						<div class="form-group soclp1options">
-							<div class="form-row">
-								<div class="col">
-									SoC-Begrenzung
-								</div>
-								<div class="col-md-8 form-text small text-info">
-									Diese Funktion ist nur aktiv, wenn mehrere Ladepunkte jeweils mit SoC-Modul konfiguriert sind und "Ladepunkt sperren nach Abstecken" deaktiviert ist. Ist diese Funktion aktiviert lässt sich der Ladepunkt nicht mehr manuell (de-)aktivieren sondern wird ausschließlich anhand des SoC de- oder aktiviert. Aktiv im Min+PV und PV Lademodus.
-								</div>
+						<div class="form-row">
+							<div class="col">
+								SoC-Begrenzung
 							</div>
+							<div class="col-md-8 form-text small text-info">
+								Diese Funktion ist nur aktiv, wenn mehrere Ladepunkte jeweils mit SoC-Modul konfiguriert sind und "Ladepunkt sperren nach Abstecken" deaktiviert ist. Ist diese Funktion aktiviert lässt sich der Ladepunkt nicht mehr manuell (de-)aktivieren sondern wird ausschließlich anhand des SoC de- oder aktiviert. Aktiv im Min+PV und PV Lademodus.
+							</div>
+						</div>
+
+<?php for($lpNum = 1; $lpNum <= 2; $lpNum++): ?>
+						<div class="form-group soclp<?php echo $lpNum; ?>options">
 							<div class="form-row mb-1">
 								<div class="col-md-4">
-									<label class="col-form-label">Ladepunkt 1</label>
+									<label class="col-form-label">Ladepunkt <?php echo $lpNum; ?></label>
 								</div>
 								<div class="col">
-									<div class="btn-group btn-block btn-group-toggle" id="socLimitationLp1" name="socLimitation" data-toggle="buttons" data-default="0" data-topicprefix="openWB/config/get/pv/"  data-topicsubgroup="lp/1/">
+									<div class="btn-group btn-block btn-group-toggle" id="socLimitationLp<?php echo $lpNum; ?>" name="socLimitation" data-toggle="buttons" data-default="0" data-topicprefix="openWB/config/get/pv/"  data-topicsubgroup="lp/<?php echo $lpNum; ?>/">
 										<label class="btn btn-outline-info">
-											<input type="radio" name="socLimitationLp1" id="socLimitationLp1Off" data-option="0" value="0">ausgeschaltet
+											<input type="radio" name="socLimitationLp<?php echo $lpNum; ?>" id="socLimitationLp<?php echo $lpNum; ?>Off" data-option="0" value="0">ausgeschaltet
 										</label>
 										<label class="btn btn-outline-info">
-											<input type="radio" name="socLimitationLp1" id="socLimitationLp1On" data-option="1" value="1">eingeschaltet
+											<input type="radio" name="socLimitationLp<?php echo $lpNum; ?>" id="socLimitationLp<?php echo $lpNum; ?>On" data-option="1" value="1">eingeschaltet
 										</label>
 									</div>
 								</div>
 							</div>
-							<div class="form-row mb-1 soclp1optionsactive">
-								<label for="maxSocLp1" class="col-md-4 col-form-label">Maximal-SoC Ladpunkt 1</label>
+							<div class="form-row mb-1 soclp<?php echo $lpNum; ?>optionsactive">
+								<label for="maxSocLp<?php echo $lpNum; ?>" class="col-md-4 col-form-label">Maximal-SoC Ladpunkt <?php echo $lpNum; ?></label>
 								<div class="col-md-8">
 									<div class="form-row vaRow mb-1">
-										<label for="maxSocLp1" class="col-2 col-form-label valueLabel" suffix="%"> %</label>
+										<label for="maxSocLp<?php echo $lpNum; ?>" class="col-2 col-form-label valueLabel" suffix="%"> %</label>
 										<div class="col-10">
-											<input type="range" class="form-control-range rangeInput" id="maxSocLp1" name="maxSoc" min="50" max="100" step="5" value="100" data-default="100" data-topicprefix="openWB/config/get/pv/" data-topicsubgroup="lp/1/">
+											<input type="range" class="form-control-range rangeInput" id="maxSocLp<?php echo $lpNum; ?>" name="maxSoc" min="50" max="100" step="5" value="100" data-default="100" data-topicprefix="openWB/config/get/pv/" data-topicsubgroup="lp/<?php echo $lpNum; ?>/">
 										</div>
 									</div>
 									<span class="form-text small">
-										Parameter in Prozent [%] für den Maximal-SoC am Ladepunkt 1 im Modus PV-Laden.
+										Parameter in Prozent [%] für den Maximal-SoC am Ladepunkt <?php echo $lpNum; ?> im Modus PV-Laden.
 										Definiert einen EV-Maximal-SoC, bis zu dem höchstens geladen wird. Diese Funktion ist nur dafür gedacht wenn mehree Ladepunkte aktiv sind. Setzen auf 100% deaktiviert sie.
 									</span>
 								</div>
 							</div>
 						</div>
-						<div class="form-group soclp2options">
-							<div class="form-row mb-1">
-								<div class="col-md-4">
-									<label class="col-form-label">Ladepunkt 2</label>
-								</div>
-								<div class="col">
-									<div class="btn-group btn-block btn-group-toggle" id="socLimitationLp2" name="socLimitation" data-toggle="buttons" data-default="0" data-topicprefix="openWB/config/get/pv/"  data-topicsubgroup="lp/2/">
-										<label class="btn btn-outline-info">
-											<input type="radio" name="socLimitationLp2" id="socLimitationLp2Off" data-option="0">ausgeschaltet
-										</label>
-										<label class="btn btn-outline-info">
-											<input type="radio" name="socLimitationLp2" id="socLimitationLp2On" data-option="1">eingeschaltet
-										</label>
-									</div>
-								</div>
-							</div>
-							<div class="form-row mb-1 soclp2optionsactive">
-								<label for="maxSocLp2" class="col-md-4 col-form-label">Maximal-SoC Ladpunkt 2</label>
-								<div class="col-md-8">
-									<div class="form-row vaRow mb-1">
-										<label for="maxSocLp2" class="col-2 col-form-label valueLabel" suffix="%"> %</label>
-										<div class="col-10">
-											<input type="range" class="form-control-range rangeInput" id="maxSocLp2" name="maxSoc" min="50" max="100" step="5" value="100" data-default="100" data-topicprefix="openWB/config/get/pv/" data-topicsubgroup="lp/2/">
-										</div>
-									</div>
-									<span class="form-text small">
-										Parameter in Prozent [%] für den Maximal-SoC am Ladepunkt 2 im Modus PV-Laden.
-										Definiert einen EV-Maximal-SoC, bis zu dem höchstens geladen wird. Diese Funktion ist nur dafür gedacht wenn mehree Ladepunkte aktiv sind. Setzen auf 100% deaktiviert sie.
-									</span>
-								</div>
-							</div>
-						</div>
+<?php endfor; ?>
+
 					</div>  <!-- end card body EV-SoC-Steuerung PV -->
 					<script>
 						$(document).ready(function(){
-							$('input[type=radio][name=socLimitationLp1]').change(function(){
-								if(this.value == '1') {
-									showSection('.soclp1optionsactive');
-								} else {
-									hideSection('.soclp1optionsactive');
-								}
-							})
-							$('input[type=radio][name=socLimitationLp2]').change(function(){
-								if(this.value == '1') {
-									showSection('.soclp2optionsactive');
-								} else {
-									hideSection('.soclp2optionsactive');
-								}
-							})
+							$('input[type=radio][name^=socLimitationLp]').change(function(){
+								(this.value === '1' ? showSection : hideSection)('.soclp' + this.name.substr('socLimitationLp'.length) + 'optionsactive');
+							});
 						});
 					</script>
 				</div>  <!-- end card EV-SoC-Steuerung PV -->


### PR DESCRIPTION
Will man eine SoC-Begrenzung für den LP2 wählen dann... Funktioniert das nicht:
![Screenshot effektbefreite Schaltfläche LP2 "eingeschaltet"](https://user-images.githubusercontent.com/1841729/119219225-c546e680-bae4-11eb-83b0-b603500b4731.png)

Das betraf vor kurzem auch den LP1, wurde mit #1046 jedoch gefixt: https://github.com/snaptec/openWB/commit/1c533505c5e25e2f43b3383108530fd10d9f595c#diff-4b400a334f9586c6f60d5e7af1f8e66137b6c450617e85f5ade0f3180c39aca2R336
Nur leider hat der Autor des Fixes damals sich nicht um den LP2 gekümmert. Wie das Beispiel schön zeigt ist es ungünstig, dass der Code dupliziert ist und somit jemand was für LP1 fixt und nicht für LP2. Deswegen habe ich in dem PR das ganze in eine PHP-Datei geändert und generiere das Formular jetzt in einer Schleife. Dann sollte sich das Problem erledigen, dass der Code für unterschiedliche LP auseinanderentwickelt (und außerdem wird der Code kürzer).

Mich wundert an der Stelle, dass nur für LP1&2 es eine Begrenzung gibt. Die openWB unterstützt ja aktuell 8 LPs und mit oWB2 sollen es unbegrenzt werden, da wäre es doch sinnvoll noch mehr davon zu erzeugen? Es wäre jedenfalls mit einer Anpassung des Schleifenstopp-parameters getan.

Eine weitere Sache die mir aufgefallen ist, ist dass der blaue Hilfetext nicht erscheint, wenn man kein SoC-Modul am LP1 konfiguriert hat. Die Sektion habe ich auch aus dem Block rausgeschoben, so dass die jetzt immer angezeigt wird.

Hier ist der Diff vom alten statischen HTML und dem neuen generierten HTML:

```diff
--- pvconfig.html       2021-05-22 10:30:33.941695091 +0200
+++ pvconfig.new.html   2021-05-22 10:30:22.273387940 +0200
@@ -297,15 +297,16 @@
                                                                </div>
                                                        </div>
                                                </div>
-                                               <div class="form-group soclp1options">
-                                                       <div class="form-row">
-                                                               <div class="col">
-                                                                       SoC-Begrenzung
-                                                               </div>
-                                                               <div class="col-md-8 form-text small text-info">
-                                                                       Diese Funktion ist nur aktiv, wenn mehrere Ladepunkte jeweils mit SoC-Modul konfiguriert sind und "Ladepunkt sperren nach Abstecken" deaktiviert ist. Ist diese Funktion aktiviert lässt sich der Ladepunkt nicht mehr manuell (de-)aktivieren sondern wird ausschließlich anhand des SoC de- oder aktiviert. Aktiv im Min+PV und PV Lademodus.
-                                                               </div>
+                                               <div class="form-row">
+                                                       <div class="col">
+                                                               SoC-Begrenzung
                                                        </div>
+                                                       <div class="col-md-8 form-text small text-info">
+                                                               Diese Funktion ist nur aktiv, wenn mehrere Ladepunkte jeweils mit SoC-Modul konfiguriert sind und "Ladepunkt sperren nach Abstecken" deaktiviert ist. Ist diese Funktion aktiviert lässt sich der Ladepunkt nicht mehr manuell (de-)aktivieren sondern wird ausschließlich anhand des SoC de- oder aktiviert. Aktiv im Min+PV und PV Lademodus.
+                                                       </div>
+                                               </div>
+
+                                               <div class="form-group soclp1options">
                                                        <div class="form-row mb-1">
                                                                <div class="col-md-4">
                                                                        <label class="col-form-label">Ladepunkt 1</label>
@@ -345,10 +346,10 @@
                                                                <div class="col">
                                                                        <div class="btn-group btn-block btn-group-toggle" id="socLimitationLp2" name="socLimitation" data-toggle="buttons" data-default="0" data-topicprefix="openWB/config/get/pv/"  data-topicsubgroup="lp/2/">
                                                                                <label class="btn btn-outline-info">
-                                                                                       <input type="radio" name="socLimitationLp2" id="socLimitationLp2Off" data-option="0">ausgeschaltet
+                                                                                       <input type="radio" name="socLimitationLp2" id="socLimitationLp2Off" data-option="0" value="0">ausgeschaltet
                                                                                </label>
                                                                                <label class="btn btn-outline-info">
-                                                                                       <input type="radio" name="socLimitationLp2" id="socLimitationLp2On" data-option="1">eingeschaltet
+                                                                                       <input type="radio" name="socLimitationLp2" id="socLimitationLp2On" data-option="1" value="1">eingeschaltet
                                                                                </label>
                                                                        </div>
                                                                </div>
@@ -369,23 +370,13 @@
                                                                </div>
                                                        </div>
                                                </div>
+
                                        </div>  <!-- end card body EV-SoC-Steuerung PV -->
                                        <script>
                                                $(document).ready(function(){
-                                                       $('input[type=radio][name=socLimitationLp1]').change(function(){
-                                                               if(this.value == '1') {
-                                                                       showSection('.soclp1optionsactive');
-                                                               } else {
-                                                                       hideSection('.soclp1optionsactive');
-                                                               }
-                                                       })
-                                                       $('input[type=radio][name=socLimitationLp2]').change(function(){
-                                                               if(this.value == '1') {
-                                                                       showSection('.soclp2optionsactive');
-                                                               } else {
-                                                                       hideSection('.soclp2optionsactive');
-                                                               }
-                                                       })
+                                                       $('input[type=radio][name^=socLimitationLp]').change(function(){
+                                                               (this.value === '1' ? showSection : hideSection)('.soclp' + this.name.substr('socLimitationLp'.length) + 'optionsactive');
+                                                       });
                                                });
                                        </script>
                                </div>  <!-- end card EV-SoC-Steuerung PV -->
```

Ich habe das ganze so gut es geht getestet, in dem ich Code in der Browserkonsole injeziert habe, aber das ist natürlich ziemlich eingeschränkt von den Möglichkeiten. Insofern müsste $irgendwer sich bereiterklären das ganze in echt zu testen.