### PR TITLE
Remove duplicate property access in readmodbus.py

### DIFF
--- a/runs/readmodbus.py
+++ b/runs/readmodbus.py
@@ -20,4 +20,4 @@ if request.isError():
     print('Modbus Error:', request)
 else:
     result = request.registers
-    print(result.registers[0])
+    print(result[0])


### PR DESCRIPTION
Commit https://github.com/snaptec/openWB/commit/d117a6eaadf609d7a0a803bb068c897430fdc64e introduced a bug in `runs/readmodbus.py` causing duplicate property access:

The original single line
```python
    print(rq.registers[0])
```
has been split into two lines:
```python
    result = request.registers
    print(result.registers[0])
```

So first the `request.registers` is assigned to variable `result`. `result` now directly contains the array. However, `result.registers[0]` is being printed afterwards which obviously leads to an error because the array doesn't have a property `registers`:

```
Traceback (most recent call last):
  File "runs/readmodbus.py", line 26, in <module>
    print(result.registers[0])
AttributeError: 'list' object has no attribute 'registers'
```

Not sure why this is only discovered now. I've found it as side-finding while verifying / improving FEMS module.  
**Theoretically, the EVSE Plugstate should never have been read properly since above mentioned commit** !