### PR TITLE
Fix smarthome runtime after 30 min elapsed for every full hour

### DIFF
--- a/web/themes/colors/powerdata.js
+++ b/web/themes/colors/powerdata.js
@@ -397,7 +397,7 @@ function formatWattH(watt) {
 	}
 }
 function formatTime(seconds) {
-	const hours = (seconds / 3600).toFixed(0);
+	const hours = Math.floor(seconds / 3600);
 	const minutes = ((seconds % 3600) / 60).toFixed(0);
 	if (hours > 0) {
 		return (hours + "h " + minutes + " min");

--- a/web/themes/dark/processAllMqttMsg.js
+++ b/web/themes/dark/processAllMqttMsg.js
@@ -1029,9 +1029,7 @@ function processSmartHomeDevicesMessages(mqttmsg, mqttpayload) {
 			actualPower += ' Min';
 		} else {
 			rest = (actualPower % 3600 / 60).toFixed(0);
-			var ganznot = (actualPower / 3600)
-			// nachkomma weg
-			ganz = (ganznot - (ganznot % 1)).toFixed(0);
+			ganz = Math.floor(actualPower / 3600);
 			actualPower = ganz + ' H ' + rest +' Min';
 		}
 		element.text(actualPower);


### PR DESCRIPTION
Smarthome runtime used toFixed(0) for fractional hours which rounds up
for everytime the fractional part becomes larger than .5. Replacing with
Math.floor leads to the desired outcome.