### PR TITLE
Fronius mit S0

### DIFF
--- a/modules/bezug_fronius_s0/fronius_s0.py
+++ b/modules/bezug_fronius_s0/fronius_s0.py
@@ -15,7 +15,7 @@ ip_address = str(sys.argv[2])
 
 response = requests.get('http://'+ip_address+'/solar_api/v1/GetPowerFlowRealtimeData.fcgi', timeout = 5).json()
 try:
-    if primo == 1:
+    if primo == str(1):
         wattbezug=int(response["Body"]["Data"]["Site"]["P_Grid"])
     else:
         wattbezug=int(response["Body"]["Data"]["PowerReal_P_Sum"])
@@ -25,15 +25,15 @@ except:
 #pvwatttmp=$(curl --connect-timeout 5 -s $wrfroniusip/solar_api/v1/GetInverterRealtimeData.cgi?Scope=System)
 #pvwatt=$(echo $pvwatttmp | jq '.Body.Data.PAC.Values' | sed 's/.*://' | tr -d '\n' | sed 's/^.\{2\}//' | sed 's/.$//' )
 f = open( "ramdisk/pvwatt" , 'r')
-pvwatt =f.read()
+pvwatt =int(f.read())
 f.close()
 wattb=pvwatt + wattbezug
 
 #wenn WR aus bzw. im standby (keine Antwort) ersetze leeren Wert durch eine 0
 regex='^[0-9]+$'
 ra='^-[0-9]+$'
-if re.search(regex, wattbezug) == None:
-    if re.search(ra, wattbezug) == None:
+if re.search(regex, str(wattbezug)) == None:
+    if re.search(ra, str(wattbezug)) == None:
         wattbezug=0
 
 # zur weiteren verwendung im webinterface
@@ -48,7 +48,8 @@ params = (('Scope', 'System'),)
 kwhtmp = requests.get('http://'+ip_address+'/solar_api/v1/GetMeterRealtimeData.cgi', params=params, timeout = 5).json()
 # jq-Funktion funktioniert hier leider nicht,  wegen "0" als Bezeichnung
 try:
-    ikwh = kwhtmp["EnergyReal_WAC_Minus_Absolute"]
+    for location in kwhtmp["Body"]["Data"]:
+        ikwh = str(kwhtmp["Body"]["Data"][location]["EnergyReal_WAC_Minus_Absolute"])
 except:
     traceback.print_exc()
 ikwh = ikwh.replace(" ", "")
@@ -66,7 +67,8 @@ f.close()
 # bei Smartmeter im Verbrauchsweig immer 0
 #ekwh=$(echo ${kwhtmp##*EnergyReal_WAC_Plus_Absolute} | sed 's/,.*//' | tr -d ' ' | tr -d ':' | tr -d '\"')
 try:
-    ekwh = kwhtmp["EnergyReal_WAC_Plus_Absolute"]
+    for location in kwhtmp["Body"]["Data"]:
+        ekwh = str(kwhtmp["Body"]["Data"][location]["EnergyReal_WAC_Plus_Absolute"])
 except:
     traceback.print_exc()
 ekwh = ekwh.split(",")[0]

--- a/modules/bezug_fronius_s0/main.sh
+++ b/modules/bezug_fronius_s0/main.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
 
-sudo python3 /var/www/html/openWB/modules/bezug_fronius_s0/fronius_s0.py froniusprimo $wrfroniusip
+sudo python3 /var/www/html/openWB/modules/bezug_fronius_s0/fronius_s0.py $froniusprimo $wrfroniusip
 wattbezug=$(</var/www/html/openWB/ramdisk/wattbezug)
 echo $wattbezug

--- a/modules/bezug_fronius_sm/main.sh
+++ b/modules/bezug_fronius_sm/main.sh
@@ -62,8 +62,7 @@ elif [[ $froniusvar2 == "2" ]]; then
 	bezuga1=$(echo "scale=2; $bezugw1 / $evuv1" | bc)
 	bezuga2=$(echo "scale=2; $bezugw2 / $evuv2" | bc)
 	bezuga3=$(echo "scale=2; $bezugw3 / $evuv3" | bc)
-	# TODO: ist dieser Parameter für diese Variante korrekt? sieht aus wie Copy-Paste
-	evuhz=$(echo "scale=2; $(echo $response_sm | jq $json_id'.Frequency_Phase_Average')/1" | bc)
+	evuhz=$(echo "scale=2; $(echo $response_sm | jq $json_id'.GRID_FREQUENCY_MEAN_F32')/1" | bc)
 	evupf1=$(echo "scale=2; $(echo $response_sm | jq $json_id'.SMARTMETER_FACTOR_POWER_01_F64')/1" | bc)
 	evupf2=$(echo "scale=2; $(echo $response_sm | jq $json_id'.SMARTMETER_FACTOR_POWER_02_F64')/1" | bc)
 	evupf3=$(echo "scale=2; $(echo $response_sm | jq $json_id'.SMARTMETER_FACTOR_POWER_03_F64')/1" | bc)


### PR DESCRIPTION
Siehe Diskussion: https://openwb.de/forum/viewtopic.php?f=9&t=3861

Änderungen in modules/bezug_fronius_s0/fronius_s0.py:
* Parametervergleich für Primo-Mode zeichenbasiert
* Zusammenrechnen des Bezugs zahlenbasiert
* Korrektur des Zugriffs auf JSON-Response mit Zählerdaten

Änderungen in modules/bezug_fronius_s0/main.sh:
* Korrektur des Parameters $froniusprimo

Außerdem wurde bei der Frequenzbestimmung für GEN24 Geräten versucht auf einen falschen/unbekannten Wert zuzugreifen.