### PR TITLE
FEMS / openEMS improvements

### DIFF
--- a/modules/bezug_fems/fems.py
+++ b/modules/bezug_fems/fems.py
@@ -7,22 +7,66 @@ import traceback
 password = str(sys.argv[1])
 ip_address = str(sys.argv[2])
 
-def get_value(url, file):
+def write_ramdisk(val, file):
     try:
-        response = requests.get(url, timeout = 2).json()
-        val = response["value"]
         f = open('/var/www/html/openWB/ramdisk/'+file, 'w')
         f.write(str(val))
         f.close()
     except:
         traceback.print_exc()
 
-get_value('http://x:'+password+'@'+ip_address+':8084/rest/channel/meter0/ActivePower', 'wattbezug')
-get_value('http://x:'+password+'@'+ip_address+':8084/rest/channel/_sum/GridBuyActiveEnergy', 'bezugkwh')
-get_value('http://x:'+password+'@'+ip_address+':8084/rest/channel/_sum/GridSellActiveEnergy', 'einspeisungkwh')
-get_value('http://x:'+password+'@'+ip_address+':8084/rest/channel/meter0/VoltageL1', 'evuv1')
-get_value('http://x:'+password+'@'+ip_address+':8084/rest/channel/meter0/VoltageL2', 'evuv2')
-get_value('http://x:'+password+'@'+ip_address+':8084/rest/channel/meter0/VoltageL3', 'evuv3')
-get_value('http://x:'+password+'@'+ip_address+':8084/rest/channel/meter0/CurrentL1', 'bezuga1')
-get_value('http://x:'+password+'@'+ip_address+':8084/rest/channel/meter0/CurrentL2', 'bezuga2')
-get_value('http://x:'+password+'@'+ip_address+':8084/rest/channel/meter0/CurrentL3', 'bezuga3')
+# Grid meter values
+try:
+    response = requests.get('http://x:'+password+'@'+ip_address+':8084/rest/channel/meter0/(ActivePowerL.|VoltageL.|Frequency)', timeout = 1).json()
+except:
+    traceback.print_exc()
+
+v1, v2, v3 = 0, 0, 0
+p1, p2, p3 = 0, 0, 0
+for singleValue in response:
+    address = singleValue['address']
+    if (address == 'meter0/Frequency'):
+        write_ramdisk(singleValue['value'], 'evuhz')
+    elif (address == 'meter0/ActivePower'):
+        write_ramdisk(singleValue['value'], 'wattbezug')
+    elif (address == 'meter0/ActivePowerL1'):
+        write_ramdisk(singleValue['value'], 'bezugw1')
+        p1 = singleValue['value']
+    elif (address == 'meter0/ActivePowerL2'):
+        write_ramdisk(singleValue['value'], 'bezugw2')
+        p2 = singleValue['value']
+    elif (address == 'meter0/ActivePowerL3'):
+        write_ramdisk(singleValue['value'], 'bezugw3')
+        p3 = singleValue['value']
+    elif (address == 'meter0/VoltageL1'):
+        write_ramdisk(singleValue['value'], 'evuv1')
+        v1 = singleValue['value']
+    elif (address == 'meter0/VoltageL2'):
+        write_ramdisk(singleValue['value'], 'evuv2')
+        v2 = singleValue['value']
+    elif (address == 'meter0/VoltageL3'):
+        write_ramdisk(singleValue['value'], 'evuv3')
+        v3 = singleValue['value']
+
+if (v1 != 0):
+    a1 = p1 / v1
+    write_ramdisk(a1, 'bezuga1')
+if (v2 != 0):
+    a2 = p2 / v2
+    write_ramdisk(a2, 'bezuga2')
+if (v3 != 0):
+    a3 = p3 / v3
+    write_ramdisk(a3, 'bezuga3')
+
+# Grid total energy sums
+try:
+    response = requests.get('http://x:'+password+'@'+ip_address+':8084/rest/channel/_sum/Grid.+ActiveEnergy', timeout = 1).json()
+except:
+    traceback.print_exc()
+
+for singleValue in response:
+    address = singleValue['address']
+    if (address == '_sum/GridBuyActiveEnergy'):
+        write_ramdisk(singleValue['value'], 'bezugkwh')
+    elif (address == '_sum/GridSellActiveEnergy'):
+        write_ramdisk(singleValue['value'], 'einspeisungkwh')

--- a/modules/bezug_fems/fems.py
+++ b/modules/bezug_fems/fems.py
@@ -17,7 +17,7 @@ def write_ramdisk(val, file):
 
 # Grid meter values
 try:
-    response = requests.get('http://x:'+password+'@'+ip_address+':8084/rest/channel/meter0/(ActivePowerL.|VoltageL.|Frequency)', timeout = 1).json()
+    response = requests.get('http://x:'+password+'@'+ip_address+':8084/rest/channel/meter0/(ActivePower.*|VoltageL.|Frequency)', timeout = 1).json()
 except:
     traceback.print_exc()
 


### PR DESCRIPTION
Here's my adaption of FEMS EVU module.

It now delivers all EVU values except for Power Factor. So per-phase powers are now available, too.  
Per-phase currents are now computed from power and voltage as power is signed to distinguish import and export while the per-phase current obtained directly from openEMS is always positive.

It greatly increases performance by only issuing two REST requests to openEMS. This is achieved by using the [Regex Feature](https://openems.github.io/openems.io/openems/latest/edge/controller.html#_get) of openEMS.

Using a single request for all per-phase values also has another important advantage: The values queried are as consistent as possible. The original approach, for example issued REST request for phase voltage and current indepently. This could result in a race where voltage and current are not from the same measurement and hence a corresponding power calculation would be at least "inaccurate".

**Please note that the Regex feature of openEMS might not be available in older versions:**  
* Fenecon has deployed FEMS firmware 2021.13 (at least on my FEMS) which clearly supports Regex in REST query.  
* For "raw" openEMS it's supported for quite some time. But you might have to update your openEMS.  
* I cannot test with Kaco Hy-Control because I don't have it. Anybody out there who could take this part?