### PR TITLE
Smarthomeerweiterung Hausverbrauch

### DIFF
--- a/loadvars.sh
+++ b/loadvars.sh
@@ -962,6 +962,7 @@ loadvars(){
 	if [ -s "ramdisk/device7_watt" ]; then shd7_w=$(<ramdisk/device7_watt); else shd7_w=0; fi
 	if [ -s "ramdisk/device8_watt" ]; then shd8_w=$(<ramdisk/device8_watt); else shd8_w=0; fi
 	if [ -s "ramdisk/device9_watt" ]; then shd9_w=$(<ramdisk/device9_watt); else shd9_w=0; fi
+	if [ -s "ramdisk/devicetotal_watt_hausmin" ]; then shdall_w=$(<ramdisk/devicetotal_watt_hausmin); else shdall_w=0; fi
 	if [ -s "ramdisk/device1_temp0" ]; then shd1_t0=$(<ramdisk/device1_temp0); else shd1_t0=0; fi
 	if [ -s "ramdisk/device1_temp1" ]; then shd1_t1=$(<ramdisk/device1_temp1); else shd1_t1=0; fi
 	if [ -s "ramdisk/device1_temp2" ]; then shd1_t2=$(<ramdisk/device1_temp2); else shd1_t2=0; fi
@@ -972,7 +973,8 @@ loadvars(){
 	if [ -s "ramdisk/verbraucher3_watt" ]; then verb3_w=$(<ramdisk/verbraucher3_watt); else verb3_w=0; fi
 	verb3_w=$(printf "%.0f\n" $verb3_w)
 
-	hausverbrauch=$((wattbezugint - pvwatt - ladeleistung - speicherleistung - shd1_w - shd2_w - shd3_w - shd4_w - shd5_w - shd6_w - shd7_w - shd8_w - shd9_w - verb1_w - verb2_w - verb3_w))
+	#hausverbrauch=$((wattbezugint - pvwatt - ladeleistung - speicherleistung - shd1_w - shd2_w - shd3_w - shd4_w - shd5_w - shd6_w - shd7_w - shd8_w - shd9_w - verb1_w - verb2_w - verb3_w))
+	hausverbrauch=$((wattbezugint - pvwatt - ladeleistung - speicherleistung - shdall_w - verb1_w - verb2_w - verb3_w))
 	if (( hausverbrauch < 0 )); then
 		if [ -f /var/www/html/openWB/ramdisk/hausverbrauch.invalid ]; then
 			hausverbrauchinvalid=$(</var/www/html/openWB/ramdisk/hausverbrauch.invalid)

--- a/runs/smarthomehandler.py
+++ b/runs/smarthomehandler.py
@@ -213,7 +213,7 @@ def sepwatt(oldwatt,oldwattk,nummer):
         try:
             measureportsdm = str(config.get('smarthomedevices', 'device_measureportsdm_'+str(nummer)))
         except:
-            measureportsdm = 8899
+            measureportsdm = "8899"
         argumentList[1] = prefixpy +'sdm630/sdm630.py'
         argumentList[4] = config.get('smarthomedevices', 'device_measureid_'+str(nummer)) # replace uberschuss as third command line parameter with measureid
         argumentList.append(measureportsdm)

--- a/runs/smarthomehandler.py
+++ b/runs/smarthomehandler.py
@@ -602,6 +602,7 @@ def on_message(client, userdata, msg):
 def getdevicevalues():
     global totalwatt
     global totalwattot
+    global totalminhaus
     for i in range(1, (numberOfSupportedDevices+1)):
         DeviceConfigured[i-1] = config.get('smarthomedevices', 'device_configured_'+str(i)) # list starts at 0
         if (DeviceConfigured[i-1] != DeviceConfiguredOld[i-1]) and (DeviceConfigured[i-1] == "0"):
@@ -620,6 +621,7 @@ def getdevicevalues():
     numberOfDevices = 0
     totalwatt = 0
     totalwattot = 0
+    totalminhaus = 0
     for n in DeviceConfigured:
         numberOfDevices += 1
         # prepare
@@ -675,6 +677,10 @@ def getdevicevalues():
                 device_acthorpower = int(config.get('smarthomedevices', 'device_acthorpower_'+str(numberOfDevices)))
             except:
                 device_acthorpower = 0
+            try:
+                device_homeconsumtion = int(config.get('smarthomedevices', 'device_homeconsumtion_'+str(numberOfDevices)))
+            except:
+                device_homeconsumtion = 0
             pyname0 = getdir(switchtyp,devicename)
             try:
                 pyname = pyname0 +"/watt.py"
@@ -753,6 +759,8 @@ def getdevicevalues():
                     totalwatt = totalwatt + watt
                 else:
                     totalwattot = totalwattot + watt
+                if (device_homeconsumtion == 0):
+                    totalminhaus = totalminhaus + watt
                 DeviceValues.update( {str(numberOfDevices) + "watt" : watt})
                 DeviceValues.update( {str(numberOfDevices) + "relais" : relais})
                 f = open(basePath+'/ramdisk/device' + str(numberOfDevices) + '_watt', 'w')
@@ -819,8 +827,12 @@ def getdevicevalues():
     f = open(basePath+'/ramdisk/devicetotal_watt_other', 'w')
     f.write(str(totalwattot))
     f.close()
+    f = open(basePath+'/ramdisk/devicetotal_watt_hausmin', 'w')
+    f.write(str(totalminhaus))
+    f.close()
     logDebug(LOGLEVELDEBUG, "Total Watt abschaltbarer smarthomedevices: " + str(totalwatt)  )
     logDebug(LOGLEVELDEBUG, "Total Watt nichtabschaltbarer smarthomedevices: " + str(totalwattot) )
+    logDebug(LOGLEVELDEBUG, "Total Watt nicht im Hausverbrauch: " + str(totalminhaus) )
     publishmqtt()
 
 def turndevicerelais(nummer, zustand,ueberschussberechnung,updatecnt):


### PR DESCRIPTION
Bisher wurde die Leistungsaufnahme aller Devices vom Hausverbrauch abgezogen. Neu kann das pro Device einzeln definiert werden. Der Smarthomehandler errechnet die abzuziehende Leistungsaufnahme der Devices und in Loadvars.sh wird der aktuelle Hausverbrauch nun anderes gerechnet. Diese Änderung bezieht sich auf die Startseite und das Langzeitlogging. Die Tages, Monats und die Jahreslogs werden später noch angepasst.