### PR TITLE
MQTT mit HTTP-API

### DIFF
--- a/web/api.php
+++ b/web/api.php
@@ -135,44 +135,4 @@ if(isset($_GET["get"])) {
 		echo json_encode($json);
 	}
 }
-
-# HTTP-API as bridge to MQTT
-if(isset($_GET["topic"])) {
-	$topic = $_GET["topic"];
-	# writing topic
-	if(isset($_GET["message"])) {
-		$message = $_GET["message"];
-		$command = "mosquitto_pub -h localhost -t '$topic' -m '$message' 2>&1";
-		$output = exec($command);
-		# Skip an annoying warning because it doesn't cause any problems
-		$output = str_replace("Warning: Unable to locate configuration directory, default config not loaded.", "", $output);
-		# no output if mosquitto_pub was successful
-		if($output != ""){
-			http_response_code(500);
-			echo "Error: $output";
-		}
-		else{
-			http_response_code(200);
-			echo "Message '$message' successfully published to topic '$topic'!";
-		}
-	}
-	# reading topic
-	else{
-		$command = "mosquitto_sub -h localhost -t '$topic' -C 1 -W 1 2>&1";
-		$output = exec($command);
-		# Skip an annoying warning because it doesn't cause any problems
-		$output = str_replace("Warning: Unable to locate configuration directory, default config not loaded.", "", $output);
-		# no output if mosquitto_sub failed
-		if($output != ""){
-			http_response_code(200);
-			echo $output;
-		}
-		else{
-			http_response_code(404);
-			echo "Error: The topic '$topic' doesn't contain a retained value!";
-		}
-	}
-
-}
-
 ?>

--- a/web/api.php
+++ b/web/api.php
@@ -148,9 +148,11 @@ if(isset($_GET["topic"])) {
 		$output = str_replace("Warning: Unable to locate configuration directory, default config not loaded.", "", $output);
 		# no output if mosquitto_pub was successful
 		if($output != ""){
+			http_response_code(500);
 			echo "Error: $output";
 		}
 		else{
+			http_response_code(200);
 			echo "Message '$message' successfully published to topic '$topic'!";
 		}
 	}
@@ -162,9 +164,11 @@ if(isset($_GET["topic"])) {
 		$output = str_replace("Warning: Unable to locate configuration directory, default config not loaded.", "", $output);
 		# no output if mosquitto_sub failed
 		if($output != ""){
+			http_response_code(200);
 			echo $output;
 		}
 		else{
+			http_response_code(404);
 			echo "Error: The topic '$topic' doesn't contain a retained value!";
 		}
 	}

--- a/web/api.php
+++ b/web/api.php
@@ -135,4 +135,40 @@ if(isset($_GET["get"])) {
 		echo json_encode($json);
 	}
 }
+
+# HTTP-API as bridge to MQTT
+if(isset($_GET["topic"])) {
+	$topic = $_GET["topic"];
+	# writing topic
+	if(isset($_GET["message"])) {
+		$message = $_GET["message"];
+		$command = "mosquitto_pub -h localhost -t '$topic' -m '$message' 2>&1";
+		$output = exec($command);
+		# Skip an annoying warning because it doesn't cause any problems
+		$output = str_replace("Warning: Unable to locate configuration directory, default config not loaded.", "", $output);
+		# no output if mosquitto_pub was successful
+		if($output != ""){
+			echo "Error: $output";
+		}
+		else{
+			echo "Message '$message' successfully published to topic '$topic'!";
+		}
+	}
+	# reading topic
+	else{
+		$command = "mosquitto_sub -h localhost -t '$topic' -C 1 -W 1 2>&1";
+		$output = exec($command);
+		# Skip an annoying warning because it doesn't cause any problems
+		$output = str_replace("Warning: Unable to locate configuration directory, default config not loaded.", "", $output);
+		# no output if mosquitto_sub failed
+		if($output != ""){
+			echo $output;
+		}
+		else{
+			echo "Error: The topic '$topic' doesn't contain a retained value!";
+		}
+	}
+
+}
+
 ?>

--- a/web/settings/mqttapi.php
+++ b/web/settings/mqttapi.php
@@ -1,0 +1,56 @@
+<?php
+# HTTP-API as bridge to MQTT
+
+function StringStartsWith ($string, $start){
+	$len = strlen($start);
+	return (substr($string, 0, $len) === $start);
+}
+
+if(isset($_GET["topic"])) {
+	$topic = $_GET["topic"];
+	# writing topic
+	if(isset($_GET["message"])) {
+		$message = $_GET["message"];
+		# check if topic is allowed to write
+		if(StringStartsWith($topic, "openWB/set/")){
+			$command = "mosquitto_pub -h localhost -t '$topic' -m '$message' 2>&1";
+			$output = exec($command);
+			# Skip an annoying warning because it doesn't cause any problems
+			$output = str_replace("Warning: Unable to locate configuration directory, default config not loaded.", "", $output);
+			# no output if mosquitto_pub was successful
+			if($output != ""){
+				http_response_code(500);
+				echo "Error: $output";
+			}
+			else{
+				http_response_code(200);
+				echo "Message '$message' successfully published to topic '$topic'.";
+			}
+		}
+		else{
+			http_response_code(400);
+			echo "Error: Only 'openWB/set/...' topics are allowed to write.";
+		}
+	}
+	# reading topic
+	else{
+		$command = "mosquitto_sub -h localhost -t '$topic' -C 1 -W 1 2>&1";
+		$output = exec($command);
+		# Skip an annoying warning because it doesn't cause any problems
+		$output = str_replace("Warning: Unable to locate configuration directory, default config not loaded.", "", $output);
+		# no output if mosquitto_sub failed
+		if($output != ""){
+			http_response_code(200);
+			echo $output;
+		}
+		else{
+			http_response_code(404);
+			echo "Error: The topic '$topic' doesn't contain a retained value.";
+		}
+	}
+}
+else{
+    http_response_code(400);
+	echo "Error: No 'topic' field provided. \nExample reading a MQTT-Topic: 'http://IP/openWB/web/settings/mqttapi.php?topic=openWB/pv/W' \nExample writing a MQTT-Topic: 'http://IP/openWB/web/settings/mqttapi.php?topic=openWB/set/pv/1/W&message=-1000' ";
+}
+?>

--- a/web/settings/mqttapi.php
+++ b/web/settings/mqttapi.php
@@ -1,18 +1,13 @@
 <?php
 # HTTP-API as bridge to MQTT
 
-function StringStartsWith ($string, $start){
-	$len = strlen($start);
-	return (substr($string, 0, $len) === $start);
-}
-
 if(isset($_GET["topic"])) {
 	$topic = $_GET["topic"];
 	# writing topic
 	if(isset($_GET["message"])) {
 		$message = $_GET["message"];
 		# check if topic is allowed to write
-		if(StringStartsWith($topic, "openWB/set/")){
+		if(strpos($topic, "/set/") !== false){
 			$command = "mosquitto_pub -h localhost -t '$topic' -m '$message' 2>&1";
 			$output = exec($command);
 			# Skip an annoying warning because it doesn't cause any problems
@@ -29,7 +24,7 @@ if(isset($_GET["topic"])) {
 		}
 		else{
 			http_response_code(400);
-			echo "Error: Only 'openWB/set/...' topics are allowed to write.";
+			echo "Error: Only '.../set/...' topics are allowed to write.";
 		}
 	}
 	# reading topic


### PR DESCRIPTION
Ich habe mal überlegt, wie man weiter das iOS-Widget verwenden kann wenn openWB mit 2.0 keine Ramdisk mehr hat.
Daher die Idee der "MQTT-HTTP-Brücke". Über die HTTP-API können so alle MQTT-Topics gelesen und geschrieben werden.

Beispiel schreiben: `http://IP/openWB/web/api.php?topic=openWB/set/pv/1/W&message=-1000`
Beispiel lesen: `http://IP/openWB/web/api.php?topic=openWB/pv/W`

Vielleicht ist es ja auch jetzt schon für manche Anwendungsfälle sinnvoll, da die HTTP-API schon sehr dünn ist. Ihr müsst es aber auch nicht mergen wenn irgendwas dagegen spricht, ist wie gesagt eher als Überlegung entstanden.