### PR TITLE
Generic JSON Modules in Python

### DIFF
--- a/modules/bezug_json/main.sh
+++ b/modules/bezug_json/main.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 OPENWBBASEDIR=$(cd `dirname $0`/../../ && pwd)
-RAMDISKDIR="$OPENWBBASEDIR/ramdisk"
+RAMDISKDIR="${OPENWBBASEDIR}/ramdisk"
 MODULEDIR=$(cd `dirname $0` && pwd)
 #DMOD="EVU"
 DMOD="MAIN"
@@ -9,10 +9,10 @@ Debug=$debug
 #For development only
 #Debug=1
 
-if [ $DMOD == "MAIN" ]; then
-	MYLOGFILE="$RAMDISKDIR/openWB.log"
+if [ ${DMOD} == "MAIN" ]; then
+	MYLOGFILE="${RAMDISKDIR}/openWB.log"
 else
-	MYLOGFILE="$RAMDISKDIR/evu_json.log"
+	MYLOGFILE="${RAMDISKDIR}/evu_json.log"
 fi
 
 openwbDebugLog ${DMOD} 2 "EVU URL: ${bezugjsonurl}"
@@ -25,5 +25,5 @@ ret=$?
 
 openwbDebugLog ${DMOD} 2 "RET: ${ret}"
 
-evuwatt=$(<$RAMDISKDIR/wattbezug)
+evuwatt=$(<${RAMDISKDIR}/wattbezug)
 echo ${evuwatt}

--- a/modules/bezug_json/main.sh
+++ b/modules/bezug_json/main.sh
@@ -1,5 +1,4 @@
 #!/bin/bash
-
 OPENWBBASEDIR=$(cd `dirname $0`/../../ && pwd)
 RAMDISKDIR="$OPENWBBASEDIR/ramdisk"
 MODULEDIR=$(cd `dirname $0` && pwd)
@@ -10,28 +9,21 @@ Debug=$debug
 #For development only
 #Debug=1
 
-openwbDebugLog ${DMOD} 2 "${bezugjsonwatt}"
-openwbDebugLog ${DMOD} 2 "${bezugjsonkwh}"
-openwbDebugLog ${DMOD} 2 "${einspeisungjsonkwh}"
+if [ $DMOD == "MAIN" ]; then
+	MYLOGFILE="$RAMDISKDIR/openWB.log"
+else
+	MYLOGFILE="$RAMDISKDIR/evu_json.log"
+fi
 
-answer=$(curl --connect-timeout 5 -s $bezugjsonurl)
-evuwatt=$(echo $answer | jq -r "$bezugjsonwatt" | sed 's/\..*$//')
+openwbDebugLog ${DMOD} 2 "EVU URL: ${bezugjsonurl}"
+openwbDebugLog ${DMOD} 2 "Filter Watt : ${bezugjsonwatt}"
+openwbDebugLog ${DMOD} 2 "Filter Bezug: ${bezugjsonkwh}"
+openwbDebugLog ${DMOD} 2 "Filter Einsp: ${einspeisungjsonkwh}"
+
+python3 $OPENWBBASEDIR/modules/bezug_json/read_json.py "${bezugjsonurl}" "${bezugjsonwatt}" "${bezugjsonkwh}" "${einspeisungjsonkwh}" >>$MYLOGFILE 2>&1
+ret=$?
+
+openwbDebugLog ${DMOD} 2 "RET: ${ret}"
+
+evuwatt=$(<$RAMDISKDIR/wattbezug)
 echo ${evuwatt}
-openwbDebugLog  ${DMOD} 1 "Watt: ${evuwatt}"
-echo $evuwatt > /var/www/html/openWB/ramdisk/wattbezug
-
-if [ ! -z "${bezugjsonkwh}" ]; then
-	evuikwh=$(echo $answer | jq -r "$bezugjsonkwh")
-else
-	evuikwh=0
-fi
-openwbDebugLog ${DMOD} 1 "BezugkWh: ${evuikwh}"
-echo $evuikwh > /var/www/html/openWB/ramdisk/bezugkwh
-
-if [ ! -z "${einspeisungjsonkwh}" ]; then
-	evuekwh=$(echo $answer | jq -r "$einspeisungjsonkwh")
-else
-	evuekwh=0
-fi
-openwbDebugLog ${DMOD} 1 "EinspeiskWh: ${evuekwh}"
-echo $evuekwh > /var/www/html/openWB/ramdisk/einspeisungkwh

--- a/modules/bezug_json/read_json.py
+++ b/modules/bezug_json/read_json.py
@@ -1,0 +1,69 @@
+#!/usr/bin/env python3
+
+import requests
+import sys
+import traceback
+import jq
+from datetime import datetime, timezone
+import os
+
+Debug         = int(os.environ.get('debug'))
+myPid         = str(os.getpid())
+
+bezugjsonurl = str(sys.argv[1])
+
+bezugjsonwatt = str(sys.argv[2])
+bezugjsonkwh = str(sys.argv[3])
+einspeisungjsonkwh = str(sys.argv[4])
+
+def DebugLog(message):
+	local_time = datetime.now(timezone.utc).astimezone()
+	print(local_time.strftime(format = "%Y-%m-%d %H:%M:%S") + ": PID: "+ myPid +": " + message)
+
+
+
+if Debug >= 2:
+	DebugLog('JQ Watt: ' + bezugjsonwatt)
+	DebugLog('JQ Bezug: ' + bezugjsonkwh)
+	DebugLog('JQ Einsp: ' + einspeisungjsonkwh)
+
+
+response = requests.get(bezugjsonurl, timeout=5).json()
+try:
+	evuwatt = jq.compile(bezugjsonwatt).input(response).first()
+	evuwatt = int(evuwatt)
+	with open("/var/www/html/openWB/ramdisk/wattbezug", "w") as f:
+		f.write(str(evuwatt))
+except:
+	traceback.print_exc()
+	exit(1)
+if Debug >= 1:
+	DebugLog('Watt: ' + str(evuwatt))
+
+try:
+	if bezugjsonkwh != "":
+		evuikwh = jq.compile(bezugjsonkwh).input(response).first()
+	else:
+		evuikwh = 0
+	with open("/var/www/html/openWB/ramdisk/bezugkwh", "w") as f:
+		f.write(str(evuikwh))
+except:
+	traceback.print_exc()
+	exit(1)
+if Debug >= 1:
+	DebugLog('Bezug: ' + str(evuikwh))
+
+try:
+	if einspeisungjsonkwh != "":
+		evuekwh = jq.compile(einspeisungjsonkwh).input(response).first()
+	else:
+		evuekwh = 0
+	with open("/var/www/html/openWB/ramdisk/einspeisungkwh", "w") as f:
+		f.write(str(evuekwh))
+except:
+	traceback.print_exc()
+	exit(1)
+if Debug >= 1:
+	DebugLog('Einsp: ' + str(evuekwh))
+
+exit(0)

--- a/modules/bezug_json/read_json.py
+++ b/modules/bezug_json/read_json.py
@@ -29,6 +29,9 @@ if Debug >= 2:
 
 
 response = requests.get(bezugjsonurl, timeout=5).json()
+if Debug>=2:
+	DebugLog(str(response))
+
 try:
 	evuwatt = jq.compile(bezugjsonwatt).input(response).first()
 	evuwatt = int(evuwatt)
@@ -37,8 +40,9 @@ try:
 except:
 	traceback.print_exc()
 	exit(1)
+
 if Debug >= 1:
-	DebugLog('Watt: ' + str(evuwatt))
+	DebugLog('EVU Watt: ' + str(evuwatt))
 
 try:
 	if bezugjsonkwh != "":
@@ -51,7 +55,7 @@ except:
 	traceback.print_exc()
 	exit(1)
 if Debug >= 1:
-	DebugLog('Bezug: ' + str(evuikwh))
+	DebugLog('EVU Bezug: ' + str(evuikwh))
 
 try:
 	if einspeisungjsonkwh != "":
@@ -64,6 +68,6 @@ except:
 	traceback.print_exc()
 	exit(1)
 if Debug >= 1:
-	DebugLog('Einsp: ' + str(evuekwh))
+	DebugLog('EVU Einsp: ' + str(evuekwh))
 
 exit(0)

--- a/modules/speicher_json/main.sh
+++ b/modules/speicher_json/main.sh
@@ -5,24 +5,29 @@ RAMDISKDIR="$OPENWBBASEDIR/ramdisk"
 MODULEDIR=$(cd `dirname $0` && pwd)
 #DMOD="BATT"
 DMOD="MAIN"
-#LOGFILE="$RAMDISKDIR/speicher.log"
-#LOGFILE="$RAMDISKDIR/openWB.log"
 Debug=$debug
 
 #For Development only
 #Debug=1
 
-answer=$(curl --connect-timeout 5 -s $battjsonurl)
-speicherleistung=$(echo $answer | jq -r "$battjsonwatt" | sed 's/\..*$//')
-openwbDebugLog ${DMOD} 1 "BattLeistung: ${speicherleistung}"
-echo ${speicherleistung}
-echo $speicherleistung > /var/www/html/openWB/ramdisk/speicherleistung
-
-if [ ! -z "$battjsonsoc" ]; then
-	battsoc=$(echo $answer | jq -r "$battjsonsoc")
+if [ $DMOD == "MAIN" ]; then
+	MYLOGFILE="$RAMDISKDIR/openWB.log"
 else
-	battsoc=0
+	MYLOGFILE="$RAMDISKDIR/speicher.log"
 fi
 
-openwbDebugLog ${DMOD} 1 "BattSoC: ${battsoc}"
-echo $battsoc > /var/www/html/openWB/ramdisk/speichersoc
+
+openwbDebugLog ${DMOD} 2 "Speicher URL: ${battjsonurl}"
+openwbDebugLog ${DMOD} 2 "Speicher Watt: ${battjsonwatt}"
+openwbDebugLog ${DMOD} 2 "Speicher SoC: ${battjsonsoc}"
+
+#python3 /var/www/html/openWB/modules/speicher_json/read_json.py "${battjsonurl}" "${battjsonwatt}" "${battjsonsoc}" >>$MYLOGFILE 2>&1
+python3 $OPENWBBASEDIR/modules/speicher_json/read_json.py "${battjsonurl}" "${battjsonwatt}" "${battjsonsoc}" >>$MYLOGFILE 2>&1
+ret=$?
+
+openwbDebugLog ${DMOD} 2 "RET: ${ret}"
+
+speicherleistung=$(<$RAMDISKDIR/speicherleistung)
+
+openwbDebugLog ${DMOD} 1 "BattLeistung: ${speicherleistung}"
+#echo ${speicherleistung}

--- a/modules/speicher_json/main.sh
+++ b/modules/speicher_json/main.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 OPENWBBASEDIR=$(cd `dirname $0`/../../ && pwd)
-RAMDISKDIR="$OPENWBBASEDIR/ramdisk"
+RAMDISKDIR="${OPENWBBASEDIR}/ramdisk"
 #MODULEDIR=$(cd `dirname $0` && pwd)
 #DMOD="BATT"
 DMOD="MAIN"
@@ -10,10 +10,10 @@ Debug=$debug
 #For Development only
 #Debug=1
 
-if [ $DMOD == "MAIN" ]; then
-	MYLOGFILE="$RAMDISKDIR/openWB.log"
+if [ ${DMOD} == "MAIN" ]; then
+	MYLOGFILE="${RAMDISKDIR}/openWB.log"
 else
-	MYLOGFILE="$RAMDISKDIR/speicher.log"
+	MYLOGFILE="${RAMDISKDIR}/speicher.log"
 fi
 
 
@@ -26,7 +26,7 @@ ret=$?
 
 openwbDebugLog ${DMOD} 2 "RET: ${ret}"
 
-speicherleistung=$(<$RAMDISKDIR/speicherleistung)
+speicherleistung=$(<${RAMDISKDIR}/speicherleistung)
 
 openwbDebugLog ${DMOD} 1 "BattLeistung: ${speicherleistung}"
 #echo ${speicherleistung}

--- a/modules/speicher_json/main.sh
+++ b/modules/speicher_json/main.sh
@@ -2,7 +2,7 @@
 
 OPENWBBASEDIR=$(cd `dirname $0`/../../ && pwd)
 RAMDISKDIR="$OPENWBBASEDIR/ramdisk"
-MODULEDIR=$(cd `dirname $0` && pwd)
+#MODULEDIR=$(cd `dirname $0` && pwd)
 #DMOD="BATT"
 DMOD="MAIN"
 Debug=$debug
@@ -21,7 +21,6 @@ openwbDebugLog ${DMOD} 2 "Speicher URL: ${battjsonurl}"
 openwbDebugLog ${DMOD} 2 "Speicher Watt: ${battjsonwatt}"
 openwbDebugLog ${DMOD} 2 "Speicher SoC: ${battjsonsoc}"
 
-#python3 /var/www/html/openWB/modules/speicher_json/read_json.py "${battjsonurl}" "${battjsonwatt}" "${battjsonsoc}" >>$MYLOGFILE 2>&1
 python3 $OPENWBBASEDIR/modules/speicher_json/read_json.py "${battjsonurl}" "${battjsonwatt}" "${battjsonsoc}" >>$MYLOGFILE 2>&1
 ret=$?
 

--- a/modules/speicher_json/read_json.py
+++ b/modules/speicher_json/read_json.py
@@ -24,12 +24,12 @@ if Debug>=2:
 	DebugLog(str(response))
 try:
 	speicherleistung = jq.compile(battjsonwatt).input(response).first()
-	speicherleistung = int(speicherleistung)
 	if Debug>=1:
 		DebugLog('Speicherleistung: ' + str(speicherleistung))
 	if not str(speicherleistung).isnumeric():
 		DebugLog('Speicherleistung nicht numerisch. Bitte Filterausdruck ueberpruefen -->0')
 		speicherleistung=0
+	speicherleistung = int(speicherleistung)
 	with open("/var/www/html/openWB/ramdisk/speicherleistung", "w") as f:
 		f.write(str(speicherleistung))
 except:
@@ -38,12 +38,12 @@ except:
 try:
 	if battjsonsoc != "":
 		battsoc = jq.compile(battjsonsoc).input(response).first()
-		battsoc = int(battsoc)
 		if Debug>=1:
 			DebugLog('SpeicherSoC: ' + str(battsoc))
 		if not str(battsoc).isnumeric():
 			DebugLog('SpeicherSoc nicht numerisch. Bitte Filterausdruck ueberpruefen -->0')
 			battsoc=0
+		battsoc = int(battsoc)
 	else:
 		battsoc = 0
 		if Debug>=1:

--- a/modules/speicher_json/read_json.py
+++ b/modules/speicher_json/read_json.py
@@ -1,0 +1,54 @@
+#!/usr/bin/env python3
+
+import requests
+import sys
+import traceback
+import jq
+from datetime import datetime, timezone
+import os
+
+Debug         = int(os.environ.get('debug'))
+myPid         = str(os.getpid())
+
+battjsonurl = str(sys.argv[1])
+battjsonwatt = str(sys.argv[2])
+battjsonsoc = str(sys.argv[3])
+
+def DebugLog(message):
+	local_time = datetime.now(timezone.utc).astimezone()
+	print(local_time.strftime(format = "%Y-%m-%d %H:%M:%S") + ": PID: "+ myPid +": " + message)
+
+
+response = requests.get(battjsonurl, timeout=5).json()
+if Debug>=2:
+	DebugLog(str(response))
+try:
+	speicherleistung = jq.compile(battjsonwatt).input(response).first()
+	speicherleistung = int(speicherleistung)
+	if Debug>=1:
+		DebugLog('Speicherleistung: ' + str(speicherleistung))
+	if not str(speicherleistung).isnumeric():
+		DebugLog('Speicherleistung nicht numerisch. Bitte Filterausdruck ueberpruefen -->0')
+		speicherleistung=0
+	with open("/var/www/html/openWB/ramdisk/speicherleistung", "w") as f:
+		f.write(str(speicherleistung))
+except:
+	traceback.print_exc()
+
+try:
+	if battjsonsoc != "":
+		battsoc = jq.compile(battjsonsoc).input(response).first()
+		battsoc = int(battsoc)
+		if Debug>=1:
+			DebugLog('SpeicherSoC: ' + str(battsoc))
+		if not str(battsoc).isnumeric():
+			DebugLog('SpeicherSoc nicht numerisch. Bitte Filterausdruck ueberpruefen -->0')
+			battsoc=0
+	else:
+		battsoc = 0
+		if Debug>=1:
+			DebugLog('SpeicherSoC: ' + str(battsoc))
+	with open("/var/www/html/openWB/ramdisk/speichersoc", "w") as f:
+		f.write(str(battsoc))
+except:
+	traceback.print_exc()

--- a/modules/wr2_json/main.sh
+++ b/modules/wr2_json/main.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 OPENWBBASEDIR=$(cd `dirname $0`/../../ && pwd)
-RAMDISKDIR="$OPENWBBASEDIR/ramdisk"
+RAMDISKDIR="${OPENWBBASEDIR}/ramdisk"
 #MODULEDIR=$(cd `dirname $0` && pwd)
 DMOD="PV"
 #DMOD="MAIN"
@@ -10,10 +10,10 @@ Debug=$debug
 #For Development only
 #Debug=1
 
-if [ $DMOD == "MAIN" ]; then
-	MYLOGFILE="$RAMDISKDIR/openWB.log"
+if [ ${DMOD} == "MAIN" ]; then
+	MYLOGFILE="${RAMDISKDIR}/openWB.log"
 else
-	MYLOGFILE="$RAMDISKDIR/nurpv.log"
+	MYLOGFILE="${RAMDISKDIR}/nurpv.log"
 fi
 
 
@@ -28,5 +28,5 @@ ret=$?
 
 openwbDebugLog ${DMOD} 2 "RET: ${ret}"
 
-watt=$(<$RAMDISKDIR/pvwatt2)
+watt=$(<${RAMDISKDIR}/pvwatt2)
 echo ${watt}

--- a/modules/wr2_json/main.sh
+++ b/modules/wr2_json/main.sh
@@ -5,39 +5,75 @@ RAMDISKDIR="$OPENWBBASEDIR/ramdisk"
 MODULEDIR=$(cd `dirname $0` && pwd)
 DMOD="PV"
 #DMOD="MAIN"
-#LOGFILE="$RAMDISKDIR/pv_wr.log"
-#LOGFILE="$RAMDISKDIR/openWB.log"
 Debug=$debug
 
 #For Development only
 #Debug=1
 
-re='^[-+]?[0-9]+\.?[0-9]*$'
-answer=$(curl --connect-timeout 5 -s $wr2jsonurl)
-pvwatt=$(echo $answer | jq -r "$wr2jsonwatt" | sed 's/\..*$//')
-# Wenn WR aus bzw. im Standby (keine Antwort), ersetze leeren Wert durch eine 0
-if ! [[ $pvwatt =~ $re ]] ; then
-	openwbDebugLog ${DMOD} 1 "PV2Watt Not Numeric: $pvwatt . Check if Filter is correct or WR is in standby"
-	pvwatt=0
-fi
-
-if (( $pvwatt > 5 )); then
-	pvwatt=$(echo "$pvwatt*-1" |bc)
-fi
-openwbDebugLog ${DMOD} 1 "PV2Watt: ${pvwatt}"
-echo ${pvwatt}
-echo $pvwatt > /var/www/html/openWB/ramdisk/pv2watt
-
-if [ ! -z "$wr2jsonkwh" ]; then
-	pvkwh=$(echo $answer | jq -r "$wr2jsonkwh")
-	if ! [[ $pvkwh =~ $re ]] ; then
-		openwbDebugLog ${DMOD} 1 "PV2kWh Not Numeric: $pvkwh . Check if Filter is correct or WR is in standby"
-		pvkwh=$(</var/www/html/openWB/ramdisk/pv2kwh)
-	fi
+if [ $DMOD == "MAIN" ]; then
+	MYLOGFILE="$RAMDISKDIR/openWB.log"
 else
-	openwbDebugLog ${DMOD} 2 "PV2kWh NoFilter is set"
-	pvkwh=0
+	MYLOGFILE="$RAMDISKDIR/nurpv.log"
 fi
 
-openwbDebugLog ${DMOD} 1 "PV2kWh: ${pvkwh}"
-echo $pvkwh > /var/www/html/openWB/ramdisk/pv2kwh
+
+
+
+openwbDebugLog ${DMOD} 2 "PV URL : ${wr2jsonurl}"
+openwbDebugLog ${DMOD} 2 "PV Watt: ${wr2jsonwatt}"
+openwbDebugLog ${DMOD} 2 "PV kWh : ${wr2jsonkwh}"
+
+python3 $OPENWBBASEDIR/modules/wr_json/read_json.py "${wr2jsonurl}" "${wr2jsonwatt}" "${wr2jsonkwh}" "2" >>$MYLOGFILE 2>&1
+ret=$?
+
+openwbDebugLog ${DMOD} 2 "RET: ${ret}"
+
+watt=$(<$RAMDISKDIR/pvwatt2)
+echo ${watt}
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+#re='^[-+]?[0-9]+\.?[0-9]*$'
+#answer=$(curl --connect-timeout 5 -s $wrjsonurl)
+#pvwatt=$(echo $answer | jq -r "$wrjsonwatt" | sed 's/\..*$//')
+## Wenn WR aus bzw. im Standby (keine Antwort), ersetze leeren Wert durch eine 0
+#if ! [[ $pvwatt =~ $re ]] ; then
+#	openwbDebugLog ${DMOD} 1 "PVWatt Not Numeric: $pvwatt . Check if Filter is correct or WR is in standby"
+#	pvwatt=0
+#fi
+#
+#if (( $pvwatt > 5 )); then
+#	pvwatt=$(echo "$pvwatt*-1" |bc)
+#fi	
+#openwbDebugLog ${DMOD} 1 "PVWatt: ${pvwatt}"
+#echo ${pvwatt}
+#echo $pvwatt > /var/www/html/openWB/ramdisk/pvwatt
+#
+#if [ ! -z "$wrjsonkwh" ]; then
+#	pvkwh=$(echo $answer | jq -r "$wrjsonkwh")
+#	if ! [[ $pvkwh =~ $re ]] ; then
+#		openwbDebugLog ${DMOD} 1 "PVkWh Not Numeric: $pvkwh . Check if Filter is correct or WR is in standby"
+#		pvkwh=$(</var/www/html/openWB/ramdisk/pvkwh)
+#	fi
+#else
+#	openwbDebugLog ${DMOD} 2 "PVkWh NoFilter is set"
+#	pvkwh=0
+#fi
+#
+#openwbDebugLog ${DMOD} 1 "PVkWh: ${pvkwh}"
+#echo $pvkwh > /var/www/html/openWB/ramdisk/pvkwh

--- a/modules/wr2_json/main.sh
+++ b/modules/wr2_json/main.sh
@@ -2,7 +2,7 @@
 
 OPENWBBASEDIR=$(cd `dirname $0`/../../ && pwd)
 RAMDISKDIR="$OPENWBBASEDIR/ramdisk"
-MODULEDIR=$(cd `dirname $0` && pwd)
+#MODULEDIR=$(cd `dirname $0` && pwd)
 DMOD="PV"
 #DMOD="MAIN"
 Debug=$debug
@@ -30,50 +30,3 @@ openwbDebugLog ${DMOD} 2 "RET: ${ret}"
 
 watt=$(<$RAMDISKDIR/pvwatt2)
 echo ${watt}
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-#re='^[-+]?[0-9]+\.?[0-9]*$'
-#answer=$(curl --connect-timeout 5 -s $wrjsonurl)
-#pvwatt=$(echo $answer | jq -r "$wrjsonwatt" | sed 's/\..*$//')
-## Wenn WR aus bzw. im Standby (keine Antwort), ersetze leeren Wert durch eine 0
-#if ! [[ $pvwatt =~ $re ]] ; then
-#	openwbDebugLog ${DMOD} 1 "PVWatt Not Numeric: $pvwatt . Check if Filter is correct or WR is in standby"
-#	pvwatt=0
-#fi
-#
-#if (( $pvwatt > 5 )); then
-#	pvwatt=$(echo "$pvwatt*-1" |bc)
-#fi	
-#openwbDebugLog ${DMOD} 1 "PVWatt: ${pvwatt}"
-#echo ${pvwatt}
-#echo $pvwatt > /var/www/html/openWB/ramdisk/pvwatt
-#
-#if [ ! -z "$wrjsonkwh" ]; then
-#	pvkwh=$(echo $answer | jq -r "$wrjsonkwh")
-#	if ! [[ $pvkwh =~ $re ]] ; then
-#		openwbDebugLog ${DMOD} 1 "PVkWh Not Numeric: $pvkwh . Check if Filter is correct or WR is in standby"
-#		pvkwh=$(</var/www/html/openWB/ramdisk/pvkwh)
-#	fi
-#else
-#	openwbDebugLog ${DMOD} 2 "PVkWh NoFilter is set"
-#	pvkwh=0
-#fi
-#
-#openwbDebugLog ${DMOD} 1 "PVkWh: ${pvkwh}"
-#echo $pvkwh > /var/www/html/openWB/ramdisk/pvkwh

--- a/modules/wr_json/main.sh
+++ b/modules/wr_json/main.sh
@@ -5,39 +5,75 @@ RAMDISKDIR="$OPENWBBASEDIR/ramdisk"
 MODULEDIR=$(cd `dirname $0` && pwd)
 DMOD="PV"
 #DMOD="MAIN"
-#LOGFILE="$RAMDISKDIR/pv_wr.log"
-#LOGFILE="$RAMDISKDIR/openWB.log"
 Debug=$debug
 
 #For Development only
 #Debug=1
 
-re='^[-+]?[0-9]+\.?[0-9]*$'
-answer=$(curl --connect-timeout 5 -s $wrjsonurl)
-pvwatt=$(echo $answer | jq -r "$wrjsonwatt" | sed 's/\..*$//')
-# Wenn WR aus bzw. im Standby (keine Antwort), ersetze leeren Wert durch eine 0
-if ! [[ $pvwatt =~ $re ]] ; then
-	openwbDebugLog ${DMOD} 1 "PVWatt Not Numeric: $pvwatt . Check if Filter is correct or WR is in standby"
-	pvwatt=0
-fi
-
-if (( $pvwatt > 5 )); then
-	pvwatt=$(echo "$pvwatt*-1" |bc)
-fi	
-openwbDebugLog ${DMOD} 1 "PVWatt: ${pvwatt}"
-echo ${pvwatt}
-echo $pvwatt > /var/www/html/openWB/ramdisk/pvwatt
-
-if [ ! -z "$wrjsonkwh" ]; then
-	pvkwh=$(echo $answer | jq -r "$wrjsonkwh")
-	if ! [[ $pvkwh =~ $re ]] ; then
-		openwbDebugLog ${DMOD} 1 "PVkWh Not Numeric: $pvkwh . Check if Filter is correct or WR is in standby"
-		pvkwh=$(</var/www/html/openWB/ramdisk/pvkwh)
-	fi
+if [ $DMOD == "MAIN" ]; then
+	MYLOGFILE="$RAMDISKDIR/openWB.log"
 else
-	openwbDebugLog ${DMOD} 2 "PVkWh NoFilter is set"
-	pvkwh=0
+	MYLOGFILE="$RAMDISKDIR/nurpv.log"
 fi
 
-openwbDebugLog ${DMOD} 1 "PVkWh: ${pvkwh}"
-echo $pvkwh > /var/www/html/openWB/ramdisk/pvkwh
+
+
+
+openwbDebugLog ${DMOD} 2 "PV URL : ${wrjsonurl}"
+openwbDebugLog ${DMOD} 2 "PV Watt: ${wrjsonwatt}"
+openwbDebugLog ${DMOD} 2 "PV kWh : ${wrjsonkwh}"
+
+python3 $OPENWBBASEDIR/modules/wr_json/read_json.py "${wrjsonurl}" "${wrjsonwatt}" "${wrjsonkwh}" "1" >>$MYLOGFILE 2>&1
+ret=$?
+
+openwbDebugLog ${DMOD} 2 "RET: ${ret}"
+
+watt=$(<$RAMDISKDIR/pvwatt)
+echo ${watt}
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+#re='^[-+]?[0-9]+\.?[0-9]*$'
+#answer=$(curl --connect-timeout 5 -s $wrjsonurl)
+#pvwatt=$(echo $answer | jq -r "$wrjsonwatt" | sed 's/\..*$//')
+## Wenn WR aus bzw. im Standby (keine Antwort), ersetze leeren Wert durch eine 0
+#if ! [[ $pvwatt =~ $re ]] ; then
+#	openwbDebugLog ${DMOD} 1 "PVWatt Not Numeric: $pvwatt . Check if Filter is correct or WR is in standby"
+#	pvwatt=0
+#fi
+#
+#if (( $pvwatt > 5 )); then
+#	pvwatt=$(echo "$pvwatt*-1" |bc)
+#fi	
+#openwbDebugLog ${DMOD} 1 "PVWatt: ${pvwatt}"
+#echo ${pvwatt}
+#echo $pvwatt > /var/www/html/openWB/ramdisk/pvwatt
+#
+#if [ ! -z "$wrjsonkwh" ]; then
+#	pvkwh=$(echo $answer | jq -r "$wrjsonkwh")
+#	if ! [[ $pvkwh =~ $re ]] ; then
+#		openwbDebugLog ${DMOD} 1 "PVkWh Not Numeric: $pvkwh . Check if Filter is correct or WR is in standby"
+#		pvkwh=$(</var/www/html/openWB/ramdisk/pvkwh)
+#	fi
+#else
+#	openwbDebugLog ${DMOD} 2 "PVkWh NoFilter is set"
+#	pvkwh=0
+#fi
+#
+#openwbDebugLog ${DMOD} 1 "PVkWh: ${pvkwh}"
+#echo $pvkwh > /var/www/html/openWB/ramdisk/pvkwh

--- a/modules/wr_json/main.sh
+++ b/modules/wr_json/main.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 OPENWBBASEDIR=$(cd `dirname $0`/../../ && pwd)
-RAMDISKDIR="$OPENWBBASEDIR/ramdisk"
+RAMDISKDIR="${OPENWBBASEDIR}/ramdisk"
 #MODULEDIR=$(cd `dirname $0` && pwd)
 DMOD="PV"
 #DMOD="MAIN"
@@ -11,9 +11,9 @@ Debug=$debug
 #Debug=1
 
 if [ $DMOD == "MAIN" ]; then
-	MYLOGFILE="$RAMDISKDIR/openWB.log"
+	MYLOGFILE="${RAMDISKDIR}/openWB.log"
 else
-	MYLOGFILE="$RAMDISKDIR/nurpv.log"
+	MYLOGFILE="${RAMDISKDIR}/nurpv.log"
 fi
 
 
@@ -28,5 +28,5 @@ ret=$?
 
 openwbDebugLog ${DMOD} 2 "RET: ${ret}"
 
-watt=$(<$RAMDISKDIR/pvwatt)
+watt=$(<${RAMDISKDIR}/pvwatt)
 echo ${watt}

--- a/modules/wr_json/main.sh
+++ b/modules/wr_json/main.sh
@@ -2,7 +2,7 @@
 
 OPENWBBASEDIR=$(cd `dirname $0`/../../ && pwd)
 RAMDISKDIR="$OPENWBBASEDIR/ramdisk"
-MODULEDIR=$(cd `dirname $0` && pwd)
+#MODULEDIR=$(cd `dirname $0` && pwd)
 DMOD="PV"
 #DMOD="MAIN"
 Debug=$debug
@@ -30,50 +30,3 @@ openwbDebugLog ${DMOD} 2 "RET: ${ret}"
 
 watt=$(<$RAMDISKDIR/pvwatt)
 echo ${watt}
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-#re='^[-+]?[0-9]+\.?[0-9]*$'
-#answer=$(curl --connect-timeout 5 -s $wrjsonurl)
-#pvwatt=$(echo $answer | jq -r "$wrjsonwatt" | sed 's/\..*$//')
-## Wenn WR aus bzw. im Standby (keine Antwort), ersetze leeren Wert durch eine 0
-#if ! [[ $pvwatt =~ $re ]] ; then
-#	openwbDebugLog ${DMOD} 1 "PVWatt Not Numeric: $pvwatt . Check if Filter is correct or WR is in standby"
-#	pvwatt=0
-#fi
-#
-#if (( $pvwatt > 5 )); then
-#	pvwatt=$(echo "$pvwatt*-1" |bc)
-#fi	
-#openwbDebugLog ${DMOD} 1 "PVWatt: ${pvwatt}"
-#echo ${pvwatt}
-#echo $pvwatt > /var/www/html/openWB/ramdisk/pvwatt
-#
-#if [ ! -z "$wrjsonkwh" ]; then
-#	pvkwh=$(echo $answer | jq -r "$wrjsonkwh")
-#	if ! [[ $pvkwh =~ $re ]] ; then
-#		openwbDebugLog ${DMOD} 1 "PVkWh Not Numeric: $pvkwh . Check if Filter is correct or WR is in standby"
-#		pvkwh=$(</var/www/html/openWB/ramdisk/pvkwh)
-#	fi
-#else
-#	openwbDebugLog ${DMOD} 2 "PVkWh NoFilter is set"
-#	pvkwh=0
-#fi
-#
-#openwbDebugLog ${DMOD} 1 "PVkWh: ${pvkwh}"
-#echo $pvkwh > /var/www/html/openWB/ramdisk/pvkwh

--- a/modules/wr_json/read_json.py
+++ b/modules/wr_json/read_json.py
@@ -1,0 +1,70 @@
+#!/usr/bin/env python3
+
+import requests
+import sys
+import traceback
+import jq
+from datetime import datetime, timezone
+import os
+
+Debug         = int(os.environ.get('debug'))
+myPid         = str(os.getpid())
+
+jsonurl = str(sys.argv[1])
+
+jsonwatt = str(sys.argv[2])
+jsonkwh = str(sys.argv[3])
+numpv = int(str(sys.argv[4]))
+
+RAMDISKDIR='/var/www/html/openWB/ramdisk/'
+
+def DebugLog(message):
+	local_time = datetime.now(timezone.utc).astimezone()
+	print(local_time.strftime(format = "%Y-%m-%d %H:%M:%S") + ": PID: "+ myPid +": " + message)
+
+
+
+if Debug >= 2:
+	DebugLog('PV' + str(numpv) + ' JQ Watt: ' + jsonwatt)
+	DebugLog('PV' + str(numpv) + ' JQ Wh  : ' + jsonkwh)
+	DebugLog('PV' + str(numpv) + ' JQ numpv  : ' + str(numpv))
+
+
+response = requests.get(jsonurl, timeout=5).json()
+if Debug>=2:
+        DebugLog('JSON Response: ' + str(response))
+try:
+	watt = jq.compile(jsonwatt).input(response).first()
+	watt=int(watt)
+	if watt >= 0:
+		watt = watt*(-1)
+	if numpv==1:
+		with open(RAMDISKDIR + "pvwatt", "w") as f:
+			f.write(str(watt))
+	else:
+		with open(RAMDISKDIR + "pvwatt" + str(numpv) , "w") as f:
+			f.write(str(watt))
+except:
+	traceback.print_exc()
+	exit(1)
+if Debug >= 1:
+	DebugLog('PV' + str(numpv) + 'Watt: ' + str(watt))
+
+try:
+	if jsonkwh != "":
+		kwh = jq.compile(jsonkwh).input(response).first()
+	else:
+		kwh = 0
+	if numpv==1:
+		with open(RAMDISKDIR + "pvkwh", "w") as f:
+			f.write(str(kwh))
+	else:
+		with open(RAMDISKDIR + "pvkwh" + str(numpv), "w") as f:
+			f.write(str(kwh))
+except:
+	traceback.print_exc()
+	exit(1)
+if Debug >= 1:
+	DebugLog('PV' + str(numpv) + 'kWh: ' + str(kwh))
+
+exit(0)

--- a/modules/wr_json/read_json.py
+++ b/modules/wr_json/read_json.py
@@ -38,7 +38,7 @@ try:
 	watt=int(watt)
 	if watt >= 0:
 		watt = watt*(-1)
-	if numpv==1:
+	if numpv == 1:
 		with open(RAMDISKDIR + "pvwatt", "w") as f:
 			f.write(str(watt))
 	else:
@@ -55,7 +55,7 @@ try:
 		kwh = jq.compile(jsonkwh).input(response).first()
 	else:
 		kwh = 0
-	if numpv==1:
+	if numpv == 1:
 		with open(RAMDISKDIR + "pvkwh", "w") as f:
 			f.write(str(kwh))
 	else:


### PR DESCRIPTION
From Shell -- Python3.

Requires python jq for python3. Should be present, as it is still used
Be careful with URLS, that don't contain a http://. Worked in curl but doesn't work in Python request.