### PR TITLE
Bridge setting 'try_private' configurable via UI

### DIFF
--- a/web/settings/cloudregistrate.php
+++ b/web/settings/cloudregistrate.php
@@ -68,6 +68,7 @@
 			'RemotePrefix' => $clouduser.'/',
 			'mqttProtocol' => 'mqttv311',
 			'tlsProtocol' => 'tlsv1.2',
+			'tryPrivate' => '1',
 			'exportStatus' => '1',
 			'exportGraph' => '1',
 			'subscribeConfigs' => '1',

--- a/web/settings/mqtt.php
+++ b/web/settings/mqtt.php
@@ -52,6 +52,7 @@
 		<div role="main" class="container" style="margin-top:20px">
 			<?php
 				$files = glob('/etc/mosquitto/conf.d/99-bridge-*.conf');
+				$files = array_merge($files, glob('/etc/mosquitto/conf.d/99-bridge-*.conf.no'));
 				$filesCount = count($files);
 				// give the user the option to configure more than one bridge
 				array_push($files, "");
@@ -81,7 +82,7 @@
 					$bridgeEnabled = preg_match('/.*\.conf$/', $currentFile) === 1;
 					$subscribeConfigs = false;
 					foreach($bridgeLines as $bridgeLine) {
-						//echo "line '$bridgeLine'<br/>";
+						// echo "line '$bridgeLine'<br/>";
 						if(is_null($remotePrefix) && preg_match('/^\s*topic\s+([^\s]+?)\s+([^\s]+?)\s+([^\s]+?)\s+([^\s]+?)\s+([^\s]+?)\s+/', $bridgeLine, $matches) === 1) {
 							// echo "Matches: " . var_dump($matches);
 							$remotePrefix = trim($matches[5]);

--- a/web/settings/mqtt.php
+++ b/web/settings/mqtt.php
@@ -51,7 +51,7 @@
 		<div id="nav"></div> <!-- placeholder for navbar -->
 		<div role="main" class="container" style="margin-top:20px">
 			<?php
-				$files = glob('/etc/mosquitto/conf.d/99-bridge-*.conf*');
+				$files = glob('/etc/mosquitto/conf.d/99-bridge-*.conf');
 				$filesCount = count($files);
 				// give the user the option to configure more than one bridge
 				array_push($files, "");
@@ -73,6 +73,7 @@
 					$exportEvu = false;
 					$exportPv = false;
 					$exportAllLps = false;
+					$tryPrivate = false;
 					$subscribeChargeMode = false;
 					$exportGraph = false;
 					$exportStatus = false;
@@ -102,6 +103,10 @@
 						}
 						else if(preg_match('/^\s*bridge_tls_version\s+(.+)/', $bridgeLine, $matches) === 1) {
 							$tlsVersion = trim($matches[1]);
+						}
+
+						if(preg_match('/^\s*try_private\s+true/', $bridgeLine) === 1) {
+							$tryPrivate = true;
 						}
 
 						if(preg_match('/^\s*topic\s+openWB\/global\/#/', $bridgeLine) === 1) {
@@ -231,6 +236,22 @@
 									Version des TLS Protokolls, welches zur Verschlüsselung der Kommunikation mit dem entfernten Server verwendet wird.
 									TLSv 1.3 ist empfohlen, wird jedoch erst ab Debian Version "Buster" unterstützt.
 								</span>
+							</div>
+						</div>
+						<div class="form-row mb-1">
+							<label class="col-md-4 col-form-label">Br&uuml;cke signalisieren</label>
+							<div class="col">
+								<div class="btn-group btn-block btn-group-toggle" data-toggle="buttons">
+									<label class="btn btn-outline-info<?php if($exportStatus == 0) echo " active" ?>">
+										<input type="radio" name="tryPrivate" id="tryPrivateOff" value="0"<?php if(! $tryPrivate) echo " checked=\"checked\"" ?>>Aus
+									</label>
+									<label class="btn btn-outline-info<?php if($exportStatus == 1) echo " active" ?>">
+										<input type="radio" name="tryPrivate" id="tryPrivateOn" value="1"<?php if($tryPrivate) echo " checked=\"checked\"" ?>>An
+									</label>
+								</div>
+								<span class="form-text small">Aktiviert eine propriet&auml;re MQTT Protokoll-Erweiterung des Mosquitto Brokers, welche dem entfernten Broker signalisiert dass es sich um
+								eine MQTT Br&uumlcke handelt. Ergibt bessere Leistung mit Mosquitto-Brokern, ist jedoch inkompatibel mit vielen anderen MQTT-Brokern. Daher bitte nur aktivieren, wenn der Ziel-Broker
+								sicher ein Mosquitto-Broker ist.</span>
 							</div>
 						</div>
 					</div>

--- a/web/settings/savemqtt.php
+++ b/web/settings/savemqtt.php
@@ -180,6 +180,7 @@ if(!preg_match('/^(tlsv1.2|tlsv1.3)$/', $tlsProtocol)) {
 	cleanAndExit("Interner Fehler: Ung&uuml;tiges TLS Protokoll '" . htmlentities($tlsProtocol) . "'");
 }
 
+$tryPrivate = isset($_POST['tryPrivate']) && ($_POST['tryPrivate'] == 1) ? "true" : "false";
 $exportStatus = isset($_POST['exportStatus']) && ($_POST['exportStatus'] == 1);
 $exportGraph = isset($_POST['exportGraph']) && ($_POST['exportGraph'] == 1);
 $subscribeConfigs = isset($_POST['subscribeConfigs']) && ($_POST['subscribeConfigs'] == 1);
@@ -306,9 +307,9 @@ bridge_tls_version $tlsProtocol
 # Only change if you know what you're doing!
 bridge_insecure false
 
-# Indicate to remote that we're a bridge.
+# Indicate to remote that we're a bridge. Only compatible with remote Mosquitto brokers.
 # Only change if you know what you're doing!
-try_private true
+try_private $tryPrivate
 
 # How often a "ping" is sent to the remote server to indicate that we're still alive and keep firewalls open.
 keepalive_interval 63


### PR DESCRIPTION
Setting `try_private` is not compatible with many non-Mosquitto brokers but beneficial for Mosquitto.

This PR allows to configure it via UI.

Addresses issue #1498.