### PR TITLE
[Kia/Hyundai] Abschaltung Hyundai-Dummy / ABRP / Erweiterte Einstellungen

### DIFF
--- a/modules/soc_bluelink/main.sh
+++ b/modules/soc_bluelink/main.sh
@@ -1,8 +1,0 @@
-#!/bin/bash
-
-OPENWBBASEDIR=$(cd `dirname $0`/../../ && pwd)
-
-# for backward compatibility only
-# functionality is in soc_kia
-$OPENWBBASEDIR/modules/soc_kia/main.sh 1
-exit 0

--- a/modules/soc_bluelinklp2/main.sh
+++ b/modules/soc_bluelinklp2/main.sh
@@ -1,8 +1,0 @@
-#!/bin/bash
-
-OPENWBBASEDIR=$(cd `dirname $0`/../../ && pwd)
-
-# for backward compatibility only
-# functionality is in soc_kia
-$OPENWBBASEDIR/modules/soc_kia/main.sh 2
-exit 0

--- a/modules/soc_kia/abrp.py
+++ b/modules/soc_kia/abrp.py
@@ -15,6 +15,18 @@ def pushABRP(soc):
     
     url = "https://api.iternio.com/1/tlm/send?api_key=" + requests.utils.quote(apiKey) + "&token=" + requests.utils.quote(userToken)
     data = {'tlm': {'utc': now, 'soc': soc, 'is_charging': state.isCharging()}}
+    
+    try:
+        f = open(parameters.getParameter('auxDataFile'), 'r')
+        auxData = json.loads(f.read())
+        f.close()        
+        data['tlm']['odometer'] = auxData['odometer']['value']
+        data['tlm']['lat'] = auxData['vehicleLocation']['coord']['lat']
+        data['tlm']['lon'] = auxData['vehicleLocation']['coord']['lon']
+        data['tlm']['speed'] = auxData['vehicleLocation']['speed']['value']
+        data['tlm']['is_parked'] = auxData['vehicleStatus']['doorLock']
+    except:
+        pass
         
     try:
         response = requests.post(url, json = data)

--- a/modules/soc_kia/main.sh
+++ b/modules/soc_kia/main.sh
@@ -23,6 +23,11 @@ case $CHARGEPOINT in
 		efficiency=$wirkungsgradlp2
 		abrp_enable=$kia_abrp_enable_2
 		abrp_token=$kia_abrp_token_2
+		advanced=$kia_advanced2
+		adv_cachevalid=$kia_adv_cachevalid2
+		adv_12v=$kia_adv_12v2
+		adv_interval_unplug=$kia_adv_interval_unplug2
+		adv_ratelimit=$kia_adv_ratelimit2
 		;;
 	*)
 		# defaults to first charge point for backward compatibility
@@ -38,6 +43,11 @@ case $CHARGEPOINT in
 		efficiency=$wirkungsgradlp1
 		abrp_enable=$kia_abrp_enable
 		abrp_token=$kia_abrp_token
+		advanced=$kia_advanced
+		adv_cachevalid=$kia_adv_cachevalid
+		adv_12v=$kia_adv_12v
+		adv_interval_unplug=$kia_adv_interval_unplug
+		adv_ratelimit=$kia_adv_ratelimit
 		;;
 esac
 
@@ -56,6 +66,11 @@ ARGS+='"batterySize": "'"$akkug"'", '
 ARGS+='"efficiency": "'"$efficiency"'", '
 ARGS+='"abrpEnable": "'"$abrp_enable"'", '
 ARGS+='"abrpToken": "'"$abrp_token"'", '
+ARGS+='"advEnable": "'"$advanced"'", '
+ARGS+='"advCacheValid": "'"$adv_cachevalid"'", '
+ARGS+='"adv12vLimit": "'"$adv_12v"'", '
+ARGS+='"advIntUnplug": "'"$adv_interval_unplug"'", '
+ARGS+='"advRateLimit": "'"$adv_ratelimit"'", '
 ARGS+='"ramDiskDir": "'"$RAMDISKDIR"'", '
 ARGS+='"debugLevel": "'"$DEBUGLEVEL"'"'
 ARGS+='}'

--- a/modules/soc_kia/parameters.py
+++ b/modules/soc_kia/parameters.py
@@ -23,9 +23,6 @@ def setParameter(key, value):
 def loadParameters(argsFile):
     setParameter('reqTimeout', 60)
     setParameter('statusTimeout', 150)
-    setParameter('cacheValid', 10 * 60)
-    setParameter('soc12vLimit', 20)
-    setParameter('timerMinInterval', 15 * 60)
 
     try:
         f = open(argsFile, 'r')
@@ -47,6 +44,18 @@ def loadParameters(argsFile):
         setParameter('accountPin', str(argsDict['accountPin']))
         setParameter('vehicleVin', str(argsDict['vehicleVin']))
         setParameter('ramDiskDir', str(argsDict['ramDiskDir']))
+        setParameter('advEnable', int(argsDict['advEnable']))
+        
+        if getParameter('advEnable') == 0:
+            setParameter('cacheValid', 10 * 60)
+            setParameter('soc12vLimit', 20)
+            setParameter('timerMinInterval', 15 * 60)
+            setParameter('timerIntervalUnplug', getParameter('timerInterval'))
+        else:
+            setParameter('cacheValid', (int(argsDict['advCacheValid']) * 60))
+            setParameter('soc12vLimit', int(argsDict['adv12vLimit']))
+            setParameter('timerMinInterval', (int(argsDict['advRateLimit']) * 60))
+            setParameter('timerIntervalUnplug', int(argsDict['advIntUnplug']))
     except:
         raise
 

--- a/modules/soc_kia/soc.py
+++ b/modules/soc_kia/soc.py
@@ -67,6 +67,14 @@ def doManualUpdate():
     
 def saveSoc(soc, manual):
     try:
+        f = open(parameters.getParameter('currentSocFile'), 'r')
+        socOld = int(f.read())
+        f.close()
+    except:
+        socOld = 0
+        pass
+        
+    try:
         f = open(parameters.getParameter('currentSocFile'), 'w')
         f.write(str(int(soc)))
         f.close()
@@ -74,7 +82,7 @@ def saveSoc(soc, manual):
         raise
         
     try:
-        if parameters.getParameter('abrpEnable') == 1:
+        if (parameters.getParameter('abrpEnable') == 1) and ((manual == 0) or (soc != socOld)):
             abrp.pushABRP(soc)
     except:
         pass

--- a/modules/soc_kia/trigger.py
+++ b/modules/soc_kia/trigger.py
@@ -53,8 +53,12 @@ def isMinimumTimerExpired():
 
 def isTimerExpired():
     now = int(time.time())
-    secLeft = (state.getState('lastRun') + (parameters.getParameter('timerInterval') * 60)) - now
-
+    
+    if state.isPlugged() == 1:
+        secLeft = (state.getState('lastRun') + (parameters.getParameter('timerInterval') * 60)) - now
+    else:
+        secLeft = (state.getState('lastRun') + (parameters.getParameter('timerIntervalUnplug') * 60)) - now
+        
     if secLeft < 0:
         trigger = 1
         soclogging.logDebug(1, "SoC download triggered by timer")

--- a/runs/updateConfig.sh
+++ b/runs/updateConfig.sh
@@ -2057,8 +2057,8 @@ updateConfig(){
 	if grep -Fq "socmodul=soc_bluelink" $ConfigFile; then
 		sed -i "s/socmodul=soc_bluelink/socmodul=soc_kia/g" $ConfigFile
 	fi
-	if grep -Fq "socmodul1=soc_bluelink" $ConfigFile; then
-		sed -i "s/socmodul1=soc_bluelink/socmodul=soc_kia/g" $ConfigFile
+	if grep -Fq "socmodul1=soc_bluelinklp2" $ConfigFile; then
+		sed -i "s/socmodul1=soc_bluelinklp2/socmodul=soc_kialp2/g" $ConfigFile
 	fi
 	echo "Config file Update done."
 }

--- a/runs/updateConfig.sh
+++ b/runs/updateConfig.sh
@@ -2054,5 +2054,11 @@ updateConfig(){
 	if ! grep -Fq "alphav123=" $ConfigFile; then
 		echo "alphav123=0" >> $ConfigFile
 	fi
+	if grep -Fq "socmodul=soc_bluelink" $ConfigFile; then
+		sed -i "s/socmodul=soc_bluelink/socmodul=soc_kia/g" $ConfigFile
+	fi
+	if grep -Fq "socmodul1=soc_bluelink" $ConfigFile; then
+		sed -i "s/socmodul1=soc_bluelink/socmodul=soc_kia/g" $ConfigFile
+	fi
 	echo "Config file Update done."
 }

--- a/runs/updateConfig.sh
+++ b/runs/updateConfig.sh
@@ -1759,6 +1759,36 @@ updateConfig(){
 	if ! grep -Fq "kia_abrp_token_2=" $ConfigFile; then
 		echo "kia_abrp_token_2=''" >> $ConfigFile
 	fi
+	if ! grep -Fq "kia_advanced=" $ConfigFile; then
+		echo "kia_advanced=0" >> $ConfigFile
+	fi
+	if ! grep -Fq "kia_advanced2=" $ConfigFile; then
+		echo "kia_advanced2=0" >> $ConfigFile
+	fi
+	if ! grep -Fq "kia_adv_cachevalid=" $ConfigFile; then
+		echo "kia_adv_cachevalid=10" >> $ConfigFile
+	fi
+	if ! grep -Fq "kia_adv_cachevalid2=" $ConfigFile; then
+		echo "kia_adv_cachevalid2=10" >> $ConfigFile
+	fi
+	if ! grep -Fq "kia_adv_12v=" $ConfigFile; then
+		echo "kia_adv_12v=20" >> $ConfigFile
+	fi
+	if ! grep -Fq "kia_adv_12v2=" $ConfigFile; then
+		echo "kia_adv_12v2=20" >> $ConfigFile
+	fi
+	if ! grep -Fq "kia_adv_interval_unplug=" $ConfigFile; then
+		echo "kia_adv_interval_unplug=360" >> $ConfigFile
+	fi
+	if ! grep -Fq "kia_adv_interval_unplug2=" $ConfigFile; then
+		echo "kia_adv_interval_unplug2=360" >> $ConfigFile
+	fi
+	if ! grep -Fq "kia_adv_ratelimit=" $ConfigFile; then
+		echo "kia_adv_ratelimit=15" >> $ConfigFile
+	fi
+	if ! grep -Fq "kia_adv_ratelimit2=" $ConfigFile; then
+		echo "kia_adv_ratelimit2=15" >> $ConfigFile
+	fi
 	if ! grep -Fq "isss=" $ConfigFile; then
 		echo "isss=0" >> $ConfigFile
 	fi

--- a/web/settings/modulconfiglp.php
+++ b/web/settings/modulconfiglp.php
@@ -689,8 +689,7 @@
 									<optgroup label="Fahrzeughersteller">
 										<option <?php if($socmodulold == "soc_audi") echo "selected" ?> value="soc_audi">Audi</option>
 										<option <?php if($socmodulold == "soc_i3") echo "selected" ?> value="soc_i3">BMW &amp; Mini</option>
-										<option <?php if($socmodulold == "soc_bluelink") echo "selected" ?> value="soc_bluelink">Hyundai</option>
-										<option <?php if($socmodulold == "soc_kia") echo "selected" ?> value="soc_kia">Kia</option>
+										<option <?php if($socmodulold == "soc_kia") echo "selected" ?> value="soc_kia">Kia / Hyundai</option>
 										<option <?php if($socmodulold == "soc_eq") echo "selected" ?> value="soc_eq">Mercedes EQ</option>
 										<option <?php if($socmodulold == "soc_myopel") echo "selected" ?> value="soc_myopel">MyOpel</option>
 										<option <?php if($socmodulold == "soc_mypeugeot") echo "selected" ?> value="soc_mypeugeot">MyPeugeot</option>
@@ -849,7 +848,7 @@
 									});
 								</script>
 							</div>
-							<div id="socmbluelink" class="hide">
+							<div id="socmkia" class="hide">
 								<div class="form-group">
 									<div class="form-row mb-1">
 										<label for="soc_bluelink_email" class="col-md-4 col-form-label">E-Mail</label>
@@ -878,10 +877,6 @@
 											</span>
 										</div>
 									</div>
-								</div>
-							</div>
-							<div id="socmkia" class="hide">
-								<div class="form-group">
 									<div class="form-row mb-1">
 										<label for="soc_bluelink_pin" class="col-md-4 col-form-label">PIN</label>
 										<div class="col">
@@ -2169,7 +2164,6 @@
 							hideSection('#socvag');
 							hideSection('#socevcc');
 							hideSection('#socmqtt');
-							hideSection('#socmbluelink');
 							hideSection('#socmkia');
 							hideSection('#socmuser');
 							hideSection('#socmpass');
@@ -2198,12 +2192,6 @@
 								showSection('#socsupportinfo');
 								showSection('#socmqtt');
 							}
-							if($('#socmodul').val() == 'soc_bluelink') {
-								$('#socsuportlink').attr('href', 'https://openwb.de/forum/viewtopic.php?f=12&t=3138')
-								showSection('#socsupportinfo');
-								showSection('#socmkia');
-								showSection('#socmbluelink');
-							}
 							if($('#socmodul').val() == 'soc_id') {
 								showSection('#socoldevccwarning');
 								showSection('#socmid');
@@ -2221,7 +2209,6 @@
 								$('#socsuportlink').attr('href', 'https://openwb.de/forum/viewtopic.php?f=12&t=3137')
 								showSection('#socsupportinfo');
 								showSection('#socmkia');
-								showSection('#socmbluelink');
 							}
 							if($('#socmodul').val() == 'soc_audi') {
 								showSection('#socoldevccwarning');
@@ -2777,8 +2764,7 @@
 									<optgroup label="Fahrzeughersteller">
 										<option <?php if($socmodul1old == "soc_audilp2") echo "selected" ?> value="soc_audilp2">Audi</option>
 										<option <?php if($socmodul1old == "soc_i3s1") echo "selected" ?> value="soc_i3s1">BMW &amp; Mini</option>
-										<option <?php if($socmodul1old == "soc_bluelinklp2") echo "selected" ?> value="soc_bluelinklp2">Hyundai</option>
-										<option <?php if($socmodul1old == "soc_kialp2") echo "selected" ?> value="soc_kialp2">Kia</option>
+										<option <?php if($socmodul1old == "soc_kialp2") echo "selected" ?> value="soc_kialp2">Kia / Hyundai</option>
 										<option <?php if($socmodul1old == "soc_eqlp2") echo "selected" ?> value="soc_eqlp2">Mercedes EQ</option>
 										<option <?php if($socmodul1old == "soc_myopellp2") echo "selected" ?> value="soc_myopellp2">MyOpel</option>
 										<option <?php if($socmodul1old == "soc_mypeugeotlp2") echo "selected" ?> value="soc_mypeugeotlp2">MyPeugeot</option>
@@ -4045,16 +4031,6 @@
 								showSection('#socmuser2');
 								showSection('#socmpass2');
 								showSection('#socmvin2');
-							}
-							if($('#socmodul1').val() == 'soc_bluelinklp2') {
-								$('#socsuportlinklp2').attr('href', 'https://openwb.de/forum/viewtopic.php?f=12&t=3138')
-								showSection('#socsupportinfolp2');
-								showSection('#socmuser2');
-								showSection('#socmpass2');
-								showSection('#socmpin2');
-								showSection('#socmvin2');
-								showSection('#socmintervall2');
-								showSection('#socmkialp2');
 							}
 							if($('#socmodul1').val() == 'soc_kialp2') {
 								$('#socsuportlinklp2').attr('href', 'https://openwb.de/forum/viewtopic.php?f=12&t=3137')

--- a/web/settings/modulconfiglp.php
+++ b/web/settings/modulconfiglp.php
@@ -965,6 +965,60 @@
 											</div>
 										</div>
 									</div>
+									<div class="form-row mb-1">
+									<label class="col-md-4 col-form-label">Erweiterte Einstellungen</label>
+										<div class="col">
+											<div class="btn-group btn-group-toggle btn-block" data-toggle="buttons">
+												<label class="btn btn-outline-info<?php if($kia_advancedold == 0) echo " active" ?>">
+													<input type="radio" name="kia_advanced" id="kia_advancedOff" value="0"<?php if($kia_advancedold == 0) echo " checked=\"checked\"" ?>>Nein
+												</label>
+												<label class="btn btn-outline-info<?php if($kia_advancedold == 1) echo " active" ?>">
+													<input type="radio" name="kia_advanced" id="kia_advancedOn" value="1"<?php if($kia_advancedold == 1) echo " checked=\"checked\"" ?>>Ja
+												</label>
+											</div>
+											<span class="form-text small">
+												<br>
+											</span>
+										</div>
+									</div>
+									<div id="kia_advanceddiv" class="hide">
+										<div class="form-row mb-1">
+											<label for="kia_adv_cachevalid" class="col-md-4 col-form-label">Cache G&uuml;ltigkeit</label>
+											<div class="col">
+												<input class="form-control" type="number" min="0" step="1" name="kia_adv_cachevalid" id="kia_adv_cachevalid" value="<?php echo $kia_adv_cachevalidold ?>">
+												<span class="form-text small">
+													Gültigkeitsdauer des letzten Status in Minuten, z.B. nach Abstellen des Autos oder Abruf in der App (0=Abruf immer vom Auto; Default: 10)<br>
+												</span>
+											</div>
+										</div>
+										<div class="form-row mb-1">
+											<label for="kia_adv_12v" class="col-md-4 col-form-label">12V SoC Limit</label>
+											<div class="col">
+												<input class="form-control" type="number" min="0" max="100" step="1" name="kia_adv_12v" id="kia_adv_12v" value="<?php echo $kia_adv_12vold ?>">
+												<span class="form-text small">
+													Minimaler SoC der 12V-Batterie für Abrufe in Prozent (Default: 20)<br>
+												</span>
+											</div>
+										</div>
+										<div class="form-row mb-1">
+											<label for="kia_adv_interval_unplug" class="col-md-4 col-form-label">Abrufintervall abgesteckt</label>
+											<div class="col">
+												<input class="form-control" type="number" min="0" step="1" name="kia_adv_interval_unplug" id="kia_adv_interval_unplug" value="<?php echo $kia_adv_interval_unplugold ?>">
+												<span class="form-text small">
+													Abrufintervall bei abgestecktem Auto in Minuten (sofern freigegeben)<br>
+												</span>
+											</div>
+										</div>
+										<div class="form-row mb-1">
+											<label for="kia_adv_ratelimit" class="col-md-4 col-form-label">Abrufsperre</label>
+											<div class="col">
+												<input class="form-control" type="number" min="0" step="1" name="kia_adv_ratelimit" id="kia_adv_ratelimit" value="<?php echo $kia_adv_ratelimitold ?>">
+												<span class="form-text small">
+													Minimaler Abstand zwischen Abrufen in Minuten (default: 15)<br>
+												</span>
+											</div>
+										</div>
+									</div>
 								</div>
 								<script>
 									$(function() {
@@ -982,6 +1036,13 @@
 												showSection('#kia_abrp_enablediv');
 											}
 										}
+										function visibility_kia_advanced() {
+											if($('#kia_advancedOff').prop("checked")) {
+												hideSection('#kia_advanceddiv');
+											} else {
+												showSection('#kia_advanceddiv');
+											}
+										}
 
 										$('input[type=radio][name=kia_soccalclp1]').change(function(){
 											visibility_kia_soccalclp1();
@@ -989,9 +1050,13 @@
 										$('input[type=radio][name=kia_abrp_enable]').change(function(){
 											visibility_kia_abrp_enable();
 										});
+										$('input[type=radio][name=kia_advanced]').change(function(){
+											visibility_kia_advanced();
+										});
 
 										visibility_kia_soccalclp1();
 										visibility_kia_abrp_enable();
+										visibility_kia_advanced();
 									});
 								</script>
 							</div>
@@ -3645,6 +3710,60 @@
 											</div>
 										</div>
 									</div>
+									<div class="form-row mb-1">
+									<label class="col-md-4 col-form-label">Erweiterte Einstellungen</label>
+										<div class="col">
+											<div class="btn-group btn-group-toggle btn-block" data-toggle="buttons">
+												<label class="btn btn-outline-info<?php if($kia_advanced2old == 0) echo " active" ?>">
+													<input type="radio" name="kia_advanced2" id="kia_advanced2Off" value="0"<?php if($kia_advanced2old == 0) echo " checked=\"checked\"" ?>>Nein
+												</label>
+												<label class="btn btn-outline-info<?php if($kia_advanced2old == 1) echo " active" ?>">
+													<input type="radio" name="kia_advanced2" id="kia_advanced2On" value="1"<?php if($kia_advanced2old == 1) echo " checked=\"checked\"" ?>>Ja
+												</label>
+											</div>
+											<span class="form-text small">
+												<br>
+											</span>
+										</div>
+									</div>
+									<div id="kia_advanced2div" class="hide">
+										<div class="form-row mb-1">
+											<label for="kia_adv_cachevalid2" class="col-md-4 col-form-label">Cache G&uuml;ltigkeit</label>
+											<div class="col">
+												<input class="form-control" type="number" min="0" step="1" name="kia_adv_cachevalid2" id="kia_adv_cachevalid2" value="<?php echo $kia_adv_cachevalid2old ?>">
+												<span class="form-text small">
+													Gültigkeitsdauer des letzten Status in Minuten, z.B. nach Abstellen des Autos oder Abruf in der App (0=Abruf immer vom Auto; Default: 10)<br>
+												</span>
+											</div>
+										</div>
+										<div class="form-row mb-1">
+											<label for="kia_adv_12v2" class="col-md-4 col-form-label">12V SoC Limit</label>
+											<div class="col">
+												<input class="form-control" type="number" min="0" max="100" step="1" name="kia_adv_12v2" id="kia_adv_12v2" value="<?php echo $kia_adv_12v2old ?>">
+												<span class="form-text small">
+													Minimaler SoC der 12V-Batterie für Abrufe in Prozent (Default: 20)<br>
+												</span>
+											</div>
+										</div>
+										<div class="form-row mb-1">
+											<label for="kia_adv_interval_unplug2" class="col-md-4 col-form-label">Abrufintervall abgesteckt</label>
+											<div class="col">
+												<input class="form-control" type="number" min="0" step="1" name="kia_adv_interval_unplug2" id="kia_adv_interval_unplug2" value="<?php echo $kia_adv_interval_unplug2old ?>">
+												<span class="form-text small">
+													Abrufintervall bei abgestecktem Auto in Minuten (sofern freigegeben)<br>
+												</span>
+											</div>
+										</div>
+										<div class="form-row mb-1">
+											<label for="kia_adv_ratelimit2" class="col-md-4 col-form-label">Abrufsperre</label>
+											<div class="col">
+												<input class="form-control" type="number" min="0" step="1" name="kia_adv_ratelimit2" id="kia_adv_ratelimit2" value="<?php echo $kia_adv_ratelimit2old ?>">
+												<span class="form-text small">
+													Minimaler Abstand zwischen Abrufen in Minuten (default: 15)<br>
+												</span>
+											</div>
+										</div>
+									</div>
 								</div>
 								<script>
 								$(function() {
@@ -3662,6 +3781,13 @@
 											showSection('#kia_abrp_enable_2div');
 										}
 									}
+									function visibility_kia_advanced2() {
+										if($('#kia_advanced2Off').prop("checked")) {
+											hideSection('#kia_advanced2div');
+										} else {
+											showSection('#kia_advanced2div');
+										}
+									}
 
 									$('input[type=radio][name=kia_soccalclp2]').change(function(){
 										visibility_kia_soccalclp2();
@@ -3669,9 +3795,13 @@
 									$('input[type=radio][name=kia_abrp_enable_2]').change(function(){
 										visibility_kia_abrp_enable_2();
 									});
+									$('input[type=radio][name=kia_advanced2]').change(function(){
+										visibility_kia_advanced2();
+									});
 
 									visibility_kia_soccalclp2();
 									visibility_kia_abrp_enable_2();
+									visibility_kia_advanced2();
 								});
 								</script>
 							</div>


### PR DESCRIPTION
Dummy-Modul für Hyundai entfernt und Kia+Hyundai komplett zusammengeführt
Weitere Daten für ABRP-Push hinzugefügt und Anzahl der Uploads verringert
Neue Konfigurationsmöglichkeiten unter "Erweiterte Einstellungen" verfügbar