### PR TITLE
Trenne AlphaESS Speicher und Wechselrichter

### DIFF
--- a/loadvars.sh
+++ b/loadvars.sh
@@ -480,11 +480,6 @@ loadvars(){
 		speichersoc=$(echo $speichersoc | sed 's/\..*$//')
 		speichervorhanden="1"
 		echo 1 > /var/www/html/openWB/ramdisk/speichervorhanden
-		if [[ $speichermodul == "speicher_alphaess" ]] ; then
-			pvwatt=$(</var/www/html/openWB/ramdisk/pvwatt)
-			echo 1 > /var/www/html/openWB/ramdisk/pv1vorhanden
-			pv1vorhanden="1"
-		fi
 		if [[ $speichermodul == "speicher_e3dc" ]] ; then
 			pvwatt=$(</var/www/html/openWB/ramdisk/pvwatt)
 			echo 1 > /var/www/html/openWB/ramdisk/pv1vorhanden
@@ -1042,9 +1037,6 @@ loadvars(){
 	if [[ $pvwattmodul == "none" ]] && [[ $speichermodul == "speicher_e3dc" ]]; then
 		usesimpv=1
 	fi
-	if [[ $pvwattmodul == "none" ]] && [[ $speichermodul == "speicher_alphaess" ]]; then
-		usesimpv=1
-	fi
 	if [[ $speichermodul == "speicher_kostalplenticore" ]] && [[ $pvwattmodul == "wr_plenticore" ]]; then
 		usesimpv=1
 	fi
@@ -1057,7 +1049,7 @@ loadvars(){
 	if [[ $pvwattmodul == "wr_fronius" ]] && [[ $wrfroniusisgen24 == "1" ]]; then
 		usesimpv=1
 	fi
-	if [[ $pvwattmodul == "wr_kostalpiko" ]] || [[ $pvwattmodul == "wr_siemens" ]] || [[ $pvwattmodul == "wr_rct" ]]|| [[ $pvwattmodul == "wr_solarwatt" ]] || [[ $pvwattmodul == "wr_shelly" ]] || [[ $pvwattmodul == "wr_sungrow" ]] || [[ $pvwattmodul == "wr_huawei" ]] || [[ $pvwattmodul == "wr_powerdog" ]] || [[ $pvwattmodul == "wr_lgessv1" ]]|| [[ $pvwattmodul == "wr_kostalpikovar2" ]]; then
+	if [[ $pvwattmodul == "wr_kostalpiko" ]] || [[ $pvwattmodul == "wr_siemens" ]] || [[ $pvwattmodul == "wr_rct" ]]|| [[ $pvwattmodul == "wr_solarwatt" ]] || [[ $pvwattmodul == "wr_shelly" ]] || [[ $pvwattmodul == "wr_sungrow" ]] || [[ $pvwattmodul == "wr_huawei" ]] || [[ $pvwattmodul == "wr_powerdog" ]] || [[ $pvwattmodul == "wr_lgessv1" ]]|| [[ $pvwattmodul == "wr_kostalpikovar2" ]] || [[ $pvwattmodul == "wr_alphaess" ]]; then
 		usesimpv=1
 	fi
 	if [[ $usesimpv == "1" ]]; then

--- a/modules/speicher_alphaess/readalpha.py
+++ b/modules/speicher_alphaess/readalpha.py
@@ -49,33 +49,3 @@ socf = int(w2 * 0.1)
 f = open('/var/www/html/openWB/ramdisk/speichersoc', 'w')
 f.write(str(socf))
 f.close()
-time.sleep(0.1)
-resp = client.read_holding_registers(0x0012,4, unit=sdmid)
-decoder = BinaryPayloadDecoder.fromRegisters(resp.registers,byteorder=Endian.Big,wordorder=Endian.Big)
-pvw = int(decoder.decode_32bit_int())
-if ( pvw < 0 ):
-    pvw=pvw * -1
-# print('pvw'+str(pvw))
-time.sleep(0.1)
-
-resp = client.read_holding_registers(0x041F,4, unit=sdmid)
-decoder = BinaryPayloadDecoder.fromRegisters(resp.registers,byteorder=Endian.Big,wordorder=Endian.Big)
-pvw2 = int(decoder.decode_32bit_int())
-# print('pvw2 '+str(pvw2))
-
-resp = client.read_holding_registers(0x0423,4, unit=sdmid)
-decoder = BinaryPayloadDecoder.fromRegisters(resp.registers,byteorder=Endian.Big,wordorder=Endian.Big)
-pvw3 = int(decoder.decode_32bit_int())
-# print('pvw3 '+str(pvw3))
-
-resp = client.read_holding_registers(0x0427,4, unit=sdmid)
-decoder = BinaryPayloadDecoder.fromRegisters(resp.registers,byteorder=Endian.Big,wordorder=Endian.Big)
-pvw4 = int(decoder.decode_32bit_int())
-# print('pvw4 '+str(pvw4))
-
-# print('pvw2'+str(pvw2))
-pvg= (pvw + pvw2 + pvw3 + pvw4) * -1
-# print('pvg'+str(pvg))
-f = open('/var/www/html/openWB/ramdisk/pvwatt', 'w')
-f.write(str(pvg))
-f.close()

--- a/modules/speicher_alphaess/readv123.py
+++ b/modules/speicher_alphaess/readv123.py
@@ -48,33 +48,3 @@ socf = int(w2 * 0.1)
 f = open('/var/www/html/openWB/ramdisk/speichersoc', 'w')
 f.write(str(socf))
 f.close()
-time.sleep(0.1)
-resp = client.read_holding_registers(0x00A1,4, unit=sdmid)
-decoder = BinaryPayloadDecoder.fromRegisters(resp.registers,byteorder=Endian.Big,wordorder=Endian.Big)
-pvw = int(decoder.decode_32bit_int())
-if ( pvw < 0 ):
-    pvw=pvw * -1
-# print('pvw'+str(pvw))
-time.sleep(0.1)
-
-resp = client.read_holding_registers(0x041F,4, unit=sdmid)
-decoder = BinaryPayloadDecoder.fromRegisters(resp.registers,byteorder=Endian.Big,wordorder=Endian.Big)
-pvw2 = int(decoder.decode_32bit_int())
-# print('pvw2 '+str(pvw2))
-
-resp = client.read_holding_registers(0x0423,4, unit=sdmid)
-decoder = BinaryPayloadDecoder.fromRegisters(resp.registers,byteorder=Endian.Big,wordorder=Endian.Big)
-pvw3 = int(decoder.decode_32bit_int())
-# print('pvw3 '+str(pvw3))
-
-resp = client.read_holding_registers(0x0427,4, unit=sdmid)
-decoder = BinaryPayloadDecoder.fromRegisters(resp.registers,byteorder=Endian.Big,wordorder=Endian.Big)
-pvw4 = int(decoder.decode_32bit_int())
-# print('pvw4 '+str(pvw4))
-
-# print('pvw2'+str(pvw2))
-pvg= (pvw + pvw2 + pvw3 + pvw4) * -1
-# print('pvg'+str(pvg))
-f = open('/var/www/html/openWB/ramdisk/pvwatt', 'w')
-f.write(str(pvg))
-f.close()

--- a/modules/wr_alphaess/main.sh
+++ b/modules/wr_alphaess/main.sh
@@ -1,0 +1,6 @@
+#!/bin/bash
+if [[ $alphav123 == "1" ]]; then
+	python /var/www/html/openWB/modules/wr_alphaess/readv123.py
+else
+	python /var/www/html/openWB/modules/wr_alphaess/readalpha.py
+fi

--- a/modules/wr_alphaess/readalpha.py
+++ b/modules/wr_alphaess/readalpha.py
@@ -1,0 +1,49 @@
+#!/usr/bin/python
+# import sys
+# import os
+import time
+# import getopt
+# import socket
+# import ConfigParser
+# import struct
+# import binascii
+# import logging
+from pymodbus.payload import BinaryPayloadDecoder
+from pymodbus.constants import Endian
+from pymodbus.client.sync import ModbusTcpClient
+
+client = ModbusTcpClient('192.168.193.125', port=8899)
+
+sdmid = int(85)
+resp = client.read_holding_registers(0x0012,4, unit=sdmid)
+decoder = BinaryPayloadDecoder.fromRegisters(resp.registers,byteorder=Endian.Big,wordorder=Endian.Big)
+pvw = int(decoder.decode_32bit_int())
+if ( pvw < 0 ):
+    pvw=pvw * -1
+# print('pvw'+str(pvw))
+time.sleep(0.1)
+
+resp = client.read_holding_registers(0x041F,4, unit=sdmid)
+decoder = BinaryPayloadDecoder.fromRegisters(resp.registers,byteorder=Endian.Big,wordorder=Endian.Big)
+pvw2 = int(decoder.decode_32bit_int())
+# print('pvw2 '+str(pvw2))
+
+resp = client.read_holding_registers(0x0423,4, unit=sdmid)
+decoder = BinaryPayloadDecoder.fromRegisters(resp.registers,byteorder=Endian.Big,wordorder=Endian.Big)
+pvw3 = int(decoder.decode_32bit_int())
+# print('pvw3 '+str(pvw3))
+
+resp = client.read_holding_registers(0x0427,4, unit=sdmid)
+decoder = BinaryPayloadDecoder.fromRegisters(resp.registers,byteorder=Endian.Big,wordorder=Endian.Big)
+pvw4 = int(decoder.decode_32bit_int())
+# print('pvw4 '+str(pvw4))
+
+# print('pvw2'+str(pvw2))
+pvg= (pvw + pvw2 + pvw3 + pvw4) * -1
+# print('pvg'+str(pvg))
+f = open('/var/www/html/openWB/ramdisk/pvwatt', 'w')
+f.write(str(pvg))
+f.close()
+
+
+

--- a/modules/wr_alphaess/readv123.py
+++ b/modules/wr_alphaess/readv123.py
@@ -1,0 +1,46 @@
+#!/usr/bin/python
+# import sys
+# import os
+import time
+# import getopt
+# import socket
+# import ConfigParser
+# import struct
+# import binascii
+# import logging
+from pymodbus.payload import BinaryPayloadDecoder
+from pymodbus.constants import Endian
+from pymodbus.client.sync import ModbusTcpClient
+client = ModbusTcpClient('192.168.193.125', port=8899)
+
+sdmid = int(85)
+resp = client.read_holding_registers(0x00A1,4, unit=sdmid)
+decoder = BinaryPayloadDecoder.fromRegisters(resp.registers,byteorder=Endian.Big,wordorder=Endian.Big)
+pvw = int(decoder.decode_32bit_int())
+if ( pvw < 0 ):
+    pvw=pvw * -1
+# print('pvw'+str(pvw))
+time.sleep(0.1)
+
+resp = client.read_holding_registers(0x041F,4, unit=sdmid)
+decoder = BinaryPayloadDecoder.fromRegisters(resp.registers,byteorder=Endian.Big,wordorder=Endian.Big)
+pvw2 = int(decoder.decode_32bit_int())
+# print('pvw2 '+str(pvw2))
+
+resp = client.read_holding_registers(0x0423,4, unit=sdmid)
+decoder = BinaryPayloadDecoder.fromRegisters(resp.registers,byteorder=Endian.Big,wordorder=Endian.Big)
+pvw3 = int(decoder.decode_32bit_int())
+# print('pvw3 '+str(pvw3))
+
+resp = client.read_holding_registers(0x0427,4, unit=sdmid)
+decoder = BinaryPayloadDecoder.fromRegisters(resp.registers,byteorder=Endian.Big,wordorder=Endian.Big)
+pvw4 = int(decoder.decode_32bit_int())
+# print('pvw4 '+str(pvw4))
+
+# print('pvw2'+str(pvw2))
+pvg= (pvw + pvw2 + pvw3 + pvw4) * -1
+#print('pvg'+str(pvg))
+f = open('/var/www/html/openWB/ramdisk/pvwatt', 'w')
+f.write(str(pvg))
+f.close()
+

--- a/web/settings/modulconfigpv.php
+++ b/web/settings/modulconfigpv.php
@@ -96,6 +96,7 @@
 										<option <?php if($pvwattmodulold == "wr_powerwall") echo "selected" ?> value="wr_powerwall">Tesla Powerwall</option>
 										<option <?php if($pvwattmodulold == "wr_victron") echo "selected" ?> value="wr_victron">Victron</option>
 										<option <?php if($pvwattmodulold == "wr_youless120") echo "selected" ?> value="wr_youless120">Youless 120</option>
+										<option <?php if($pvwattmodulold == "wr_alphaess") echo "selected" ?> value="wr_alphaess">AlphaESS-Speicher</option>
 									</optgroup>
 									<optgroup label="generische Module">
 										<option <?php if($pvwattmodulold == "wr_http") echo "selected" ?> value="wr_http">Http</option>
@@ -115,6 +116,11 @@
 								Per MQTT zu schreiben:<br>
 								<span class="text-info">openWB/set/pv/1/W</span> PV-Leistung in Watt, int, negativ<br>
 								<span class="text-info">openWB/set/pv/1/WhCounter</span> Erzeugte Energie in Wh, float, nur positiv
+							</div>
+						</div>
+						<div id="pvalphaess" class="hide">
+							<div class="card-text alert alert-info">
+								Keine Konfiguration erforderlich.
 							</div>
 						</div>
 						<div id="pvsungrow" class="hide">
@@ -806,6 +812,7 @@
 								hideSection('#pvpowerdog');
 								hideSection('#pvsolarwatt');
 								hideSection('#pvsungrow');
+								hideSection('#pvalphaess');
 								if($('#pvwattmodul').val() == 'wr_siemens') {
 									showSection('#pvip');
 									showSection('#pvsiemens');
@@ -911,6 +918,9 @@
 								}
 								if($('#pvwattmodul').val() == 'wr_solarwatt')   {
 									showSection('#pvsolarwatt');
+								}
+								if($('#pvwattmodul').val() == 'wr_alphaess')   {
+									showSection('#pvalphaess');
 								}
 								if($('#pvsungrow').val() == 'wr_sungrow')   {
 									showSection('#pvsungrow');


### PR DESCRIPTION
Anwender des AlphaESS-Speichermoduls, welche die PV-Watt-Werte vom
Speicher auslesen wollen, muessen jetzt explizit das dazugehoerige
PV-Modul waehlen. Die Konfiguration ueber die Firmwareversion verbleibt
auf der Config-Seite vom Speicher (wie auch beim AlphaESS-EVU-Modul).