### PR TITLE
Veränderung Counter automatische Phasenumschaltung

### DIFF
--- a/u1p3p.sh
+++ b/u1p3p.sh
@@ -177,7 +177,7 @@ u1p3pswitch(){
 										openwbDebugLog "MAIN" 1 "auf 3 Phasen MinPV Automatik geaendert"
 									fi
 								fi
-								if (( oldll == maximalstromstaerke )); then
+								if (( oldll == maximalstromstaerke )) && (( uberschuss > 1000 )); then
 									uhcounter=$(</var/www/html/openWB/ramdisk/uhcounter)
 									if (( uhcounter < uhwaittime )); then
 										uhcounter=$((uhcounter + 10))
@@ -212,7 +212,7 @@ u1p3pswitch(){
 										openwbDebugLog "MAIN" 1 "auf 1 Phasen MinPV Automatik geaendert da geringerer Überschuss"
 									fi
 								fi
-								if (( oldll == minimalampv )); then
+								if (( oldll == minimalampv )) && (( uberschuss < 0 )); then
 									urcounter=$(</var/www/html/openWB/ramdisk/urcounter)
 									if (( urcounter < urwaittime )); then
 										urcounter=$((urcounter + 10))
@@ -271,7 +271,7 @@ u1p3pswitch(){
 										openwbDebugLog "MAIN" 1 "auf 3 Phasen NurPV Automatik geaendert"
 									fi
 								fi
-								if (( oldll == maximalstromstaerke )); then
+								if (( oldll == maximalstromstaerke )) && (( uberschuss > 1000 )); then
 									uhcounter=$(</var/www/html/openWB/ramdisk/uhcounter)
 									if (( uhcounter < uhwaittime )); then
 										uhcounter=$((uhcounter + 10))
@@ -306,7 +306,7 @@ u1p3pswitch(){
 										openwbDebugLog "MAIN" 1 "auf 1 Phasen NurPV Automatik geaendert da geringerer Überschuss"
 									fi
 								fi
-								if (( oldll == minimalapv )); then
+								if (( oldll == minimalapv )) && (( uberschuss < 0 )); then
 									urcounter=$(</var/www/html/openWB/ramdisk/urcounter)
 									if (( urcounter  < urwaittime )); then
 										urcounter=$((urcounter + 10))


### PR DESCRIPTION
Der Counter für die automatische Phasenumschaltung auf 3 bzw. 1 Phase wird aktuell erhöht, wenn die Regelgrenze der Ladestromstärke erreicht ist. Dies kann dazu führen, das ein Phasenwechsel stattfindet, obwohl die neue Phasenanzahl nicht zur Situation passt.

Mit diesem PR würde der Umschaltcounter nur erhöht werden, wenn auch genügend Strom für das 3-pasige Laden vorhanden ist, bzw. beim Wechsel auf 1-phasiges Laden auch kein Überschuss mehr vorhanden ist.

Bei meinen Tests hat die Regelung so besser funktioniert und verhindert, dass nach einem Phasenwechsel gleich wieder der Counter für den gegensätzlichen Phasenwechsel hochgezählt wird.
Vollständig getestet ist es allerdings nicht, da das durch die Wetterabhängigkeit schlecht zu testen und der Peugeot bei der Umschaltung der Phasen ohnehin zickig ist.