### PR TITLE
Restore missing lines in atreboot.sh

### DIFF
--- a/runs/atreboot.sh
+++ b/runs/atreboot.sh
@@ -167,6 +167,8 @@ fi
 
 # check for LAN/WLAN connection
 openwbDebugLog "MAIN" 0 "LAN/WLAN..."
+ethstate=$(</sys/class/net/eth0/carrier)
+if (( ethstate == 1 )); then
 	sudo ifconfig eth0:0 192.168.193.5 netmask 255.255.255.0 up
 else
 	sudo ifconfig wlan0:0 192.168.193.6 netmask 255.255.255.0 up


### PR DESCRIPTION
These got lost in https://github.com/snaptec/openWB/commit/a49e67ffb92bb6187360713bf06da8ee233608ac

Fixes

```
/var/www/html/openWB/runs/atreboot.sh: line 171: syntax error near unexpected token `else'
/var/www/html/openWB/runs/atreboot.sh: line 171: `else'
```