### PR TITLE
Send tag scan info also for RFID mode 1

### DIFF
--- a/rfidtag.sh
+++ b/rfidtag.sh
@@ -52,10 +52,16 @@ rfid() {
 		if [ "$lasttag" == "$rfidlp1start1" ] || [ "$lasttag" == "$rfidlp1start2" ] || [ "$lasttag" == "$rfidlp1start3" ] || [ "$lasttag" == "$rfidlp1start4" ] || [ "$lasttag" == "$rfidlp1start5" ]; then
 			mosquitto_pub -r -t openWB/set/lp/1/ChargePointEnabled -m "1"
 			lp1enabled=1
+			tagScanInfo="$NowItIs,$lasttag,1"
+			echo "$tagScanInfo" > "ramdisk/tagScanInfoLp1"
+			mosquitto_pub -r -q 2 -t "openWB/lp/1/tagScanInfo" -m "$tagScanInfo"
 		fi
 		if [ "$lasttag" == "$rfidlp2start1" ] || [ "$lasttag" == "$rfidlp2start2" ] || [ "$lasttag" == "$rfidlp2start3" ] || [ "$lasttag" == "$rfidlp2start4" ] || [ "$lasttag" == "$rfidlp2start5" ]; then
 			mosquitto_pub -r -t openWB/set/lp/2/ChargePointEnabled -m "1"
 			lp2enabled=1
+			tagScanInfo="$NowItIs,$lasttag,1"
+			echo "$tagScanInfo" > "ramdisk/tagScanInfoLp2"
+			mosquitto_pub -r -q 2 -t "openWB/lp/2/tagScanInfo" -m "$tagScanInfo"
 		fi
 
 		# check all CPs that we support for whether the tag is valid for that CP


### PR DESCRIPTION
As promised in https://github.com/snaptec/openWB/pull/1420#issuecomment-854493022 this is the minimal change needed to support display unlock in case of _valid_ RFID tag scan in "mode 1".

**Note:**
The code (also the original one of https://github.com/snaptec/openWB/pull/1420) has a behaviour that is important to notice: Even in case of valid RFID tag there can be publishes on the `tagScanInfoLp*` with validity "0" (invalid).

A proper fix for this would require significant refactoring of `rfidtag.sh`.

Currently that effort seems not to be justified as the "invalid tag" publishes do not have any impact on UI behviour (UI just ignores it).

A more simple work-around could be to not publish immediately but just update ramdisk file. This would, however, reduce responsiveness of display as it would only detect the scan at the end of the control loop (when `pubmqtt.sh` is called). So at least 1-2 secs more latency must be expected for this approach.