### PR TITLE
modules/wr_rct: Auslesen der PV-Energie

### DIFF
--- a/loadvars.sh
+++ b/loadvars.sh
@@ -1049,7 +1049,7 @@ loadvars(){
 	if [[ $pvwattmodul == "wr_fronius" ]] && [[ $wrfroniusisgen24 == "1" ]]; then
 		usesimpv=1
 	fi
-	if [[ $pvwattmodul == "wr_kostalpiko" ]] || [[ $pvwattmodul == "wr_siemens" ]] || [[ $pvwattmodul == "wr_rct" ]]|| [[ $pvwattmodul == "wr_solarwatt" ]] || [[ $pvwattmodul == "wr_shelly" ]] || [[ $pvwattmodul == "wr_sungrow" ]] || [[ $pvwattmodul == "wr_huawei" ]] || [[ $pvwattmodul == "wr_powerdog" ]] || [[ $pvwattmodul == "wr_lgessv1" ]]|| [[ $pvwattmodul == "wr_kostalpikovar2" ]] || [[ $pvwattmodul == "wr_alphaess" ]]; then
+	if [[ $pvwattmodul == "wr_kostalpiko" ]] || [[ $pvwattmodul == "wr_siemens" ]] || [[ $pvwattmodul == "wr_solarwatt" ]] || [[ $pvwattmodul == "wr_shelly" ]] || [[ $pvwattmodul == "wr_sungrow" ]] || [[ $pvwattmodul == "wr_huawei" ]] || [[ $pvwattmodul == "wr_powerdog" ]] || [[ $pvwattmodul == "wr_lgessv1" ]]|| [[ $pvwattmodul == "wr_kostalpikovar2" ]] || [[ $pvwattmodul == "wr_alphaess" ]]; then
 		usesimpv=1
 	fi
 	if [[ $usesimpv == "1" ]]; then

--- a/modules/wr_rct/main.sh
+++ b/modules/wr_rct/main.sh
@@ -1,7 +1,16 @@
 #!/bin/bash
+#pv1watt und pv1total ist String A
+#pv2watt und pv2total ist der externe Bezug
+#pv3watt und pv3total ist String B
 pv1watt=$(echo "scale=0; $(python /var/www/html/openWB/modules/bezug_rct/rct_read.py --ip=$bezug1_ip --id='0xB5317B78')/1" | bc)
 pv2watt=$(echo "scale=0; $(python /var/www/html/openWB/modules/bezug_rct/rct_read.py --ip=$bezug1_ip --id='0xE96F1844')/1" | bc)
 pv3watt=$(echo "scale=0; $(python /var/www/html/openWB/modules/bezug_rct/rct_read.py --ip=$bezug1_ip --id='0xAA9AA253')/1" | bc)
 pvwatt=$(echo "scale=0; ($pv1watt + $pv2watt + $pv3watt) * -1" | bc)
 echo $pvwatt > /var/www/html/openWB/ramdisk/pvwatt
 echo $pvwatt
+pv1total=$(echo "scale=0; $(python /var/www/html/openWB/modules/bezug_rct/rct_read.py --ip=$bezug1_ip --id='0xFC724A9E')/1" | bc)
+pv2total=$(echo "scale=0; $(python /var/www/html/openWB/modules/bezug_rct/rct_read.py --ip=$bezug1_ip --id='0xF28E2E1')/1" | bc)
+pv3total=$(echo "scale=0; $(python /var/www/html/openWB/modules/bezug_rct/rct_read.py --ip=$bezug1_ip --id='0x68EEFD3D')/1" | bc)
+pvtotal=$(echo "scale=0; ($pv1total + $pv2total + $pv3total)" | bc)
+echo $pvtotal > /var/www/html/openWB/ramdisk/pvkwh
+


### PR DESCRIPTION
Bisher wurde beim RCT Wechselrichter die gesamte Energiemenge aus der ausgelesenen Leistung berechnet. Das ist ungenau und führt zu Problemen beim Neustart/Netzausfall.
Die Energiemenge wird jetzt direkt aus dem Wechselrichter ausgelesen.