### PR TITLE
Fix openwb.conf manipulations with sed when running in Docker

### DIFF
--- a/modules/soc_tesla/main.sh
+++ b/modules/soc_tesla/main.sh
@@ -100,13 +100,13 @@ incrementTimer(){
 
 clearPassword(){
 	openwbDebugLog ${DMOD} 2 "Lp$CHARGEPOINT: Removing password from config."
-	sed -i "s/$passwordConfigText=.*/$passwordConfigText=''/" $CONFIGFILE
+	echo $(cat $CONFIGFILE | sed "s/$passwordConfigText=.*/$passwordConfigText=''/") > $CONFIGFILE
 }
 
 setTokenPassword(){
 	openwbDebugLog ${DMOD} 2 "Lp$CHARGEPOINT: Writing token password to config."
-	sed -i "s/$passwordConfigText=.*/$passwordConfigText='$TOKENPASSWORD'/" $CONFIGFILE
-	sed -i "s/$mfaPasscodeConfigText=.*/$mfaPasscodeConfigText=XXX/" $CONFIGFILE
+	echo $(cat $CONFIGFILE | sed "s/$passwordConfigText=.*/$passwordConfigText='$TOKENPASSWORD'/") > $CONFIGFILE
+	echo $(cat $CONFIGFILE | sed "s/$mfaPasscodeConfigText=.*/$mfaPasscodeConfigText=XXX/") > $CONFIGFILE
 }
 
 checkToken(){

--- a/runs/cronnightly.sh
+++ b/runs/cronnightly.sh
@@ -101,7 +101,7 @@ if [[ $verbraucher1_typ == "tasmota" ]]; then
 		else
 			verbraucher1_writewh=$(echo "scale=0;(($verbraucher1_oldwh * 1000) + $verbraucher1_tempwh) / 1" | bc)
 		fi
-		sed -i "s/verbraucher1_tempwh=.*/verbraucher1_tempwh=$verbraucher1_writewh/" /var/www/html/openWB/openwb.conf
+		echo $(cat /var/www/html/openWB/openwb.conf | sed "s/verbraucher1_tempwh=.*/verbraucher1_tempwh=$verbraucher1_writewh/") > /var/www/html/openWB/openwb.conf
 		curl -s http://$verbraucher1_ip/cm?cmnd=EnergyReset1%200
 		curl -s http://$verbraucher1_ip/cm?cmnd=EnergyReset2%200
 		curl -s http://$verbraucher1_ip/cm?cmnd=EnergyReset3%200
@@ -115,7 +115,7 @@ if [[ $verbraucher2_typ == "tasmota" ]]; then
 		else
 			verbraucher2_writewh=$(echo "scale=0;(($verbraucher2_oldwh * 1000) + $verbraucher2_tempwh) / 1" | bc)
 		fi
-		sed -i "s/verbraucher2_tempwh=.*/verbraucher2_tempwh=$verbraucher2_writewh/" /var/www/html/openWB/openwb.conf
+		echo $(cat /var/www/html/openWB/openwb.conf | sed "s/verbraucher2_tempwh=.*/verbraucher2_tempwh=$verbraucher2_writewh/") > /var/www/html/openWB/openwb.conf
 		curl -s http://$verbraucher2_ip/cm?cmnd=EnergyReset1%200
 		curl -s http://$verbraucher2_ip/cm?cmnd=EnergyReset2%200
 		curl -s http://$verbraucher2_ip/cm?cmnd=EnergyReset3%200

--- a/runs/replaceinconfig.sh
+++ b/runs/replaceinconfig.sh
@@ -30,4 +30,4 @@ if [ -e /var/www/html/openWB/openwb.conf.1 ]
 	 then cp /var/www/html/openWB/openwb.conf /var/www/html/openWB/openwb.conf.1
 fi
 
-sed -i "s,$1.*,$1$2,g" /var/www/html/openWB/openwb.conf
+echo $(cat /var/www/html/openWB/openwb.conf | sed "s,$1.*,$1$2,g") > /var/www/html/openWB/openwb.conf

--- a/runs/senddebug.sh
+++ b/runs/senddebug.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-sed -i 's/debug.*/debug=1/' /var/www/html/openWB/openwb.conf
+echo $(cat /var/www/html/openWB/openwb.conf | sed 's/debug.*/debug=1/') > /var/www/html/openWB/openwb.conf
 sleep 60
 
 debugFile=/var/www/html/openWB/ramdisk/debug.log
@@ -47,7 +47,7 @@ ls -lRa /var/www/html/openWB/modules/soc_* >> $debugFile
 curl --upload $debugFile "https://openwb.de/tools/debug2.php?debugemail=$debugemail"
 
 
-sed -i 's/debug.*/debug=0/' /var/www/html/openWB/openwb.conf
+echo $(cat /var/www/html/openWB/openwb.conf | sed 's/debug.*/debug=0/') > /var/www/html/openWB/openwb.conf
 rm $debugFile
 rm /var/www/html/openWB/ramdisk/debuguser
 rm /var/www/html/openWB/ramdisk/debugemail

--- a/runs/updateConfig.sh
+++ b/runs/updateConfig.sh
@@ -269,7 +269,7 @@ updateConfig(){
 	if ! grep -Fq "leafpasswort=" $ConfigFile; then
 		echo "leafpasswort=''" >> $ConfigFile
 	else
-		sed -i "/leafpasswort='/b; s/^leafpasswort=\(.*\)/leafpasswort=\'\1\'/g" $ConfigFile
+		echo $(cat $ConfigFile | sed "/leafpasswort='/b; s/^leafpasswort=\(.*\)/leafpasswort=\'\1\'/g") > $ConfigFile
 	fi
 	if ! grep -Fq "leafusernames1=" $ConfigFile; then
 		echo "leafusernames1=username" >> $ConfigFile
@@ -277,7 +277,7 @@ updateConfig(){
 	if ! grep -Fq "leafpassworts1=" $ConfigFile; then
 		echo "leafpassworts1=''" >> $ConfigFile
 	else
-		sed -i "/leafpassworts1='/b; s/^leafpassworts1=\(.*\)/leafpassworts1=\'\1\'/g" $ConfigFile
+		echo $(cat $ConfigFile | sed "/leafpassworts1='/b; s/^leafpassworts1=\(.*\)/leafpassworts1=\'\1\'/g") > $ConfigFile
 	fi
 	if ! grep -Fq "i3username=" $ConfigFile; then
 		echo "i3username=username" >> $ConfigFile
@@ -291,7 +291,7 @@ updateConfig(){
 	if ! grep -Fq "i3passwort=" $ConfigFile; then
 		echo "i3passwort=''" >> $ConfigFile
 	else
-		sed -i "/i3passwort='/b; s/^i3passwort=\(.*\)/i3passwort=\'\1\'/g" $ConfigFile
+		echo $(cat $ConfigFile | sed "/i3passwort='/b; s/^i3passwort=\(.*\)/i3passwort=\'\1\'/g") > $ConfigFile
 	fi
 	if ! grep -Fq "i3usernames1=" $ConfigFile; then
 		echo "i3usernames1=username" >> $ConfigFile
@@ -299,7 +299,7 @@ updateConfig(){
 	if ! grep -Fq "i3passworts1=" $ConfigFile; then
 		echo "i3passworts1=''" >> $ConfigFile
 	else
-		sed -i "/i3passworts1='/b; s/^i3passworts1=\(.*\)/i3passworts1=\'\1\'/g" $ConfigFile
+		echo $(cat $ConfigFile | sed "/i3passworts1='/b; s/^i3passworts1=\(.*\)/i3passworts1=\'\1\'/g") > $ConfigFile
 	fi
 	if ! grep -Fq "i3vins1=" $ConfigFile; then
 		echo "i3vins1=VIN" >> $ConfigFile
@@ -313,12 +313,12 @@ updateConfig(){
 	if ! grep -Fq "zoepasswort=" $ConfigFile; then
 		echo "zoepasswort=''" >> $ConfigFile
 	else
-		sed -i "/zoepasswort='/b; s/^zoepasswort=\(.*\)/zoepasswort=\'\1\'/g" $ConfigFile
+		echo $(cat $ConfigFile | sed "/zoepasswort='/b; s/^zoepasswort=\(.*\)/zoepasswort=\'\1\'/g") > $ConfigFile
 	fi
 	if ! grep -Fq "socpass=" $ConfigFile; then
 		echo "socpass=''" >> $ConfigFile
 	else
-		sed -i "/socpass='/b; s/^socpass=\(.*\)/socpass=\'\1\'/g" $ConfigFile
+		echo $(cat $ConfigFile | sed "/socpass='/b; s/^socpass=\(.*\)/socpass=\'\1\'/g") > $ConfigFile
 	fi
 	if ! grep -Fq "socuser=" $ConfigFile; then
 		echo "socuser=username" >> $ConfigFile
@@ -329,7 +329,7 @@ updateConfig(){
 	if ! grep -Fq "zoelp2passwort=" $ConfigFile; then
 		echo "zoelp2passwort=''" >> $ConfigFile
 	else
-		sed -i "/zoelp2passwort='/b; s/^zoelp2passwort=\(.*\)/zoelp2passwort=\'\1\'/g" $ConfigFile
+		echo $(cat $ConfigFile | sed "/zoelp2passwort='/b; s/^zoelp2passwort=\(.*\)/zoelp2passwort=\'\1\'/g") > $ConfigFile
 	fi
 	if ! grep -Fq "minnurpvsocll=" $ConfigFile; then
 		echo "minnurpvsocll=12" >> $ConfigFile
@@ -473,7 +473,7 @@ updateConfig(){
 	if ! grep -Fq "soc_tesla_password=" $ConfigFile; then
 		echo "soc_tesla_password=''" >> $ConfigFile
 	else
-		sed -i "/soc_tesla_password='/b; s/^soc_tesla_password=\(.*\)/soc_tesla_password=\'\1\'/g" $ConfigFile
+		echo $(cat $ConfigFile | sed "/soc_tesla_password='/b; s/^soc_tesla_password=\(.*\)/soc_tesla_password=\'\1\'/g") > $ConfigFile
 	fi
 	if ! grep -Fq "soc_tesla_intervallladen=" $ConfigFile; then
 		echo "soc_tesla_intervallladen=20" >> $ConfigFile
@@ -652,7 +652,7 @@ updateConfig(){
 	if ! grep -Fq "bezug_smartme_pass=" $ConfigFile; then
 		echo "bezug_smartme_pass=''" >> $ConfigFile
 	else
-		sed -i "/bezug_smartme_pass='/b; s/^bezug_smartme_pass=\(.*\)/bezug_smartme_pass=\'\1\'/g" $ConfigFile
+		echo $(cat $ConfigFile | sed "/bezug_smartme_pass='/b; s/^bezug_smartme_pass=\(.*\)/bezug_smartme_pass=\'\1\'/g") > $ConfigFile
 	fi
 	if ! grep -Fq "bezug_smartme_url=" $ConfigFile; then
 		echo "bezug_smartme_url='https://smart-me.com:443/api/Devices/[ID]'" >> $ConfigFile
@@ -663,7 +663,7 @@ updateConfig(){
 	if ! grep -Fq "wr_smartme_pass=" $ConfigFile; then
 		echo "wr_smartme_pass=''" >> $ConfigFile
 	else
-		sed -i "/wr_smartme_pass='/b; s/^wr_smartme_pass=\(.*\)/wr_smartme_pass=\'\1\'/g" $ConfigFile
+		echo $(cat $ConfigFile | sed "/wr_smartme_pass='/b; s/^wr_smartme_pass=\(.*\)/wr_smartme_pass=\'\1\'/g") > $ConfigFile
 	fi
 	if ! grep -Fq "wr_smartme_url=" $ConfigFile; then
 		echo "wr_smartme_url='https://smart-me.com:443/api/Devices/[ID]'" >> $ConfigFile
@@ -674,7 +674,7 @@ updateConfig(){
 	if ! grep -Fq "wr_piko2_pass=" $ConfigFile; then
 		echo "wr_piko2_pass=''" >> $ConfigFile
 	else
-		sed -i "/wr_piko2_pass='/b; s/^wr_piko2_pass=\(.*\)/wr_piko2_pass=\'\1\'/g" $ConfigFile
+		echo $(cat $ConfigFile | sed "/wr_piko2_pass='/b; s/^wr_piko2_pass=\(.*\)/wr_piko2_pass=\'\1\'/g") > $ConfigFile
 	fi
 	if ! grep -Fq "wr_piko2_url=" $ConfigFile; then
 		echo "wr_piko2_url='https://url'" >> $ConfigFile
@@ -685,7 +685,7 @@ updateConfig(){
 	if ! grep -Fq "wr2_piko2_pass=" $ConfigFile; then
 		echo "wr2_piko2_pass=''" >> $ConfigFile
 	else
-		sed -i "/wr2_piko2_pass='/b; s/^wr2_piko2_pass=\(.*\)/wr2_piko2_pass=\'\1\'/g" $ConfigFile
+		echo $(cat $ConfigFile | sed "/wr2_piko2_pass='/b; s/^wr2_piko2_pass=\(.*\)/wr2_piko2_pass=\'\1\'/g") > $ConfigFile
 	fi
 	if ! grep -Fq "wr2_piko2_url=" $ConfigFile; then
 		echo "wr2_piko2_url='https://url'" >> $ConfigFile
@@ -696,7 +696,7 @@ updateConfig(){
 	if ! grep -Fq "carnetpass=" $ConfigFile; then
 		echo "carnetpass=''" >> $ConfigFile
 	else
-		sed -i "/carnetpass='/b; s/^carnetpass=\(.*\)/carnetpass=\'\1\'/g" $ConfigFile
+		echo $(cat $ConfigFile | sed "/carnetpass='/b; s/^carnetpass=\(.*\)/carnetpass=\'\1\'/g") > $ConfigFile
 	fi
 	if ! grep -Fq "soccarnetintervall=" $ConfigFile; then
 		echo "soccarnetintervall=10" >> $ConfigFile
@@ -710,11 +710,11 @@ updateConfig(){
 	if ! grep -Fq "soc_vag_password=" $ConfigFile; then
 		echo "soc_vag_password=''" >> $ConfigFile
 	else
-		sed -i "/soc_vag_password='/b; s/^soc_vag_password=\(.*\)/soc_vag_password=\'\1\'/g" $ConfigFile
+		echo $(cat $ConfigFile | sed "/soc_vag_password='/b; s/^soc_vag_password=\(.*\)/soc_vag_password=\'\1\'/g") > $ConfigFile
 	fi
 	# remove line with syntax error from config
 	if grep -Fq "soc_vag_vin=vin (WVWZZZ...)" $ConfigFile; then
-		sed -i '/^soc_vag_vin=/d' $ConfigFile
+		echo $(cat $ConfigFile | sed '/^soc_vag_vin=/d') > $ConfigFile
 	fi
 	if ! grep -Fq "soc_vag_vin=" $ConfigFile; then
 		echo "soc_vag_vin='WVWZZZ...'" >> $ConfigFile
@@ -739,7 +739,7 @@ updateConfig(){
 	if ! grep -Fq "bydhvpass=" $ConfigFile; then
 		echo "bydhvpass=''" >> $ConfigFile
 	else
-		sed -i "/bydhvpass='/b; s/^bydhvpass=\(.*\)/bydhvpass=\'\1\'/g" $ConfigFile
+		echo $(cat $ConfigFile | sed "/bydhvpass='/b; s/^bydhvpass=\(.*\)/bydhvpass=\'\1\'/g") > $ConfigFile
 	fi
 	if ! grep -Fq "bydhvip=" $ConfigFile; then
 		echo "bydhvip=192.168.10.12" >> $ConfigFile
@@ -967,7 +967,7 @@ updateConfig(){
 	if ! grep -Fq "carnetlp2pass=" $ConfigFile; then
 		echo "carnetlp2pass=''" >> $ConfigFile
 	else
-		sed -i "/carnetlp2pass='/b; s/^carnetlp2pass=\(.*\)/carnetlp2pass=\'\1\'/g" $ConfigFile
+		echo $(cat $ConfigFile | sed "/carnetlp2pass='/b; s/^carnetlp2pass=\(.*\)/carnetlp2pass=\'\1\'/g") > $ConfigFile
 	fi
 	if ! grep -Fq "soccarnetlp2intervall=" $ConfigFile; then
 		echo "soccarnetlp2intervall=10" >> $ConfigFile
@@ -981,7 +981,7 @@ updateConfig(){
 	if ! grep -Fq "soc_teslalp2_password=" $ConfigFile; then
 		echo "soc_teslalp2_password=''" >> $ConfigFile
 	else
-		sed -i "/soc_teslalp2_password='/b; s/^soc_teslalp2_password=\(.*\)/soc_teslalp2_password=\'\1\'/g" $ConfigFile
+		echo $(cat $ConfigFile | sed "/soc_teslalp2_password='/b; s/^soc_teslalp2_password=\(.*\)/soc_teslalp2_password=\'\1\'/g") > $ConfigFile
 	fi
 	if ! grep -Fq "soc_teslalp2_intervallladen=" $ConfigFile; then
 		echo "soc_teslalp2_intervallladen=20" >> $ConfigFile
@@ -1168,7 +1168,7 @@ updateConfig(){
 	fi
 	# remove obsolete line from config
 	if grep -Fq "awattaraktiv=" $ConfigFile; then
-		sed -i '/^awattaraktiv=/d' $ConfigFile
+		echo $(cat $ConfigFile | sed '/^awattaraktiv=/d') > $ConfigFile
 	fi
 	if ! grep -Fq "plz=" $ConfigFile; then
 		echo "plz=36124" >> $ConfigFile
@@ -1397,7 +1397,7 @@ updateConfig(){
 	if ! grep -Fq "soc_zerong_password=" $ConfigFile; then
 		echo "soc_zerong_password=''" >> $ConfigFile
 	else
-		sed -i "/soc_zerong_password='/b; s/^soc_zerong_password=\(.*\)/soc_zerong_password=\'\1\'/g" $ConfigFile
+		echo $(cat $ConfigFile | sed "/soc_zerong_password='/b; s/^soc_zerong_password=\(.*\)/soc_zerong_password=\'\1\'/g") > $ConfigFile
 	fi
 	if ! grep -Fq "soc_zerong_intervallladen=" $ConfigFile; then
 		echo "soc_zerong_intervallladen=10" >> $ConfigFile
@@ -1411,7 +1411,7 @@ updateConfig(){
 	if ! grep -Fq "soc_zeronglp2_password=" $ConfigFile; then
 		echo "soc_zeronglp2_password=''" >> $ConfigFile
 	else
-		sed -i "/soc_zeronglp2_password='/b; s/^soc_zeronglp2_password=\(.*\)/soc_zeronglp2_password=\'\1\'/g" $ConfigFile
+		echo $(cat $ConfigFile | sed "/soc_zeronglp2_password='/b; s/^soc_zeronglp2_password=\(.*\)/soc_zeronglp2_password=\'\1\'/g") > $ConfigFile
 	fi
 	if ! grep -Fq "soc_zeronglp2_intervallladen=" $ConfigFile; then
 		echo "soc_zeronglp2_intervallladen=10" >> $ConfigFile
@@ -1434,7 +1434,7 @@ updateConfig(){
 	if ! grep -Fq "discovergypass=" $ConfigFile; then
 		echo "discovergypass=''" >> $ConfigFile
 	else
-		sed -i "/discovergypass='/b; s/^discovergypass=\(.*\)/discovergypass=\'\1\'/g" $ConfigFile
+		echo $(cat $ConfigFile | sed "/discovergypass='/b; s/^discovergypass=\(.*\)/discovergypass=\'\1\'/g") > $ConfigFile
 	fi
 	if ! grep -Fq "discovergyevuid=" $ConfigFile; then
 		echo "discovergyevuid=idesmeters" >> $ConfigFile
@@ -1448,7 +1448,7 @@ updateConfig(){
 	if ! grep -Fq "powerfoxpass=" $ConfigFile; then
 		echo "powerfoxpass=''" >> $ConfigFile
 	else
-		sed -i "/powerfoxpass='/b; s/^powerfoxpass=\(.*\)/powerfoxpass=\'\1\'/g" $ConfigFile
+		echo $(cat $ConfigFile | sed "/powerfoxpass='/b; s/^powerfoxpass=\(.*\)/powerfoxpass=\'\1\'/g") > $ConfigFile
 	fi
 	if ! grep -Fq "powerfoxid=" $ConfigFile; then
 		echo "powerfoxid=idesmeters" >> $ConfigFile
@@ -1531,7 +1531,7 @@ updateConfig(){
 	if ! grep -Fq "soc_audi_passwort=" $ConfigFile; then
 		echo "soc_audi_passwort=''" >> $ConfigFile
 	else
-		sed -i "/soc_audi_passwort='/b; s/^soc_audi_passwort=\(.*\)/soc_audi_passwort=\'\1\'/g" $ConfigFile
+		echo $(cat $ConfigFile | sed "/soc_audi_passwort='/b; s/^soc_audi_passwort=\(.*\)/soc_audi_passwort=\'\1\'/g") > $ConfigFile
 	fi
 	if ! grep -Fq "soc_audi_vin=" $ConfigFile; then
 		echo "soc_audi_vin=VIN" >> $ConfigFile
@@ -1542,7 +1542,7 @@ updateConfig(){
 	if ! grep -Fq "soc2pass=" $ConfigFile; then
 		echo "soc2pass=''" >> $ConfigFile
 	else
-		sed -i "/soc2pass='/b; s/^soc2pass=\(.*\)/soc2pass=\'\1\'/g" $ConfigFile
+		echo $(cat $ConfigFile | sed "/soc2pass='/b; s/^soc2pass=\(.*\)/soc2pass=\'\1\'/g") > $ConfigFile
 	fi
 	if ! grep -Fq "soc2pin=" $ConfigFile; then
 		echo "soc2pin=pin" >> $ConfigFile
@@ -1553,7 +1553,7 @@ updateConfig(){
 	if ! grep -Fq "lgessv1pass=" $ConfigFile; then
 		echo "lgessv1pass='regnum_as_default_password'" >> $ConfigFile
 	else
-		sed -i "/lgessv1pass='/b; s/^lgessv1pass=\(.*\)/lgessv1pass=\'\1\'/g" $ConfigFile
+		echo $(cat $ConfigFile | sed "/lgessv1pass='/b; s/^lgessv1pass=\(.*\)/lgessv1pass=\'\1\'/g") > $ConfigFile
 	fi
 	if ! grep -Fq "ess_api_ver=" $ConfigFile; then
 		echo "ess_api_ver=01.2020" >> $ConfigFile
@@ -1648,8 +1648,8 @@ updateConfig(){
 		echo "myrenault_locationlp2=de_DE" >> $ConfigFile
 		echo "myrenault_countrylp2=DE" >> $ConfigFile
 	else
-		sed -i "/myrenault_passlp1='/b; s/^myrenault_passlp1=\(.*\)/myrenault_passlp1=\'\1\'/g" $ConfigFile
-		sed -i "/myrenault_passlp2='/b; s/^myrenault_passlp2=\(.*\)/myrenault_passlp2=\'\1\'/g" $ConfigFile
+		echo $(cat $ConfigFile | sed "/myrenault_passlp1='/b; s/^myrenault_passlp1=\(.*\)/myrenault_passlp1=\'\1\'/g") > $ConfigFile
+		echo $(cat $ConfigFile | sed "/myrenault_passlp2='/b; s/^myrenault_passlp2=\(.*\)/myrenault_passlp2=\'\1\'/g") > $ConfigFile
 	fi
 	if ! grep -Fq "evukitversion=" $ConfigFile; then
 		echo "evukitversion=0" >> $ConfigFile
@@ -1721,10 +1721,10 @@ updateConfig(){
 		echo "pv2user=none" >> $ConfigFile
 		echo "pv2pass=''" >> $ConfigFile
 	else
-		sed -i "/pv2pass='/b; s/^pv2pass=\(.*\)/pv2pass=\'\1\'/g" $ConfigFile
+		echo $(cat $ConfigFile | sed "/pv2pass='/b; s/^pv2pass=\(.*\)/pv2pass=\'\1\'/g") > $ConfigFile
 	fi
 	if grep -Fq "pv2id=none" $ConfigFile; then
-		sed -i "/^pv2id=none/pv2id=1/g" $ConfigFile
+		echo $(cat $ConfigFile | sed "/^pv2id=none/pv2id=1/g") > $ConfigFile
 	fi
 	if ! grep -Fq "soc_bluelink_email=" $ConfigFile; then
 		echo "soc_bluelink_email=mail@mail.de" >> $ConfigFile
@@ -1732,7 +1732,7 @@ updateConfig(){
 		echo "soc_bluelink_pin=1111" >> $ConfigFile
 		echo "soc_bluelink_interval=30" >> $ConfigFile
 	else
-		sed -i "/soc_bluelink_password='/b; s/^soc_bluelink_password=\(.*\)/soc_bluelink_password=\'\1\'/g" $ConfigFile
+		echo $(cat $ConfigFile | sed "/soc_bluelink_password='/b; s/^soc_bluelink_password=\(.*\)/soc_bluelink_password=\'\1\'/g") > $ConfigFile
 	fi
 	if ! grep -Fq "soc_vin=" $ConfigFile; then
 		echo "soc_vin=VIN" >> $ConfigFile
@@ -1800,7 +1800,7 @@ updateConfig(){
 	else
 		# fix wizzarddone value
 		if grep -Fq "wizzarddone=1[0-9][0-9]" $ConfigFile; then
-			sed -i 's/^wizzarddone=1[0-9][0-9]/wizzarddone=100/g' $ConfigFile
+			echo $(cat $ConfigFile | sed 's/^wizzarddone=1[0-9][0-9]/wizzarddone=100/g') > $ConfigFile
 		fi
 	fi
 	if ! grep -Fq "preisjekwh=" $ConfigFile; then
@@ -1834,8 +1834,8 @@ updateConfig(){
 		echo "mypeugeot_clientidlp2=ID" >> $ConfigFile
 		echo "mypeugeot_clientsecretlp2=Secret" >> $ConfigFile
 	else
-		sed -i "/mypeugeot_passlp1='/b; s/^mypeugeot_passlp1=\(.*\)/mypeugeot_passlp1=\'\1\'/g" $ConfigFile
-		sed -i "/mypeugeot_passlp2='/b; s/^mypeugeot_passlp2=\(.*\)/mypeugeot_passlp2=\'\1\'/g" $ConfigFile
+		echo $(cat $ConfigFile | sed "/mypeugeot_passlp1='/b; s/^mypeugeot_passlp1=\(.*\)/mypeugeot_passlp1=\'\1\'/g") > $ConfigFile
+		echo $(cat $ConfigFile | sed "/mypeugeot_passlp2='/b; s/^mypeugeot_passlp2=\(.*\)/mypeugeot_passlp2=\'\1\'/g") > $ConfigFile
 	fi
 	if ! grep -Fq "myopel_userlp1=" $ConfigFile; then
 		echo "myopel_userlp1=User" >> $ConfigFile
@@ -1847,8 +1847,8 @@ updateConfig(){
 		echo "myopel_clientidlp2=ID" >> $ConfigFile
 		echo "myopel_clientsecretlp2=Secret" >> $ConfigFile
 	else
-		sed -i "/myopel_passlp1='/b; s/^myopel_passlp1=\(.*\)/myopel_passlp1=\'\1\'/g" $ConfigFile
-		sed -i "/myopel_passlp2='/b; s/^myopel_passlp2=\(.*\)/myopel_passlp2=\'\1\'/g" $ConfigFile
+		echo $(cat $ConfigFile | sed "/myopel_passlp1='/b; s/^myopel_passlp1=\(.*\)/myopel_passlp1=\'\1\'/g") > $ConfigFile
+		echo $(cat $ConfigFile | sed "/myopel_passlp2='/b; s/^myopel_passlp2=\(.*\)/myopel_passlp2=\'\1\'/g") > $ConfigFile
 	fi
 	if ! grep -Fq "psa_userlp1=" $ConfigFile; then
 		echo "psa_userlp1=User" >> $ConfigFile
@@ -1860,8 +1860,8 @@ updateConfig(){
 		echo "psa_clientidlp2=ID" >> $ConfigFile
 		echo "psa_clientsecretlp2=Secret" >> $ConfigFile
 	else
-		sed -i "/psa_passlp1='/b; s/^psa_passlp1=\(.*\)/psa_passlp1=\'\1\'/g" $ConfigFile
-		sed -i "/psa_passlp2='/b; s/^psa_passlp2=\(.*\)/psa_passlp2=\'\1\'/g" $ConfigFile
+		echo $(cat $ConfigFile | sed "/psa_passlp1='/b; s/^psa_passlp1=\(.*\)/psa_passlp1=\'\1\'/g") > $ConfigFile
+		echo $(cat $ConfigFile | sed "/psa_passlp2='/b; s/^psa_passlp2=\(.*\)/psa_passlp2=\'\1\'/g") > $ConfigFile
 	fi
 	if ! grep -Fq "psa_intervallp1=" $ConfigFile; then
 		echo "psa_intervallp1=10" >> $ConfigFile
@@ -1891,7 +1891,7 @@ updateConfig(){
 	if ! grep -Fq "soc_id_passwort=" $ConfigFile; then
 		echo "soc_id_passwort=''" >> $ConfigFile
 	else
-		sed -i "/soc_id_passwort='/b; s/^soc_id_passwort=\(.*\)/soc_id_passwort=\'\1\'/g" $ConfigFile
+		echo $(cat $ConfigFile | sed "/soc_id_passwort='/b; s/^soc_id_passwort=\(.*\)/soc_id_passwort=\'\1\'/g") > $ConfigFile
 	fi
 	if ! grep -Fq "soc_id_vin=" $ConfigFile; then
 		echo "soc_id_vin=VIN" >> $ConfigFile
@@ -1975,7 +1975,7 @@ updateConfig(){
 		echo "speicherpwuser=Username" >> $ConfigFile
 		echo "speicherpwpass=''" >> $ConfigFile
 	else
-		sed -i "/speicherpwpass='/b; s/^speicherpwpass=\(.*\)/speicherpwpass=\'\1\'/g" $ConfigFile
+		echo $(cat $ConfigFile | sed "/speicherpwpass='/b; s/^speicherpwpass=\(.*\)/speicherpwpass=\'\1\'/g") > $ConfigFile
 	fi
 	if ! grep -Fq "multifems=" $ConfigFile; then
 		echo "multifems=1" >> $ConfigFile

--- a/runs/wlanconnect.sh
+++ b/runs/wlanconnect.sh
@@ -21,5 +21,5 @@ wlan0ip=$(ifconfig wlan0 |grep 'inet ' |awk '{print $2}')
 if [[ $wlan0state -eq 0 || $wlan0ip -eq "192.168.4.1"  ]]; then
 	sudo reboot now
 else
-	sed -i 's/displayconfigured.*/displayconfigured=1/' /var/www/html/openWB/openwb.conf
+	echo $(cat /var/www/html/openWB/openwb.conf | sed 's/displayconfigured.*/displayconfigured=1/') > /var/www/html/openWB/openwb.conf
 fi


### PR DESCRIPTION
`sed -i` creates a temporary file and replaces the original file when successful. This fails with "Device or resource busy" when openwb.conf is mounted from a Docker host because it would change the inode.

This change replaces all invocations of `sed -i` on openwb.conf so that the replacement result is stored in memory and then written to the target file in a separate step.

See https://github.com/IngmarStein/openwb-docker/issues/3