### PR TITLE
Editorconfig hinzufügen um Verwirrung um Einrückung etc. auszuräumen

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,11 @@
+root = true
+
+[*]
+indent_style = tab
+charset = utf-8
+end_of_line = lf
+insert_final_newline = true
+
+[*.py]
+indent_style = space
+indent_size = 4


### PR DESCRIPTION
Ich habe gerade einen PR aufgemacht und dann viel mir doch noch ein... Bei dem letzten PR habt ihr geschimpft, weil ich Leerzeichen als Einrückung verwendet habe anstatt Tabs. Das habe ich dann nochmal schnell geändert. Doof ist es trotzdem, denn das ist nirgendwo dokumentiert und wenn Tabs auf die gleiche Breite eingestellt sind wie man üblicherweise Leerzeichen verwendet fällt es auch nicht auf.

Ganz offensichtlich bin ich nicht der einzige, der das "falsch" gemacht hat. Ich habe mal gezählt welche Dateien welche Einrückung verwenden:

|Endung   |Tabs|Leerzeichen|
|---------|----|-----------|
|.conf    |1   |0          |
|.css     |16  |25         |
|.eot     |4   |3          |
|.htaccess|0   |1          |
|.gif     |2   |           |
|.html    |25  |5          |
|.idx     |4   |0          |
|.js      |53  |35         |
|.json    |1   |0          |
|.md      |1   |0          |
|.pack    |4   |2          |
|.php     |102 |19         |
|.png     |32  |2          |
|.py      |11  |177        |
|.sample  |7   |3          |
|.sh      |148 |35         |
|.svg     |2   |3          |
|.ttf     |5   |3          |
|.txt     |0   |1          |
|.woff    |4   |           |
|.woff2   |3   |           |

(Zum Zählen der Dateien mit Tabs habe ich `grep -rlP '^\t' . | grep -v idea | grep -Po '\.[^./]+$' | sort | uniq -c` verwendet und zum Zählen der Dateien mit Leerzeiche `grep -rlP '^  ' . | grep -v idea | grep -Po '\.[^./]+$' | sort | uniq -c`. Wenn eine Datei gemischt ist, würde sie also in beiden Spalten auftauchen.

Also in den meisten Fällen "gewinnen" die Tabs in der Statistik. Nur nicht bei Python, da ist es ziemlich eindeutig andersrum. Da stellt sich dann noch die Frage wie viele Leerzeiche es bei Python sein sollen. Da habe ich auch mal gezählt mit `find -iname "*.py" -exec grep -Pho '^ {2,}' '{}' '+' | awk '{print length}' | sort -g | uniq -c`:

Anzahl Leerzeichen | Vorkommnisse
-- | --
2 | 41
3 | 313
4 | 9090
5 | 5
6 | 108
7 | 5
8 | 5017
9 | 23
10 | 54
11 | 3
12 | 2541
13 | 1
14 | 31
15 | 6
16 | 1343
17 | 4
18 | 2
19 | 3
20 | 1158
21 | 5
22 | 1
23 | 3
24 | 349
27 | 14
28 | 72
29 | 4
31 | 12
32 | 30
35 | 4
36 | 8
38 | 2
40 | 8
57 | 2

Also die Dateien, die eine durch 4 teilbare Einrückung haben sind hier klar im Vorsprung.

Ich habe dann noch rausgefunden, dass als Zeilenumbruch LF zum Einsatz kommt, UTF-8 kodiert wird und die Dateien auch üblicherweise mit einem LF enden. (Genau gezählt habe ich das nicht, weil ich bei Stichproben keine Abweichungen festgestellt habe.

Damit das nicht in Zukunft alles Leute erraten müssen, habe ich eine [editorconfig](https://editorconfig.org/) erstellt, die ich hiermit dem Projekt gerne beisteuern möchte. Dann sollte jeder, der eine IDE/einen Texteditor der es Wert ist verwendet zu werden in Zukunft auch automatisch die richtige Einrückung etc. verwendet.