### PR TITLE
Additional Handling of incomplete responses

### DIFF
--- a/modules/soc_eq/soc.py
+++ b/modules/soc_eq/soc.py
@@ -174,7 +174,12 @@ if req_soc.status_code == 200:
 				range = entry[values]['value']
 			else:
 				socDebugLog("unknown entry: " + entry)
-
+	if not soc:
+		socDebugLog("SoC Value not filled " + req_soc.text)
+		soc = "0"
+	if not range:
+		socDebugLog("RangeElectric Value not filled " + req_soc.text)
+		range = "0"
 	socDebugLog("SOC: " + soc + " RANGE: " + range)
 	fd = open(soc_file,'w')
 	fd.write(str(soc))


### PR DESCRIPTION
API sometimes lacks the soc value. Added a handling for that case. Soc is set to 0 and Message including the response is written in soc.log