### PR TITLE
Smarthome: Use SMA EnergyMeter as measuring module

### DIFF
--- a/modules/smarthome/smaem/speedwiredecoder.py
+++ b/modules/smarthome/smaem/speedwiredecoder.py
@@ -1,0 +1,164 @@
+"""
+ *
+ * by david-m-m 2019-Mar-17
+ * by datenschuft 2020-Jan-04
+ *
+ *  this software is released under GNU General Public License, version 2.
+ *  This program is free software;
+ *  you can redistribute it and/or modify it under the terms of the GNU General Public License
+ *  as published by the Free Software Foundation; version 2 of the License.
+ *  This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;
+ *  without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ *  See the GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License along with this program;
+ *  if not, write to the Free Software Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+ *
+ */
+"""
+
+import binascii
+
+# unit definitions with scaling
+sma_units={
+    "W":    10,
+    "VA":    10,
+    "VAr":    10,
+    "kWh":   3600000,
+    "kVAh":   3600000,
+    "kVArh":   3600000,
+    "A":    1000,
+    "V":    1000,
+    "°": 1000,
+    "Hz": 1000,
+}
+
+# map of all defined SMA channels
+# format: <channel_number>:(emparts_name>,<unit_actual>,<unit_total>)
+sma_channels={
+    # totals
+    1:('pconsume','W','kWh'),
+    2:('psupply','W','kWh'),
+    3:('sconsume','VA','kVAh'),
+    4:('ssupply','VA','kVAh'),
+    9:('qconsume','VAr','kVArh'),
+    10:('qsupply','VAr','kVArh'),
+    13:('cosphi','°'),
+    14:('frequency','Hz'),
+    # phase 1
+    21:('p1consume','W','kWh'),
+    22:('p1supply','W','kWh'),
+    23:('s1consume','VA','kVAh'),
+    24:('s1supply','VA','kVAh'),
+    29:('q1consume','VAr','kVArh'),
+    30:('q1supply','VAr','kVArh'),
+    31:('i1','A'),
+    32:('u1','V'),
+    33:('cosphi1','°'),
+    # phase 2
+    41:('p2consume','W','kWh'),
+    42:('p2supply','W','kWh'),
+    43:('s2consume','VA','kVAh'),
+    44:('s2supply','VA','kVAh'),
+    49:('q2consume','VAr','kVArh'),
+    50:('q2supply','VAr','kVArh'),
+    51:('i2','A'),
+    52:('u2','V'),
+    53:('cosphi2','°'),
+    # phase 3
+    61:('p3consume','W','kWh'),
+    62:('p3supply','W','kWh'),
+    63:('s3consume','VA','kVAh'),
+    64:('s3supply','VA','kVAh'),
+    69:('q3consume','VAr','kVArh'),
+    70:('q3supply','VAr','kVArh'),
+    71:('i3','A'),
+    72:('u3','V'),
+    73:('cosphi3','°'),
+    # common
+    36864:('speedwire-version',''),
+}
+
+def decode_OBIS(obis):
+  measurement=int.from_bytes(obis[0:2], byteorder='big' )
+  raw_type=int.from_bytes(obis[2:3], byteorder='big')
+  if raw_type==4:
+    datatype='actual'
+  elif raw_type==8:
+    datatype='counter'
+  elif raw_type==0 and measurement==36864:
+    datatype='version'
+  else:
+    datatype='unknown'
+    print('unknown datatype: measurement {} datatype {} raw_type {}'.format(measurement,datatype,raw_type))
+  return (measurement,datatype)
+
+def decode_speedwire(datagram):
+  emparts={}
+  # process data only of SMA header is present
+  if datagram[0:3]==b'SMA':
+    # datagram length
+    datalength=int.from_bytes(datagram[12:14],byteorder='big')+16
+    #print('data lenght: {}'.format(datalength))
+    # serial number
+    emID=int.from_bytes(datagram[20:24],byteorder='big')
+    #print('seral: {}'.format(emID))
+    emparts['serial']=emID
+    # timestamp
+    timestamp=int.from_bytes(datagram[24:28],byteorder='big')
+    #print('timestamp: {}'.format(timestamp))
+    # decode OBIS data blocks
+    # start with header
+    position=28
+    while position<datalength:
+      # decode header
+      #print('pos: {}'.format(position))
+      (measurement,datatype)=decode_OBIS(datagram[position:position+4])
+      #print('measurement {} datatype: {}'.format(measurement,datatype))
+      # decode values
+      # actual values
+      if datatype=='actual':
+        value=int.from_bytes( datagram[position+4:position+8], byteorder='big' )
+        position+=8
+        if measurement in sma_channels.keys():
+          emparts[sma_channels[measurement][0]]=value/sma_units[sma_channels[measurement][1]]
+          emparts[sma_channels[measurement][0]+'unit']=sma_channels[measurement][1]
+      # counter values
+      elif datatype=='counter':
+        value=int.from_bytes( datagram[position+4:position+12], byteorder='big' )
+        position+=12
+        if measurement in sma_channels.keys():
+          emparts[sma_channels[measurement][0]+'counter']=value/sma_units[sma_channels[measurement][2]]
+          emparts[sma_channels[measurement][0]+'counterunit']=sma_channels[measurement][2]
+      elif datatype=='version':
+        value=datagram[position+4:position+8]
+        if measurement in sma_channels.keys():
+          bversion=(binascii.b2a_hex(value).decode("utf-8"))
+          version=str(int(bversion[0:2],16))+"."+str(int(bversion[2:4],16))+"."+str(int(bversion[4:6],16))
+          revision=str(chr(int(bversion[6:8])))
+          #revision definitions
+          if revision=="1":
+              #S – Spezial Version
+              version=version+".S"
+          elif revision=="2":
+              #A – Alpha (noch kein Feature Complete, Version für Verifizierung und Validierung)
+              version=version+".A"
+          elif revision=="3":
+              #B – Beta (Feature Complete, Version für Verifizierung und Validierung)
+              version=version+".B"
+          elif revision=="4":
+              #R – Release Candidate / Release (Version für Verifizierung, Validierung und Feldtest / öffentliche Version)
+              version=version+".R"
+          elif revision=="5":
+              #E – Experimental Version (dient zur lokalen Verifizierung)
+              version=version+".E"
+          elif revision=="6":
+              #N – Keine Revision
+              version=version+".N"
+          #adding versionnumber to compare verions
+          version=version+"|"+str(bversion[0:2])+str(bversion[2:4])+str(bversion[4:6])
+          emparts[sma_channels[measurement][0]]=version
+        position+=8
+      else:
+        position+=8
+  return emparts

--- a/modules/smarthome/smaem/watt.py
+++ b/modules/smarthome/smaem/watt.py
@@ -1,0 +1,138 @@
+#!/usr/bin/python3
+# coding=utf-8
+"""
+ *
+ * by Markus Gießen 2021-05-12
+ * adopted from Florian Wenger
+ * 
+ * Here we only use a SMA EnergyMeter as SmartHome Device
+ * Only two values are returned: 
+ * pconsume = current power consumation in Watt
+ * pconsumecounter = cumulated value of power consumation in kWh
+ * endless loop (until ctrl+c) displays measurement from SMA Energymeter
+ *
+ *  this software is released under GNU General Public License, version 2.
+ *  This program is free software;
+ *  you can redistribute it and/or modify it under the terms of the GNU General Public License
+ *  as published by the Free Software Foundation; version 2 of the License.
+ *  This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;
+ *  without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ *  See the GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License along with this program;
+ *  if not, write to the Free Software Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+ *
+ * 2018-12-22 Tommi2Day small enhancements
+ * 2019-08-13 datenschuft run without config
+ * 2020-01-04 datenschuft changes to tun with speedwiredecoder
+ * 2020-01-13 Kevin Wieland changes to run with openWB
+ * 2020-02-03 theHolgi added phase-wise load and power factor
+ * 2021-09-01 Markus Gießen adoption for usage as Smart Home Device for power consumption
+ *
+ */
+"""
+import sys
+import os
+import time
+import getopt
+import binascii
+import json
+import signal
+import sys
+import socket
+import struct
+from speedwiredecoder import *
+
+# clean exit
+def abortprogram(signal,frame):
+    # Housekeeping -> nothing to cleanup
+    print('STRG + C = end program')
+    sys.exit(0)
+
+# abort-signal
+signal.signal(signal.SIGINT, abortprogram)
+
+# read configuration
+# default values
+devicenumber = str(sys.argv[1]) # SmartHomeDevice-Nummer
+smaserial = sys.argv[2] # SMA EnergyMeter Serial number
+secondssincelastmetering = sys.argv[3] # Seconds since last metering, useful for handling with more than one EnergyMeter
+debugmodus = sys.argv[4] # Switch for activating debug log "ramdisk/smaem.log": 0 = off / 1 = on
+
+# TEST until we have the GUI configuration
+debugmodus = 0
+secondssincelastmetering = 15
+# TEST
+
+ipbind = '0.0.0.0'
+MCAST_GRP = '239.12.255.254'
+MCAST_PORT = 9522
+
+returnfile = '/var/www/html/openWB/ramdisk/smarthome_device_ret' + str(devicenumber)
+if debugmodus == 1:
+	debugfile = open('/var/www/html/openWB/ramdisk/smaem.log','a',newline='\r\n')
+
+# debugfile.write('smaserial: #' + smaserial + '#\n')
+
+sock = socket.socket(socket.AF_INET, socket.SOCK_DGRAM, socket.IPPROTO_UDP)
+sock.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)
+sock.bind(('', MCAST_PORT))
+try:
+    mreq = struct.pack("4s4s", socket.inet_aton(MCAST_GRP), socket.inet_aton(ipbind))
+    sock.setsockopt(socket.IPPROTO_IP, socket.IP_ADD_MEMBERSHIP, mreq)
+except BaseException:
+    print('Module SMAEM: Could not connect to multicast group or bind to given interface')
+    sys.exit(1)
+
+if os.path.isfile(returnfile):
+	lastmodificationtime=os.path.getmtime(returnfile)
+else:
+	lastmodificationtime=time.time()
+
+# Processing received messages
+# The SMA EnergyMeter does not send any data package if there is no Power Consumption / no data to send
+# Therefore we have to do a special processing for this scenario.
+# We also have to take care if there are more than one EnergyMeter in the network sending, that's why we check the modification time in scenario 2.
+# Without this check we would generate a ret-file everytime we receive data from a not desired EnergyMeter.
+emparts={}
+emparts=decode_speedwire(sock.recv(608))
+
+# debugfile.write('Current SMA serial number:#' + str(emparts['serial']) + '# - watt:#' + str(int(emparts.get("pconsume"))) + '# - wattc:#' + str("{:.3f}".format(int(emparts.get('pconsumecounter')*1000))) + '#\n')
+
+if smaserial is None or smaserial == 'none' or str(emparts['serial']) == smaserial: # Scenario 1: Our EnergyMeter is sending, so we put the current values in our output variables
+ watt=str(int(emparts.get("pconsume")))
+ wattc=str("{:.3f}".format(int(emparts.get('pconsumecounter')*1000)))
+ if debugmodus == 1:
+ 	debugfile.write('1 - Our SMA EM ' + smaserial + ' is sending, everything fine\n')
+elif (os.path.isfile(returnfile)) and ((time.time()-lastmodificationtime) >= int(secondssincelastmetering)): # Scenario 2: Our EnergyMeter is not sending but we have a returnfile which is older than n seconds (parameter secondssincelastmetering)
+ # We have a ret-file which is older than n seconds so we create a "fake" ret-file.
+ # We set "0" as current Power Consume (pconsume) and (from the existing ret-file) the last value for the Power Consume Counter (pconsumecounter)
+ watt='0'
+ ret=open(returnfile, 'r')
+ lastvalues = ret.read()
+ ret.close()
+ wattc = lastvalues[int(lastvalues.rfind('powerc')) + 9:lastvalues.find('}')]
+ if debugmodus == 1:
+ 	debugfile.write('2 - We create a fake ret-file. lastvalues:# ' + lastvalues + '# - int-lastvalues.rfind-powerc-:#' + str((lastvalues.rfind('powerc'))) + '#\n')
+
+elif (os.path.isfile(returnfile)) and ((time.time()-lastmodificationtime) < int(secondssincelastmetering)): # Scenario 3: Our EnergyMeter is not sending but we have a returnfile which is younger than n seconds (parameter secondssincelastmetering)
+ # We have a ret-file which is younger than n seconds. We do nothing as the existing ret-file is good enough.
+ if debugmodus == 1:
+ 	debugfile.write('3 - The existing ret-file is fine enough. time.time():# ' + str(time.time()) + '# - lastmodificationtime:# ' + str(lastmodificationtime) + '# - secondssincelastmetering:# ' + str(secondssincelastmetering) + '#\n')
+ sys.exit("Module SMAEM: No data received and no historical data which is older than " + str(secondssincelastmetering) + " seconds.") 
+else:
+ # Our EnergyMeter is not sending right now and it didn't send any data since boottime
+ # In this case we do nothing and we don't create a "fake" returnfile
+ # This will cause error messages in /var/www/html/openWB/ramdisk/smarthome.log: 
+ # Module SMAEM: No data received and no historical data since boottime
+ # Leistungsmessung smaem [...] Fehlermeldung: [Errno 2] No such file or directory: '/var/www/html/openWB/ramdisk/smarthome_device_ret1'W
+ # debugfile.write('4 - Our SMA EM ' + smaserial + ' is not sending right now\n')
+ sys.exit("Module SMAEM: No data received and no historical data since boottime")
+# general output section
+
+answer = '{"power":' + watt + ',"powerc":' + wattc + '}'
+f = open(returnfile, 'w')
+json.dump(answer,f)
+f.close()
+if debugmodus == 1:
+	debugfile.close()

--- a/runs/smarthomehandler.py
+++ b/runs/smarthomehandler.py
@@ -290,6 +290,8 @@ def sepwatt(oldwatt,oldwattk,nummer):
             argumentList.append(measurepassword)
         except:
             argumentList.append("undef")
+    elif meastyp == "smaem":
+        argumentList[1] = prefixpy + 'smaem/watt.py'
     else:
        # no known meastyp, so return the old values directly
         logDebug(LOGLEVELERROR, "Leistungsmessung %s %d %s Geraetetyp ist nicht implementiert!" % (meastyp, nummer, str(configuredName)))


### PR DESCRIPTION
English:
I've reused the existing speedwiredecoder.py and created a module for using a SMA EnergyMeter for measuring.
The ret-file contains the current consumption (watt) and the total consumption (wattc).
My EnergyMeter is used for my heatpump and the heatpump is shut down twice a day. During this time the energy won't send and the current consumption is wrong. So I've implemented a workaround for handling an existing ret-file but changing the current consumption to 0 while the powerc remains.

Deutsch:
Ich habe ein Smarthome-Modul entwickelt um einen SMA EnergyMeter zur  Leistungsmessung zu verwenden.
Dabei habe ich die bestehende speedwiredecoder.py verwendet.
Es wird die aktuelle Leistungsaufnahme (watt) und die Summe der Leistungsaufnahme (wattc) ausgelesen.
Mein EnergyMeter misst meine Wärmepumpe und diese schalte ich zweimal am Tag für einige Stunden aus.
Während dieser Zeit ist der EnergyMeter ausgeschaltet und somit sendet er auch keine Datenpakete. Ich habe einen Workaround implmentiert sodass ich auch ein bestehendes ret-file verwenden kann (wattc wird ausgelesen, watt wird mit 0 geschrieben).


Benötigte GUI Komponenten für den Gerätetyp "SMA EnergyMeter":
"Seriennummer des SMA Energy Meter": Numerisch, zB 1901411846 --> "smaserial" in smarthome.ini
"Trägheit": Nummer, definiert wie alt in Sekunden ein bestehendes ret-file sein darf um akzeptiert zu werden. Default = 5 --> "secondssincelastmetering" in smarthome.ini
"Debug": Nummer: 0 = aus / 1 = ein - wenn 1, schreibe ich ein logfile smaem.log in die ramdisk. Default = 0 = aus --> "debugmodus" in smarthome.ini

Wenn die GUI-Komponenten existieren, passe ich den Code entsprechend an. Danke!