### PR TITLE
Flexible evu-Kit Modules (parameters)

### DIFF
--- a/modules/bezug_ethmpm3pm/main.sh
+++ b/modules/bezug_ethmpm3pm/main.sh
@@ -1,10 +1,32 @@
 #!/bin/bash
-if (( evukitversion == 1 )); then
-	sudo python /var/www/html/openWB/modules/bezug_ethmpm3pm/readlovato.py
-elif (( evukitversion == 2 )); then
-	sudo python /var/www/html/openWB/modules/bezug_ethmpm3pm/readsdm.py 
+OPENWBBASEDIR=$(cd `dirname $0`/../../ && pwd)
+RAMDISKDIR="${OPENWBBASEDIR}/ramdisk"
+MODULEDIR=$(cd `dirname $0` && pwd)
+#DMOD="EVU"
+DMOD="MAIN"
+Debug=$debug
+
+#For development only
+#Debug=1
+
+if [ ${DMOD} == "MAIN" ]; then
+        MYLOGFILE="${RAMDISKDIR}/openWB.log"
 else
-	sudo python /var/www/html/openWB/modules/bezug_ethmpm3pm/readmpm3pm.py 
+        MYLOGFILE="${RAMDISKDIR}/evu.log"
 fi
-wattbezug=$(</var/www/html/openWB/ramdisk/wattbezug)
+
+
+if (( evukitversion == 1 )); then
+	sudo python ${OPENWBBASEDIR}/modules/bezug_ethmpm3pm/readlovato.py >>${MYLOGFILE} 2>&1
+	ret=$?
+elif (( evukitversion == 2 )); then
+	sudo python ${OPENWBBASEDIR}/modules/bezug_ethmpm3pm/readsdm.py >>${MYLOGFILE} 2>&1
+	ret=$?
+else
+	sudo python ${OPENWBBASEDIR}/modules/bezug_ethmpm3pm/readmpm3pm.py >>${MYLOGFILE} 2>&1
+	ret=$?
+fi
+
+openwbDebugLog ${DMOD} 2 "EVU RET: ${ret}"
+wattbezug=$(<${RAMDISKDIR}/wattbezug)
 echo $wattbezug

--- a/modules/bezug_ethmpm3pm/main.sh
+++ b/modules/bezug_ethmpm3pm/main.sh
@@ -15,6 +15,7 @@ else
         MYLOGFILE="${RAMDISKDIR}/evu.log"
 fi
 
+openwbDebugLog ${DMOD} 2 "EVU Kit Version: ${evukitversion}"
 
 if (( evukitversion == 1 )); then
 	sudo python ${OPENWBBASEDIR}/modules/bezug_ethmpm3pm/readlovato.py >>${MYLOGFILE} 2>&1

--- a/modules/bezug_ethmpm3pm/readlovato.py
+++ b/modules/bezug_ethmpm3pm/readlovato.py
@@ -1,44 +1,64 @@
 #!/usr/bin/python
-# import sys
+import sys
 # import os
 # import time
 # import getopt
 import struct
 from pymodbus.client.sync import ModbusTcpClient
 
-client = ModbusTcpClient('192.168.193.15', port=8899)
+##EVU Kit Defaults
+mbip='192.168.193.15'
+mbport=8899
+mbid=0x02
+
+#Check Argumentlist and replace Defaults if present
+if len(sys.argv) >= 2:
+        mbip=str(sys.argv[1])
+
+if len(sys.argv) >= 3:
+        mbport=int(sys.argv[2])
+
+if len(sys.argv) >= 4:
+        mbid=int(sys.argv[3])
+
+
+#client = ModbusTcpClient('192.168.193.15', port=8899)
+client = ModbusTcpClient()
+client.host(mbip)
+client.port(mbport)
+client.unit_id(mbid)
 
 #Voltage
-resp = client.read_input_registers(0x0001,2, unit=0x02)
+resp = client.read_input_registers(0x0001,2, unit=mbid)
 voltage1 = float(resp.registers[1] / 100)
 f = open('/var/www/html/openWB/ramdisk/evuv1', 'w')
 f.write(str(voltage1))
 f.close()
-resp = client.read_input_registers(0x0003,2, unit=0x02)
+resp = client.read_input_registers(0x0003,2, unit=mbid)
 voltage2 = float(resp.registers[1] / 100)
 f = open('/var/www/html/openWB/ramdisk/evuv2', 'w')
 f.write(str(voltage2))
 f.close()
-resp = client.read_input_registers(0x0005,2, unit=0x02)
+resp = client.read_input_registers(0x0005,2, unit=mbid)
 voltage3 = float(resp.registers[1] / 100)
 f = open('/var/www/html/openWB/ramdisk/evuv3', 'w')
 f.write(str(voltage3))
 f.close()
 
 #phasen watt
-resp = client.read_input_registers(0x0013,2, unit=0x02)
+resp = client.read_input_registers(0x0013,2, unit=mbid)
 all = format(resp.registers[0], '04x') + format(resp.registers[1], '04x')
 finalw1 = int(struct.unpack('>i', all.decode('hex'))[0] / 100)
 f = open('/var/www/html/openWB/ramdisk/bezugw1', 'w')
 f.write(str(finalw1))
 f.close()
-resp = client.read_input_registers(0x0015,2, unit=0x02)
+resp = client.read_input_registers(0x0015,2, unit=mbid)
 all = format(resp.registers[0], '04x') + format(resp.registers[1], '04x')
 finalw2 = int(struct.unpack('>i', all.decode('hex'))[0] / 100)
 f = open('/var/www/html/openWB/ramdisk/bezugw2', 'w')
 f.write(str(finalw2))
 f.close()
-resp = client.read_input_registers(0x0017,2, unit=0x02)
+resp = client.read_input_registers(0x0017,2, unit=mbid)
 all = format(resp.registers[0], '04x') + format(resp.registers[1], '04x')
 finalw3 = int(struct.unpack('>i', all.decode('hex'))[0] / 100)
 f = open('/var/www/html/openWB/ramdisk/bezugw3', 'w')
@@ -47,7 +67,7 @@ f.close()
 
 finalw= finalw1 + finalw2 + finalw3
 # total watt
-# resp = client.read_input_registers(0x0039,2, unit=0x02)
+# resp = client.read_input_registers(0x0039,2, unit=mbid)
 # all = format(resp.registers[0], '04x') + format(resp.registers[1], '04x')
 # finalw = int(struct.unpack('>i', all.decode('hex'))[0] / 100)
 f = open('/var/www/html/openWB/ramdisk/wattbezug', 'w')
@@ -55,7 +75,7 @@ f.write(str(finalw))
 f.close()
 
 #ampere l1
-resp = client.read_input_registers(0x0007, 2, unit=0x02)
+resp = client.read_input_registers(0x0007, 2, unit=mbid)
 all = format(resp.registers[0], '04x') + format(resp.registers[1], '04x')
 lla1 = float(struct.unpack('>i', all.decode('hex'))[0]) / 10000
 f = open('/var/www/html/openWB/ramdisk/bezuga1', 'w')
@@ -66,7 +86,7 @@ else:
 f.close()
 
 #ampere l2
-resp = client.read_input_registers(0x0009, 2, unit=0x02)
+resp = client.read_input_registers(0x0009, 2, unit=mbid)
 all = format(resp.registers[0], '04x') + format(resp.registers[1], '04x')
 lla2 = float(struct.unpack('>i', all.decode('hex'))[0]) / 10000
 f = open('/var/www/html/openWB/ramdisk/bezuga2', 'w')
@@ -77,7 +97,7 @@ else:
 f.close()
 
 #ampere l3
-resp = client.read_input_registers(0x000b, 2, unit=0x02)
+resp = client.read_input_registers(0x000b, 2, unit=mbid)
 all = format(resp.registers[0], '04x') + format(resp.registers[1], '04x')
 lla3 = float(struct.unpack('>i', all.decode('hex'))[0]) / 10000
 f = open('/var/www/html/openWB/ramdisk/bezuga3', 'w')
@@ -88,7 +108,7 @@ else:
 f.close()
 
 #evuhz
-resp = client.read_input_registers(0x0031,2, unit=0x02)
+resp = client.read_input_registers(0x0031,2, unit=mbid)
 evuhz= float(resp.registers[1])
 evuhz= float(evuhz / 100)
 if evuhz > 100:
@@ -98,19 +118,19 @@ f.write(str(evuhz))
 f.close()
 
 #Power Factor
-resp = client.read_input_registers(0x0025,2, unit=0x02)
+resp = client.read_input_registers(0x0025,2, unit=mbid)
 evupf1 = float(resp.registers[1]) / 10000
 f = open('/var/www/html/openWB/ramdisk/evupf1', 'w')
 f.write(str(evupf1))
 f.close()
 
-resp = client.read_input_registers(0x0027,2, unit=0x02)
+resp = client.read_input_registers(0x0027,2, unit=mbid)
 evupf2 = float(resp.registers[1]) / 10000
 f = open('/var/www/html/openWB/ramdisk/evupf2', 'w')
 f.write(str(evupf2))
 f.close()
 
-resp = client.read_input_registers(0x0029,2, unit=0x02)
+resp = client.read_input_registers(0x0029,2, unit=mbid)
 evupf3 = float(resp.registers[1]) / 10000
 f = open('/var/www/html/openWB/ramdisk/evupf3', 'w')
 f.write(str(evupf3))

--- a/modules/bezug_ethmpm3pm/readlovato.py
+++ b/modules/bezug_ethmpm3pm/readlovato.py
@@ -23,9 +23,9 @@ if len(sys.argv) >= 4:
 
 
 #client = ModbusTcpClient('192.168.193.15', port=8899)
-client = ModbusTcpClient()
-client.host(mbip)
-client.port(mbport)
+client = ModbusTcpClient(mbip,port=mbport)
+#client.host(mbip)
+#client.port(mbport)
 #client.unit_id(mbid)
 
 #Voltage

--- a/modules/bezug_ethmpm3pm/readlovato.py
+++ b/modules/bezug_ethmpm3pm/readlovato.py
@@ -26,7 +26,7 @@ if len(sys.argv) >= 4:
 client = ModbusTcpClient()
 client.host(mbip)
 client.port(mbport)
-client.unit_id(mbid)
+#client.unit_id(mbid)
 
 #Voltage
 resp = client.read_input_registers(0x0001,2, unit=mbid)

--- a/modules/bezug_ethmpm3pm/readmpm3pm.py
+++ b/modules/bezug_ethmpm3pm/readmpm3pm.py
@@ -24,9 +24,9 @@ if len(sys.argv) >= 4:
 
 
 #client = ModbusTcpClient('192.168.193.15', port=8899)
-client = ModbusTcpClient()
-client.host(mbip)
-client.port(mbport)
+client = ModbusTcpClient(mbip,port=mbport)
+#client.host(mbip)
+#client.port(mbport)
 #client.unit_id(mbid)
 
 # Voltage
@@ -52,10 +52,10 @@ f.write(str(voltage3))
 f.close()
 
 resp = client.read_input_registers(0x0002,4, unit=mbid)
-value1 = resp.registers[0] 
-value2 = resp.registers[1] 
+value1 = resp.registers[0]
+value2 = resp.registers[1]
 all = format(value1, '04x') + format(value2, '04x')
-ikwh = int(struct.unpack('>i', all.decode('hex'))[0]) 
+ikwh = int(struct.unpack('>i', all.decode('hex'))[0])
 ikwh = float(ikwh) * 10
 f = open('/var/www/html/openWB/ramdisk/bezugkwh', 'w')
 f.write(str(ikwh))
@@ -63,24 +63,24 @@ f.close()
 
 # phasen watt
 resp = client.read_input_registers(0x14,2, unit=mbid)
-value1 = resp.registers[0] 
-value2 = resp.registers[1] 
+value1 = resp.registers[0]
+value2 = resp.registers[1]
 all = format(value1, '04x') + format(value2, '04x')
 finalw1 = int(struct.unpack('>i', all.decode('hex'))[0]) / 100
 f = open('/var/www/html/openWB/ramdisk/bezugw1', 'w')
 f.write(str(finalw1))
 f.close()
 resp = client.read_input_registers(0x16,2, unit=mbid)
-value1 = resp.registers[0] 
-value2 = resp.registers[1] 
+value1 = resp.registers[0]
+value2 = resp.registers[1]
 all = format(value1, '04x') + format(value2, '04x')
 finalw2 = int(struct.unpack('>i', all.decode('hex'))[0]) / 100
 f = open('/var/www/html/openWB/ramdisk/bezugw2', 'w')
 f.write(str(finalw2))
 f.close()
 resp = client.read_input_registers(0x18,2, unit=mbid)
-value1 = resp.registers[0] 
-value2 = resp.registers[1] 
+value1 = resp.registers[0]
+value2 = resp.registers[1]
 all = format(value1, '04x') + format(value2, '04x')
 finalw3 = int(struct.unpack('>i', all.decode('hex'))[0]) / 100
 f = open('/var/www/html/openWB/ramdisk/bezugw3', 'w')
@@ -106,15 +106,15 @@ f.close()
 # resp = client.read_input_registers(0x12,2, unit=mbid)
 # lla3 = resp.registers[1]
 # lla3 = float(lla3) / 100
-lla3=round(float(float(finalw3) / float(voltage3)), 2) 
+lla3=round(float(float(finalw3) / float(voltage3)), 2)
 f = open('/var/www/html/openWB/ramdisk/bezuga3', 'w')
 f.write(str(lla3))
 f.close()
 
 # total watt
 resp = client.read_input_registers(0x26,2, unit=mbid)
-value1 = resp.registers[0] 
-value2 = resp.registers[1] 
+value1 = resp.registers[0]
+value2 = resp.registers[1]
 all = format(value1, '04x') + format(value2, '04x')
 final = int(struct.unpack('>i', all.decode('hex'))[0]) / 100
 f = open('/var/www/html/openWB/ramdisk/wattbezug', 'w')
@@ -123,10 +123,10 @@ f.close()
 
 # export kwh
 resp = client.read_input_registers(0x0004,4, unit=mbid)
-value1 = resp.registers[0] 
-value2 = resp.registers[1] 
+value1 = resp.registers[0]
+value2 = resp.registers[1]
 all = format(value1, '04x') + format(value2, '04x')
-ekwh = int(struct.unpack('>i', all.decode('hex'))[0]) 
+ekwh = int(struct.unpack('>i', all.decode('hex'))[0])
 ekwh = float(ekwh) * 10
 f = open('/var/www/html/openWB/ramdisk/einspeisungkwh', 'w')
 f.write(str(ekwh))
@@ -134,10 +134,10 @@ f.close()
 
 # evuhz
 resp = client.read_input_registers(0x2c,4, unit=mbid)
-value1 = resp.registers[0] 
-value2 = resp.registers[1] 
+value1 = resp.registers[0]
+value2 = resp.registers[1]
 all = format(value1, '04x') + format(value2, '04x')
-hz = int(struct.unpack('>i', all.decode('hex'))[0]) 
+hz = int(struct.unpack('>i', all.decode('hex'))[0])
 hz = round((float(hz) / 100), 2)
 f = open('/var/www/html/openWB/ramdisk/evuhz', 'w')
 f.write(str(hz))
@@ -145,30 +145,30 @@ f.close()
 
 # Power Factor
 resp = client.read_input_registers(0x20,4, unit=mbid)
-value1 = resp.registers[0] 
+value1 = resp.registers[0]
 value2 = resp.registers[1]
 all = format(value1, '04x') + format(value2, '04x')
-evupf1 = int(struct.unpack('>i', all.decode('hex'))[0]) 
+evupf1 = int(struct.unpack('>i', all.decode('hex'))[0])
 evupf1 = round((float(evupf1) / 10), 0)
 f = open('/var/www/html/openWB/ramdisk/evupf1', 'w')
 f.write(str(evupf1))
 f.close()
 
 resp = client.read_input_registers(0x22,4, unit=mbid)
-value1 = resp.registers[0] 
+value1 = resp.registers[0]
 value2 = resp.registers[1]
 all = format(value1, '04x') + format(value2, '04x')
-evupf2 = int(struct.unpack('>i', all.decode('hex'))[0]) 
+evupf2 = int(struct.unpack('>i', all.decode('hex'))[0])
 evupf2 = round((float(evupf2) / 10), 0)
 f = open('/var/www/html/openWB/ramdisk/evupf2', 'w')
 f.write(str(evupf2))
 f.close()
 
 resp = client.read_input_registers(0x24,4, unit=mbid)
-value1 = resp.registers[0] 
+value1 = resp.registers[0]
 value2 = resp.registers[1]
 all = format(value1, '04x') + format(value2, '04x')
-evupf3 = int(struct.unpack('>i', all.decode('hex'))[0]) 
+evupf3 = int(struct.unpack('>i', all.decode('hex'))[0])
 evupf3 = round((float(evupf3) / 10), 0)
 f = open('/var/www/html/openWB/ramdisk/evupf3', 'w')
 f.write(str(evupf3))

--- a/modules/bezug_ethmpm3pm/readmpm3pm.py
+++ b/modules/bezug_ethmpm3pm/readmpm3pm.py
@@ -1,36 +1,57 @@
 #!/usr/bin/python
-# import sys
+import sys
 # import os
 # import time
 # import getopt
 import struct
 from pymodbus.client.sync import ModbusTcpClient
 
-client = ModbusTcpClient('192.168.193.15', port=8899)
+##EVU Kit Defaults
+mbip='192.168.193.15'
+mbport=8899
+mdid = 5
+
+#Check Argumentlist and replace Defaults if present
+if len(sys.argv) >= 2:
+        mbip=str(sys.argv[1])
+
+if len(sys.argv) >= 3:
+        mbport=int(sys.argv[2])
+
+if len(sys.argv) >= 4:
+        mbid=int(sys.argv[3])
+
+
+
+#client = ModbusTcpClient('192.168.193.15', port=8899)
+client = ModbusTcpClient()
+client.host(mbip)
+client.port(mbport)
+#client.unit_id(mbid)
 
 # Voltage
-resp = client.read_input_registers(0x08,4, unit=5)
+resp = client.read_input_registers(0x08,4, unit=mbid)
 voltage1 = resp.registers[1]
 voltage1 = float(voltage1) / 10
 f = open('/var/www/html/openWB/ramdisk/evuv1', 'w')
 f.write(str(voltage1))
 f.close()
 
-resp = client.read_input_registers(0x0A,4, unit=5)
+resp = client.read_input_registers(0x0A,4, unit=mbid)
 voltage2 = resp.registers[1]
 voltage2 = float(voltage2) / 10
 f = open('/var/www/html/openWB/ramdisk/evuv2', 'w')
 f.write(str(voltage2))
 f.close()
 
-resp = client.read_input_registers(0x0C,4, unit=5)
+resp = client.read_input_registers(0x0C,4, unit=mbid)
 voltage3 = resp.registers[1]
 voltage3 = float(voltage3) / 10
 f = open('/var/www/html/openWB/ramdisk/evuv3', 'w')
 f.write(str(voltage3))
 f.close()
 
-resp = client.read_input_registers(0x0002,4, unit=5)
+resp = client.read_input_registers(0x0002,4, unit=mbid)
 value1 = resp.registers[0] 
 value2 = resp.registers[1] 
 all = format(value1, '04x') + format(value2, '04x')
@@ -41,7 +62,7 @@ f.write(str(ikwh))
 f.close()
 
 # phasen watt
-resp = client.read_input_registers(0x14,2, unit=5)
+resp = client.read_input_registers(0x14,2, unit=mbid)
 value1 = resp.registers[0] 
 value2 = resp.registers[1] 
 all = format(value1, '04x') + format(value2, '04x')
@@ -49,7 +70,7 @@ finalw1 = int(struct.unpack('>i', all.decode('hex'))[0]) / 100
 f = open('/var/www/html/openWB/ramdisk/bezugw1', 'w')
 f.write(str(finalw1))
 f.close()
-resp = client.read_input_registers(0x16,2, unit=5)
+resp = client.read_input_registers(0x16,2, unit=mbid)
 value1 = resp.registers[0] 
 value2 = resp.registers[1] 
 all = format(value1, '04x') + format(value2, '04x')
@@ -57,7 +78,7 @@ finalw2 = int(struct.unpack('>i', all.decode('hex'))[0]) / 100
 f = open('/var/www/html/openWB/ramdisk/bezugw2', 'w')
 f.write(str(finalw2))
 f.close()
-resp = client.read_input_registers(0x18,2, unit=5)
+resp = client.read_input_registers(0x18,2, unit=mbid)
 value1 = resp.registers[0] 
 value2 = resp.registers[1] 
 all = format(value1, '04x') + format(value2, '04x')
@@ -66,7 +87,7 @@ f = open('/var/www/html/openWB/ramdisk/bezugw3', 'w')
 f.write(str(finalw3))
 f.close()
 
-# resp = client.read_input_registers(0x0E,2, unit=5)
+# resp = client.read_input_registers(0x0E,2, unit=mbid)
 # lla1 = resp.registers[1]
 # lla1 = float(lla1) / 100
 lla1=round(float(float(finalw1) / float(voltage1)), 2)
@@ -74,7 +95,7 @@ f = open('/var/www/html/openWB/ramdisk/bezuga1', 'w')
 f.write(str(lla1))
 f.close()
 
-# resp = client.read_input_registers(0x10,2, unit=5)
+# resp = client.read_input_registers(0x10,2, unit=mbid)
 # lla2 = resp.registers[1]
 # lla2 = float(lla2) / 100
 lla2=round(float(float(finalw2) / float(voltage2)), 2)
@@ -82,7 +103,7 @@ f = open('/var/www/html/openWB/ramdisk/bezuga2', 'w')
 f.write(str(lla2))
 f.close()
 
-# resp = client.read_input_registers(0x12,2, unit=5)
+# resp = client.read_input_registers(0x12,2, unit=mbid)
 # lla3 = resp.registers[1]
 # lla3 = float(lla3) / 100
 lla3=round(float(float(finalw3) / float(voltage3)), 2) 
@@ -91,7 +112,7 @@ f.write(str(lla3))
 f.close()
 
 # total watt
-resp = client.read_input_registers(0x26,2, unit=5)
+resp = client.read_input_registers(0x26,2, unit=mbid)
 value1 = resp.registers[0] 
 value2 = resp.registers[1] 
 all = format(value1, '04x') + format(value2, '04x')
@@ -101,7 +122,7 @@ f.write(str(final))
 f.close()
 
 # export kwh
-resp = client.read_input_registers(0x0004,4, unit=5)
+resp = client.read_input_registers(0x0004,4, unit=mbid)
 value1 = resp.registers[0] 
 value2 = resp.registers[1] 
 all = format(value1, '04x') + format(value2, '04x')
@@ -112,7 +133,7 @@ f.write(str(ekwh))
 f.close()
 
 # evuhz
-resp = client.read_input_registers(0x2c,4, unit=5)
+resp = client.read_input_registers(0x2c,4, unit=mbid)
 value1 = resp.registers[0] 
 value2 = resp.registers[1] 
 all = format(value1, '04x') + format(value2, '04x')
@@ -123,7 +144,7 @@ f.write(str(hz))
 f.close()
 
 # Power Factor
-resp = client.read_input_registers(0x20,4, unit=5)
+resp = client.read_input_registers(0x20,4, unit=mbid)
 value1 = resp.registers[0] 
 value2 = resp.registers[1]
 all = format(value1, '04x') + format(value2, '04x')
@@ -133,7 +154,7 @@ f = open('/var/www/html/openWB/ramdisk/evupf1', 'w')
 f.write(str(evupf1))
 f.close()
 
-resp = client.read_input_registers(0x22,4, unit=5)
+resp = client.read_input_registers(0x22,4, unit=mbid)
 value1 = resp.registers[0] 
 value2 = resp.registers[1]
 all = format(value1, '04x') + format(value2, '04x')
@@ -143,7 +164,7 @@ f = open('/var/www/html/openWB/ramdisk/evupf2', 'w')
 f.write(str(evupf2))
 f.close()
 
-resp = client.read_input_registers(0x24,4, unit=5)
+resp = client.read_input_registers(0x24,4, unit=mbid)
 value1 = resp.registers[0] 
 value2 = resp.registers[1]
 all = format(value1, '04x') + format(value2, '04x')

--- a/modules/bezug_ethmpm3pm/readsdm.py
+++ b/modules/bezug_ethmpm3pm/readsdm.py
@@ -1,13 +1,33 @@
 #!/usr/bin/python
-# import sys
+import sys
 # import os
 # import time
 # import getopt
 import struct
 from pymodbus.client.sync import ModbusTcpClient
 
-client = ModbusTcpClient('192.168.193.15', port=8899)
+##EVU Kit Defaults
+mbip='192.168.193.15'
+mbport=8899
 sdmid = 115
+
+#Check Argumentlist and replace Defaults if present
+if len(sys.argv) >= 2:
+	mbip=str(sys.argv[1])
+
+if len(sys.argv) >= 3:
+	mbport=int(sys.argv[2])
+
+if len(sys.argv) >= 4:
+	sdmid=int(sys.argv[3])
+
+
+#client = ModbusTcpClient('192.168.193.15', port=8899)
+client = ModbusTcpClient()
+client.host(mbip)
+client.port(mbport)
+#client.unit_id(sdmid)
+
 
 # Voltage
 resp = client.read_input_registers(0x00,2, unit=sdmid)

--- a/modules/bezug_ethmpm3pm/readsdm.py
+++ b/modules/bezug_ethmpm3pm/readsdm.py
@@ -9,7 +9,7 @@ from pymodbus.client.sync import ModbusTcpClient
 ##EVU Kit Defaults
 mbip='192.168.193.15'
 mbport=8899
-sdmid = 115
+mbid = 115
 
 #Check Argumentlist and replace Defaults if present
 if len(sys.argv) >= 2:
@@ -19,30 +19,30 @@ if len(sys.argv) >= 3:
 	mbport=int(sys.argv[2])
 
 if len(sys.argv) >= 4:
-	sdmid=int(sys.argv[3])
+	mbid=int(sys.argv[3])
 
 
 #client = ModbusTcpClient('192.168.193.15', port=8899)
 client = ModbusTcpClient()
 client.host(mbip)
 client.port(mbport)
-#client.unit_id(sdmid)
+#client.unit_id(mbid)
 
 
 # Voltage
-resp = client.read_input_registers(0x00,2, unit=sdmid)
+resp = client.read_input_registers(0x00,2, unit=mbid)
 voltage = struct.unpack('>f',struct.pack('>HH',*resp.registers))[0]
 voltage1 = float("%.1f" % voltage)
 f = open('/var/www/html/openWB/ramdisk/evuv1', 'w')
 f.write(str(voltage1))
 f.close()
-resp = client.read_input_registers(0x02,2, unit=sdmid)
+resp = client.read_input_registers(0x02,2, unit=mbid)
 voltage = struct.unpack('>f',struct.pack('>HH',*resp.registers))[0]
 voltage2 = float("%.1f" % voltage)
 f = open('/var/www/html/openWB/ramdisk/evuv2', 'w')
 f.write(str(voltage2))
 f.close()
-resp = client.read_input_registers(0x04,2, unit=sdmid)
+resp = client.read_input_registers(0x04,2, unit=mbid)
 voltage = struct.unpack('>f',struct.pack('>HH',*resp.registers))[0]
 voltage3 = float("%.1f" % voltage)
 f = open('/var/www/html/openWB/ramdisk/evuv3', 'w')
@@ -50,19 +50,19 @@ f.write(str(voltage3))
 f.close()
 
 # phasen watt
-resp = client.read_input_registers(0x0C,2, unit=sdmid)
+resp = client.read_input_registers(0x0C,2, unit=mbid)
 llw1 = struct.unpack('>f',struct.pack('>HH',*resp.registers))[0]
 finalw1 = int(llw1)
 f = open('/var/www/html/openWB/ramdisk/bezugw1', 'w')
 f.write(str(finalw1))
 f.close()
-resp = client.read_input_registers(0x0E,2, unit=sdmid)
+resp = client.read_input_registers(0x0E,2, unit=mbid)
 llw1 = struct.unpack('>f',struct.pack('>HH',*resp.registers))[0]
 finalw2 = int(llw1)
 f = open('/var/www/html/openWB/ramdisk/bezugw2', 'w')
 f.write(str(finalw2))
 f.close()
-resp = client.read_input_registers(0x10,2, unit=sdmid)
+resp = client.read_input_registers(0x10,2, unit=mbid)
 llw1 = struct.unpack('>f',struct.pack('>HH',*resp.registers))[0]
 finalw3 = int(llw1)
 f = open('/var/www/html/openWB/ramdisk/bezugw3', 'w')
@@ -75,7 +75,7 @@ f.write(str(finalw))
 f.close()
 
 # ampere l1
-resp = client.read_input_registers(0x06,2, unit=sdmid)
+resp = client.read_input_registers(0x06,2, unit=mbid)
 lla1 = float(struct.unpack('>f',struct.pack('>HH',*resp.registers))[0])
 lla1 = float("%.1f" % lla1)
 f = open('/var/www/html/openWB/ramdisk/bezuga1', 'w')
@@ -86,7 +86,7 @@ else:
 f.close()
 
 # ampere l2
-resp = client.read_input_registers(0x08,2, unit=sdmid)
+resp = client.read_input_registers(0x08,2, unit=mbid)
 lla1 = float(struct.unpack('>f',struct.pack('>HH',*resp.registers))[0])
 lla2 = float("%.1f" % lla1)
 f = open('/var/www/html/openWB/ramdisk/bezuga2', 'w')
@@ -97,7 +97,7 @@ else:
 f.close()
 
 # ampere l3
-resp = client.read_input_registers(0x0A,2, unit=sdmid)
+resp = client.read_input_registers(0x0A,2, unit=mbid)
 lla1 = float(struct.unpack('>f',struct.pack('>HH',*resp.registers))[0])
 lla3 = float("%.1f" % lla1)
 f = open('/var/www/html/openWB/ramdisk/bezuga3', 'w')
@@ -108,7 +108,7 @@ else:
 f.close()
 
 # evuhz
-resp = client.read_input_registers(0x46,2, unit=sdmid)
+resp = client.read_input_registers(0x46,2, unit=mbid)
 hz = struct.unpack('>f',struct.pack('>HH',*resp.registers))[0]
 evuhz = float("%.2f" % hz)
 if evuhz > 100:
@@ -118,21 +118,21 @@ f.write(str(evuhz))
 f.close()
 
 # Power Factor
-resp = client.read_input_registers(0x1E,2, unit=sdmid)
+resp = client.read_input_registers(0x1E,2, unit=mbid)
 evu1pf = struct.unpack('>f',struct.pack('>HH',*resp.registers))[0]
 evu1pf = float("%.2f" % evu1pf)
 f = open('/var/www/html/openWB/ramdisk/evupf1', 'w')
 f.write(str(evu1pf))
 f.close()
 
-resp = client.read_input_registers(0x20,2, unit=sdmid)
+resp = client.read_input_registers(0x20,2, unit=mbid)
 evu2pf = struct.unpack('>f',struct.pack('>HH',*resp.registers))[0]
 evu2pf = float("%.2f" % evu2pf)
 f = open('/var/www/html/openWB/ramdisk/evupf2', 'w')
 f.write(str(evu2pf))
 f.close()
 
-resp = client.read_input_registers(0x22,2, unit=sdmid)
+resp = client.read_input_registers(0x22,2, unit=mbid)
 evu3pf = struct.unpack('>f',struct.pack('>HH',*resp.registers))[0]
 evu3pf = float("%.2f" % evu3pf)
 f = open('/var/www/html/openWB/ramdisk/evupf3', 'w')

--- a/modules/bezug_ethmpm3pm/readsdm.py
+++ b/modules/bezug_ethmpm3pm/readsdm.py
@@ -23,9 +23,9 @@ if len(sys.argv) >= 4:
 
 
 #client = ModbusTcpClient('192.168.193.15', port=8899)
-client = ModbusTcpClient()
-client.host(mbip)
-client.port(mbport)
+client = ModbusTcpClient(mbip,port=mbport)
+#client.host(mbip)
+#client.port(mbport)
 #client.unit_id(mbid)
 
 


### PR DESCRIPTION
Anpassung der EVU-Kit Module. Die Module können jetzt Parameter für IP, Port und Unit_id übernehmen.
Ohne Parameter werden die bisherigen Defaults verwendet. 
Es können 1-3 Parameter übergeben werden
1. IP 
2. Port
3. UNIT_ID

In dieser Reihenfolge sind die Parameter auch beim Aufruf zu übergeben, um die entsprechende Variable im Programm zu überschreiben. 

@benderl : Bitte eingehend überprüfen, ob das für openWB so funktioniert.

Ich habe auch auf meiner openWB mal geschaut, wie es mit den pymodbus Versionen aussieht.

pi@openWB:~ $ pip list |grep -i modbu
**pymodbus (2.5.1)**
pi@openWB:~ $ pip3 list |grep -i modbu
**pymodbus (2.4.0)**

Es sind unterschiedliche Package Versionen installiert. Aktuellste Version wäre pymodbus 2.5.2. 