### PR TITLE
smarthomehandler viessmann

### DIFF
--- a/modules/smarthome/viessmann/off.py
+++ b/modules/smarthome/viessmann/off.py
@@ -19,7 +19,7 @@ uberschuss=int(sys.argv[3])
 #ausserhalb des Zeitprogrammes:
 #0: "Einmalige Warmwasserbereitung" AUS
 #1: "Einmalige Warmwasserbereitung" EIN
-#Für die "Einmalige Warmwasserbereitung" wird der Warmwassertemperatur-Sollwert 2 genutzt.
+#Fuer die "Einmalige Warmwasserbereitung" wird der Warmwassertemperatur-Sollwert 2 genutzt.
 #CO-17
 #coiss read write bolean
 #register start 00000
@@ -32,8 +32,9 @@ else:
    f = open( file_string , 'w')
 print ('%s devicenr %s ipadr %s ueberschuss %6d try to connect (modbus)' % (time_string,devicenumber,ipadr,uberschuss),file=f)
 client = ModbusTcpClient(ipadr, port=502)
-rq = client.write_coil(16, False)
+rq = client.write_coil(16, False,unit=1)
 print (rq,file=f)
+client.close()
 print ('%s devicenr %s ipadr %s Einmalige Warmwasseraufbereitung deaktiviert CO-17 = 0 ' % (time_string,devicenumber,ipadr),file=f)
 f.close()
 pvmodus = 0

--- a/modules/smarthome/viessmann/on.py
+++ b/modules/smarthome/viessmann/on.py
@@ -21,7 +21,7 @@ uberschuss=int(sys.argv[3])
 #ausserhalb des Zeitprogrammes:
 #0: "Einmalige Warmwasserbereitung" AUS
 #1: "Einmalige Warmwasserbereitung" EIN
-#Für die "Einmalige Warmwasserbereitung" wird der Warmwassertemperatur-Sollwert 2 genutzt.
+#Fuer die "Einmalige Warmwasserbereitung" wird der Warmwassertemperatur-Sollwert 2 genutzt.
 #CO-17
 #coiss read write bolean
 #register start 00000
@@ -34,8 +34,9 @@ else:
    f = open( file_string , 'w')
 print ('%s devicenr %s ipadr %s ueberschuss %6d try to connect (modbus)' % (time_string,devicenumber,ipadr,uberschuss),file=f)
 client = ModbusTcpClient(ipadr, port=502)
-rq = client.write_coil(16, True)
+rq = client.write_coil(16, True,unit=1)
 print (rq,file=f)
+client.close()
 print ('%s devicenr %s ipadr %s Einmalige Warmwasseraufbereitung aktiviert CO-17 = 1' % (time_string,devicenumber,ipadr),file=f)
 f.close()
 f = open( file_stringpv , 'w')


### PR DESCRIPTION
Die WP von Viessmann braucht zwingend einen close auf die modbus Schnittstelle anderenfalls hängt sich die Steuerung der WP auf.