### PR TITLE
Flexible pv-kit Modules (Parameters)

### DIFF
--- a/modules/wr2_ethlovato/main.sh
+++ b/modules/wr2_ethlovato/main.sh
@@ -24,5 +24,5 @@ elif (( pvkitversion == 2 )); then
 else
 	#python3 ${OPENWBBASEDIR}/modules/wr_pvkit/readmpm3pm.py "2" "192.168.193.13" "8899" "8" >>${MYLOGFILE} 2>&1
 fi
-pvwatt=$(<${RAMDISKDIR}/pvwatt)
+pvwatt=$(<${RAMDISKDIR}/pv2watt)
 echo $pvwatt

--- a/modules/wr2_ethlovato/main.sh
+++ b/modules/wr2_ethlovato/main.sh
@@ -1,10 +1,28 @@
 #!/bin/bash
+OPENWBBASEDIR=$(cd `dirname $0`/../../ && pwd)
+RAMDISKDIR="${OPENWBBASEDIR}/ramdisk"
+MODULEDIR=$(cd `dirname $0` && pwd)
+DMOD="PV"
+#DMOD="MAIN"
+Debug=$debug
 
-if (( pv2kitversion == 1 )); then
-	python /var/www/html/openWB/modules/wr2_ethlovato/readsdm.py  
+#For development only
+#Debug=1
+
+if [ ${DMOD} == "MAIN" ]; then
+	MYLOGFILE="${RAMDISKDIR}/openWB.log"
 else
-	python /var/www/html/openWB/modules/wr2_ethlovato/readlovato.py  
+	MYLOGFILE="${RAMDISKDIR}/nurpv.log"
 fi
 
-pv2watt=$(</var/www/html/openWB/ramdisk/pv2watt)
-echo $pv2watt
+#python3 ${OPENWBBASEDIR}/modules/wr_pvkitflex/test.py "2" ${pvflexip} ${pvflexport} ${pvflexid} >>${MYLOGFILE} 2>&1
+
+if (( pvkitversion == 1 )); then
+	python3 ${OPENWBBASEDIR}/modules/wr_pvkit/readlovato.py "2" "192.168.193.13" "8899" "0x08" >>${MYLOGFILE} 2>&1
+elif (( pvkitversion == 2 )); then
+	python3 ${OPENWBBASEDIR}/modules/wr_pvkit/readsdm.py "2" "192.168.193.13" "8899" "116" >>${MYLOGFILE} 2>&1
+else
+	#python3 ${OPENWBBASEDIR}/modules/wr_pvkit/readmpm3pm.py "2" "192.168.193.13" "8899" "8" >>${MYLOGFILE} 2>&1
+fi
+pvwatt=$(<${RAMDISKDIR}/pvwatt)
+echo $pvwatt

--- a/modules/wr2_ethlovatoaevu/main.sh
+++ b/modules/wr2_ethlovatoaevu/main.sh
@@ -1,10 +1,28 @@
 #!/bin/bash
+OPENWBBASEDIR=$(cd `dirname $0`/../../ && pwd)
+RAMDISKDIR="${OPENWBBASEDIR}/ramdisk"
+MODULEDIR=$(cd `dirname $0` && pwd)
+DMOD="PV"
+#DMOD="MAIN"
+Debug=$debug
 
-if (( pv2kitversion == 1 )); then
-	python /var/www/html/openWB/modules/wr2_ethlovatoaevu/readsdm.py  
+#For development only
+#Debug=1
+
+if [ ${DMOD} == "MAIN" ]; then
+	MYLOGFILE="${RAMDISKDIR}/openWB.log"
 else
-	python /var/www/html/openWB/modules/wr2_ethlovatoaevu/readlovato.py  
+	MYLOGFILE="${RAMDISKDIR}/nurpv.log"
 fi
 
-pvwatt2=$(</var/www/html/openWB/ramdisk/pv2watt)
-echo $pvwatt2
+#python3 ${OPENWBBASEDIR}/modules/wr_pvkitflex/test.py "2" ${pvflexip} ${pvflexport} ${pvflexid} >>${MYLOGFILE} 2>&1
+
+if (( pvkitversion == 1 )); then
+	python3 ${OPENWBBASEDIR}/modules/wr_pvkit/readlovato.py "2" "192.168.193.15" "8899" "0x08" >>${MYLOGFILE} 2>&1
+elif (( pvkitversion == 2 )); then
+	python3 ${OPENWBBASEDIR}/modules/wr_pvkit/readsdm.py "2" "192.168.193.15" "8899" "116" >>${MYLOGFILE} 2>&1
+else
+	#python3 ${OPENWBBASEDIR}/modules/wr_pvkit/readmpm3pm.py "2" "192.168.193.15" "8899" "8" >>${MYLOGFILE} 2>&1
+fi
+pvwatt=$(<${RAMDISKDIR}/pvwatt)
+echo $pvwatt

--- a/modules/wr2_ethlovatoaevu/main.sh
+++ b/modules/wr2_ethlovatoaevu/main.sh
@@ -24,5 +24,5 @@ elif (( pvkitversion == 2 )); then
 else
 	#python3 ${OPENWBBASEDIR}/modules/wr_pvkit/readmpm3pm.py "2" "192.168.193.15" "8899" "8" >>${MYLOGFILE} 2>&1
 fi
-pvwatt=$(<${RAMDISKDIR}/pvwatt)
+pvwatt=$(<${RAMDISKDIR}/pv2watt)
 echo $pvwatt

--- a/modules/wr_ethmpm3pmaevu/main.sh
+++ b/modules/wr_ethmpm3pmaevu/main.sh
@@ -22,7 +22,7 @@ if (( pvkitversion == 1 )); then
 elif (( pvkitversion == 2 )); then
 	python3 ${OPENWBBASEDIR}/modules/wr_pvkit/readsdm.py "1" "192.168.193.15" "8899" "116" >>${MYLOGFILE} 2>&1
 else
-	#python3 ${OPENWBBASEDIR}/modules/wr_pvkit/readmpm3pm.py "1" "192.168.193.15" "8899" "8" >>${MYLOGFILE} 2>&1
+	python3 ${OPENWBBASEDIR}/modules/wr_pvkit/readmpm3pm.py "1" "192.168.193.15" "8899" "8" >>${MYLOGFILE} 2>&1
 fi
 pvwatt=$(<${RAMDISKDIR}/pvwatt)
 echo $pvwatt

--- a/modules/wr_ethmpm3pmaevu/main.sh
+++ b/modules/wr_ethmpm3pmaevu/main.sh
@@ -1,10 +1,28 @@
 #!/bin/bash
-if (( pvkitversion == 1 )); then
-	python /var/www/html/openWB/modules/wr_ethmpm3pmaevu/readlovato.py 
-elif (( pvkitversion == 2 )); then
-	python /var/www/html/openWB/modules/wr_ethmpm3pmaevu/readsdm.py
+OPENWBBASEDIR=$(cd `dirname $0`/../../ && pwd)
+RAMDISKDIR="${OPENWBBASEDIR}/ramdisk"
+MODULEDIR=$(cd `dirname $0` && pwd)
+DMOD="PV"
+#DMOD="MAIN"
+Debug=$debug
+
+#For development only
+#Debug=1
+
+if [ ${DMOD} == "MAIN" ]; then
+	MYLOGFILE="${RAMDISKDIR}/openWB.log"
 else
-	python /var/www/html/openWB/modules/wr_ethmpm3pmaevu/readmpm3pm.py 
+	MYLOGFILE="${RAMDISKDIR}/nurpv.log"
 fi
-pvwatt=$(</var/www/html/openWB/ramdisk/pvwatt)
+
+#python3 ${OPENWBBASEDIR}/modules/wr_pvkitflex/test.py "1" ${pvflexip} ${pvflexport} ${pvflexid} "1" >>${MYLOGFILE} 2>&1
+
+if (( pvkitversion == 1 )); then
+	python3 ${OPENWBBASEDIR}/modules/wr_pvkit/readlovato.py "1" "192.168.193.15" "8899" "116" >>${MYLOGFILE} 2>&1
+elif (( pvkitversion == 2 )); then
+	python3 ${OPENWBBASEDIR}/modules/wr_pvkit/readsdm.py "1" "192.168.193.15" "8899" "116" >>${MYLOGFILE} 2>&1
+else
+	#python3 ${OPENWBBASEDIR}/modules/wr_pvkit/readmpm3pm.py "1" "192.168.193.15" "8899" "116" >>${MYLOGFILE} 2>&1
+fi
+pvwatt=$(<${RAMDISKDIR}/pvwatt)
 echo $pvwatt

--- a/modules/wr_ethmpm3pmaevu/main.sh
+++ b/modules/wr_ethmpm3pmaevu/main.sh
@@ -18,11 +18,11 @@ fi
 #python3 ${OPENWBBASEDIR}/modules/wr_pvkitflex/test.py "1" ${pvflexip} ${pvflexport} ${pvflexid} "1" >>${MYLOGFILE} 2>&1
 
 if (( pvkitversion == 1 )); then
-	python3 ${OPENWBBASEDIR}/modules/wr_pvkit/readlovato.py "1" "192.168.193.15" "8899" "116" >>${MYLOGFILE} 2>&1
+	python3 ${OPENWBBASEDIR}/modules/wr_pvkit/readlovato.py "1" "192.168.193.15" "8899" "0x08" >>${MYLOGFILE} 2>&1
 elif (( pvkitversion == 2 )); then
 	python3 ${OPENWBBASEDIR}/modules/wr_pvkit/readsdm.py "1" "192.168.193.15" "8899" "116" >>${MYLOGFILE} 2>&1
 else
-	#python3 ${OPENWBBASEDIR}/modules/wr_pvkit/readmpm3pm.py "1" "192.168.193.15" "8899" "116" >>${MYLOGFILE} 2>&1
+	#python3 ${OPENWBBASEDIR}/modules/wr_pvkit/readmpm3pm.py "1" "192.168.193.15" "8899" "8" >>${MYLOGFILE} 2>&1
 fi
 pvwatt=$(<${RAMDISKDIR}/pvwatt)
 echo $pvwatt

--- a/modules/wr_pvkit/main.sh
+++ b/modules/wr_pvkit/main.sh
@@ -1,10 +1,27 @@
 #!/bin/bash
-if (( pvkitversion == 1 )); then
-	python /var/www/html/openWB/modules/wr_pvkit/readlovato.py 
-elif (( pvkitversion == 2 )); then
-	python /var/www/html/openWB/modules/wr_pvkit/readsdm.py
+OPENWBBASEDIR=$(cd `dirname $0`/../../ && pwd)
+RAMDISKDIR="${OPENWBBASEDIR}/ramdisk"
+MODULEDIR=$(cd `dirname $0` && pwd)
+DMOD="PV"
+#DMOD="MAIN"
+Debug=$debug
+
+#For development only
+#Debug=1
+
+if [ ${DMOD} == "MAIN" ]; then
+        MYLOGFILE="${RAMDISKDIR}/openWB.log"
 else
-	python /var/www/html/openWB/modules/wr_pvkit/readmpm3pm.py 
+        MYLOGFILE="${RAMDISKDIR}/nurpv.log"
 fi
-pvwatt=$(</var/www/html/openWB/ramdisk/pvwatt)
+
+
+if (( pvkitversion == 1 )); then
+	python3 ${OPENWBBASEDIR}/modules/wr_pvkit/readlovato.py >>${MYLOGFILE} 2>&1
+elif (( pvkitversion == 2 )); then
+	python3 ${OPENWBBASEDIR}/modules/wr_pvkit/readsdm.py >>${MYLOGFILE} 2>&1
+else
+	python3 ${OPENWBBASEDIR}/modules/wr_pvkit/readmpm3pm.py >>${MYLOGFILE} 2>&1
+fi
+pvwatt=$(<${RAMDISKDIR}/pvwatt)
 echo $pvwatt

--- a/modules/wr_pvkit/readlovato.py
+++ b/modules/wr_pvkit/readlovato.py
@@ -14,10 +14,10 @@ numpv = 1
 
 #Check Argumentlist and replace Defaults if present
 if len(sys.argv) >= 2:
-	numpv=str(sys.argv[1])
+	numpv=int(sys.argv[1])
 
 if len(sys.argv) >= 3:
-	mbip=int(sys.argv[2])
+	mbip=str(sys.argv[2])
 
 if len(sys.argv) >= 4:
 	mbport=int(sys.argv[3])

--- a/modules/wr_pvkit/readlovato.py
+++ b/modules/wr_pvkit/readlovato.py
@@ -1,72 +1,114 @@
 #!/usr/bin/python
-# import sys
+import sys
 # import os
 # import time
 # import getopt
 import struct
 from pymodbus.client.sync import ModbusTcpClient
 
-client = ModbusTcpClient('192.168.193.13', port=8899)
+##PV Kit Defaults
+mbip='192.168.193.13'
+mbport=8899
+mbid=0x08
+numpv = 1
+
+#Check Argumentlist and replace Defaults if present
+if len(sys.argv) >= 2:
+	numpv=str(sys.argv[1])
+
+if len(sys.argv) >= 3:
+	mbip=int(sys.argv[2])
+
+if len(sys.argv) >= 4:
+	mbport=int(sys.argv[3])
+
+if len(sys.argv) >= 5:
+	mbid=int(sys.argv[4])
+
+#client = ModbusTcpClient('192.168.193.13', port=8899)
+client = ModbusTcpClient(mbip,port=mbport)
+#client.host(mbip)
+#client.port(mbport)
+#client.unit_id(mbid)
+
+
+
 
 # Counters
-resp = client.read_input_registers(0x1a1f,2, unit=0x08)
+resp = client.read_input_registers(0x1a1f,2, unit=mbid)
 all = format(resp.registers[0], '04x') + format(resp.registers[1], '04x')
 finalbezug1 = int(struct.unpack('>i', all.decode('hex'))[0])
-resp = client.read_input_registers(0x1a21,2, unit=0x08)
+resp = client.read_input_registers(0x1a21,2, unit=mbid)
 all = format(resp.registers[0], '04x') + format(resp.registers[1], '04x')
 finalbezug2 = int(struct.unpack('>i', all.decode('hex'))[0])
 if ( finalbezug1 > finalbezug2 ):
-    finalbezug=finalbezug1
+	finalbezug=finalbezug1
 else:
-    finalbezug=finalbezug2
-f = open('/var/www/html/openWB/ramdisk/pvkwh', 'w')
+	finalbezug=finalbezug2
+if numpv == 1:
+	f = open('/var/www/html/openWB/ramdisk/pvkwh', 'w')
+else:
+	f = open('/var/www/html/openWB/ramdisk/pv' + str(numpv) + 'kwh', 'w')
+
 f.write(str(finalbezug))
 f.close()
 
 # phasen watt
-resp = client.read_input_registers(0x0013,2, unit=0x08)
+resp = client.read_input_registers(0x0013,2, unit=mbid)
 all = format(resp.registers[0], '04x') + format(resp.registers[1], '04x')
 finalw1 = int(struct.unpack('>i', all.decode('hex'))[0] / 100)
 
-resp = client.read_input_registers(0x0015,2, unit=0x08)
+resp = client.read_input_registers(0x0015,2, unit=mbid)
 all = format(resp.registers[0], '04x') + format(resp.registers[1], '04x')
 finalw2 = int(struct.unpack('>i', all.decode('hex'))[0] / 100)
-resp = client.read_input_registers(0x0017,2, unit=0x08)
+resp = client.read_input_registers(0x0017,2, unit=mbid)
 all = format(resp.registers[0], '04x') + format(resp.registers[1], '04x')
 finalw3 = int(struct.unpack('>i', all.decode('hex'))[0] / 100)
 
 finalw= finalw1 + finalw2 + finalw3
 if ( finalw > 10):
-    finalw=finalw*-1
+	finalw=finalw*-1
 
 # total watt
-# resp = client.read_input_registers(0x0039,2, unit=0x08)
+# resp = client.read_input_registers(0x0039,2, unit=mbid)
 # all = format(resp.registers[0], '04x') + format(resp.registers[1], '04x')
 # finalw = int(struct.unpack('>i', all.decode('hex'))[0] / 100)
-f = open('/var/www/html/openWB/ramdisk/pvwatt', 'w')
+if numpv == 1:
+	f = open('/var/www/html/openWB/ramdisk/pvwatt', 'w')
+else:
+	f = open('/var/www/html/openWB/ramdisk/pv' + str(numpv)+ 'watt', 'w')
 f.write(str(finalw))
 f.close()
 
 # ampere l1
-resp = client.read_input_registers(0x0007, 2, unit=0x08)
+resp = client.read_input_registers(0x0007, 2, unit=mbid)
 all = format(resp.registers[0], '04x') + format(resp.registers[1], '04x')
 lla1 = float(struct.unpack('>i', all.decode('hex'))[0]) / 10000
-f = open('/var/www/html/openWB/ramdisk/pva1', 'w')
+if numpv == 1:
+	f = open('/var/www/html/openWB/ramdisk/pva1', 'w')
+else:
+	f = open('/var/www/html/openWB/ramdisk/pv' + str(numpv) + 'a1', 'w')
 f.write(str(lla1))
 f.close()
 
 # ampere l2
-resp = client.read_input_registers(0x0009, 2, unit=0x08)
+resp = client.read_input_registers(0x0009, 2, unit=mbid)
 all = format(resp.registers[0], '04x') + format(resp.registers[1], '04x')
 lla2 = float(struct.unpack('>i', all.decode('hex'))[0]) / 10000
-f = open('/var/www/html/openWB/ramdisk/pva2', 'w')
+if numpv == 1:
+	f = open('/var/www/html/openWB/ramdisk/pva2', 'w')
+else:
+	f = open('/var/www/html/openWB/ramdisk/pv' + str(numpv) + 'a2', 'w')
 f.write(str(lla2))
 f.close()
 
 # ampere l3
-resp = client.read_input_registers(0x000b, 2, unit=0x08)
+resp = client.read_input_registers(0x000b, 2, unit=mbid)
 all = format(resp.registers[0], '04x') + format(resp.registers[1], '04x')
 lla3 = float(struct.unpack('>i', all.decode('hex'))[0]) / 10000
-f = open('/var/www/html/openWB/ramdisk/pva3', 'w')
+if numpv == 1:
+	f = open('/var/www/html/openWB/ramdisk/pva3', 'w')
+else:
+	f = open('/var/www/html/openWB/ramdisk/pv' + str(numpv) + 'a3', 'w')
 f.write(str(lla3))
 f.close()

--- a/modules/wr_pvkit/readmpm3pm.py
+++ b/modules/wr_pvkit/readmpm3pm.py
@@ -13,10 +13,10 @@ numpv=1
 
 #Check Argumentlist and replace Defaults if present
 if len(sys.argv) >= 2:
-	numpv=str(sys.argv[1])
+	numpv=int(sys.argv[1])
 
 if len(sys.argv) >= 3:
-	mbip=int(sys.argv[2])
+	mbip=str(sys.argv[2])
 
 if len(sys.argv) >= 4:
 	mbport=int(sys.argv[3])

--- a/modules/wr_pvkit/readmpm3pm.py
+++ b/modules/wr_pvkit/readmpm3pm.py
@@ -1,14 +1,38 @@
 #!/usr/bin/python
-# import sys
+import sys
 # import os
 # import time
 # import getopt
 import struct
 from pymodbus.client.sync import ModbusTcpClient
 
-client = ModbusTcpClient('192.168.193.13', port=8899)
+mbip='192.168.193.13'
+mbport=8899
+mbid=8
+numpv=1
 
-resp = client.read_input_registers(0x0004,4, unit=8)
+#Check Argumentlist and replace Defaults if present
+if len(sys.argv) >= 2:
+	numpv=str(sys.argv[1])
+
+if len(sys.argv) >= 3:
+	mbip=int(sys.argv[2])
+
+if len(sys.argv) >= 4:
+	mbport=int(sys.argv[3])
+
+if len(sys.argv) >= 5:
+	mbid=int(sys.argv[4])
+
+
+#client = ModbusTcpClient('192.168.193.13', port=8899)
+
+client = ModbusTcpClient(mbip,port=mbport)
+#client.host(mbip)
+#client.port(mbport)
+#client.unit_id(mbid)
+
+resp = client.read_input_registers(0x0004,4, unit=mbid)
 value1 = resp.registers[0] 
 value2 = resp.registers[1] 
 all = format(value1, '04x') + format(value2, '04x')
@@ -17,46 +41,67 @@ ikwh = int(struct.unpack('>i', all.decode('hex'))[0])
 # resp = client.read_input_registers(0x0004,2, unit=sdmid)
 # ikwh = resp.registers[1]
 ikwh = float(ikwh) * 10
-f = open('/var/www/html/openWB/ramdisk/pvkwh', 'w')
+if numpv == 1:
+	f = open('/var/www/html/openWB/ramdisk/pvkwh', 'w')
+else:
+	f = open('/var/www/html/openWB/ramdisk/pv' + str(numpv) + 'kwh', 'w')
 f.write(str(ikwh))
 f.close()
 pvkwhk= ikwh / 1000
-f = open('/var/www/html/openWB/ramdisk/pvkwhk', 'w')
+if numpv == 1:
+	f = open('/var/www/html/openWB/ramdisk/pvkwhk', 'w')
+else:
+	f = open('/var/www/html/openWB/ramdisk/pvkwhk', 'w')
 f.write(str(pvkwhk))
 f.close()
 
 ikwhk = float(ikwh) / 1000
-f = open('/var/www/html/openWB/ramdisk/pvkwhk', 'w')
+if numpv == 1:
+	f = open('/var/www/html/openWB/ramdisk/pvkwhk', 'w')
+else:
+	f = open('/var/www/html/openWB/ramdisk/pv' + str(numpv)+ 'kwhk', 'w')
 f.write(str(ikwhk))
 f.close()
 
-resp = client.read_input_registers(0x0E,2, unit=8)
+resp = client.read_input_registers(0x0E,2, unit=mbid)
 lla1 = resp.registers[1]
 lla1 = float(lla1) / 100
-f = open('/var/www/html/openWB/ramdisk/pva1', 'w')
+if numpv == 1:
+	f = open('/var/www/html/openWB/ramdisk/pva1', 'w')
+else:
+	f = open('/var/www/html/openWB/ramdisk/pv' + str(numpv)+ 'a1', 'w')
 f.write(str(lla1))
 f.close()
 
-resp = client.read_input_registers(0x10,2, unit=8)
+resp = client.read_input_registers(0x10,2, unit=mbid)
 lla2 = resp.registers[1]
 lla2 = float(lla2) / 100
-f = open('/var/www/html/openWB/ramdisk/pva2', 'w')
+if numpv == 1:
+	f = open('/var/www/html/openWB/ramdisk/pva2', 'w')
+else:
+	f = open('/var/www/html/openWB/ramdisk/pv' + str(numpv) + 'a2', 'w')
 f.write(str(lla2))
 f.close()
 
-resp = client.read_input_registers(0x12,2, unit=8)
+resp = client.read_input_registers(0x12,2, unit=mbid)
 lla3 = resp.registers[1]
 lla3 = float(lla3) / 100
-f = open('/var/www/html/openWB/ramdisk/pva3', 'w')
+if numpv == 1:
+	f = open('/var/www/html/openWB/ramdisk/pva3', 'w')
+else:
+	f = open('/var/www/html/openWB/ramdisk/pv' + str(numpv)+ 'a3', 'w')
 f.write(str(lla3))
 f.close()
 
 # total watt
-resp = client.read_input_registers(0x26,2, unit=8)
+resp = client.read_input_registers(0x26,2, unit=mbid)
 value1 = resp.registers[0] 
 value2 = resp.registers[1] 
 all = format(value1, '04x') + format(value2, '04x')
 final = int(struct.unpack('>i', all.decode('hex'))[0]) / 100
-f = open('/var/www/html/openWB/ramdisk/pvwatt', 'w')
+if numpv == 1:
+	f = open('/var/www/html/openWB/ramdisk/pvwatt', 'w')
+else:
+	f = open('/var/www/html/openWB/ramdisk/pv' + str(numpv)+ 'watt', 'w')
 f.write(str(final))
 f.close()

--- a/modules/wr_pvkit/readsdm.py
+++ b/modules/wr_pvkit/readsdm.py
@@ -15,10 +15,10 @@ numpv = 1
 
 #Check Argumentlist and replace Defaults if present
 if len(sys.argv) >= 2:
-	numpv=str(sys.argv[1])
+	numpv=int(sys.argv[1])
 
 if len(sys.argv) >= 3:
-	mbip=int(sys.argv[2])
+	mbip=str(sys.argv[2])
 
 if len(sys.argv) >= 4:
 	mbport=int(sys.argv[3])

--- a/modules/wr_pvkit/readsdm.py
+++ b/modules/wr_pvkit/readsdm.py
@@ -27,7 +27,7 @@ if len(sys.argv) >= 5:
         mbid=int(sys.argv[4])
 
 
-client = ModbusTcpClient('192.168.193.13', port=8899)
+#client = ModbusTcpClient('192.168.193.13', port=8899)
 client = ModbusTcpClient(mbip,port=mbport)
 #client.host(mbip)
 #client.port(mbport)

--- a/modules/wr_pvkit/readsdm.py
+++ b/modules/wr_pvkit/readsdm.py
@@ -1,60 +1,100 @@
 #!/usr/bin/python
-# import sys
+import sys
 # import os
 # import time
 # import getopt
 import struct
 from pymodbus.client.sync import ModbusTcpClient
 
+##PV Kit Defaults
+mbip='192.168.193.13'
+mbport=8899
+mbid=116
+numpv = 1
+
+
+#Check Argumentlist and replace Defaults if present
+if len(sys.argv) >= 2:
+	numpv=str(sys.argv[1])
+
+if len(sys.argv) >= 3:
+	mbip=int(sys.argv[2])
+
+if len(sys.argv) >= 4:
+	mbport=int(sys.argv[3])
+
+if len(sys.argv) >= 5:
+        mbid=int(sys.argv[4])
+
+
 client = ModbusTcpClient('192.168.193.13', port=8899)
-sdmid = 116
+client = ModbusTcpClient(mbip,port=mbport)
+#client.host(mbip)
+#client.port(mbport)
+#client.unit_id(mbid)
+
 
 # phasen watt
-resp = client.read_input_registers(0x0C,2, unit=sdmid)
+resp = client.read_input_registers(0x0C,2, unit=mbid)
 llw1 = struct.unpack('>f',struct.pack('>HH',*resp.registers))[0]
 finalw1 = int(llw1)
-resp = client.read_input_registers(0x0E,2, unit=sdmid)
+resp = client.read_input_registers(0x0E,2, unit=mbid)
 llw1 = struct.unpack('>f',struct.pack('>HH',*resp.registers))[0]
 finalw2 = int(llw1)
-resp = client.read_input_registers(0x10,2, unit=sdmid)
+resp = client.read_input_registers(0x10,2, unit=mbid)
 llw1 = struct.unpack('>f',struct.pack('>HH',*resp.registers))[0]
 finalw3 = int(llw1)
 
 finalw= finalw1 + finalw2 + finalw3
 if ( finalw > 10):
-    finalw=finalw*-1
+	finalw=finalw*-1
 
-f = open('/var/www/html/openWB/ramdisk/pvwatt', 'w')
+if numpv == 1:
+	f = open('/var/www/html/openWB/ramdisk/pvwatt', 'w')
+else:
+	f = open('/var/www/html/openWB/ramdisk/pv' + str(numpv) + 'watt', 'w')
 f.write(str(finalw))
 f.close()
 
 # ampere l1
-resp = client.read_input_registers(0x06,2, unit=sdmid)
+resp = client.read_input_registers(0x06,2, unit=mbid)
 lla1 = float(struct.unpack('>f',struct.pack('>HH',*resp.registers))[0])
 lla1 = float("%.1f" % lla1)
-f = open('/var/www/html/openWB/ramdisk/pva1', 'w')
+if numpv == 1:
+	f = open('/var/www/html/openWB/ramdisk/pva1', 'w')
+else:
+	f = open('/var/www/html/openWB/ramdisk/pv' + str(numpv) + 'a1', 'w')
 f.write(str(lla1))
 f.close()
 
 # ampere l2
-resp = client.read_input_registers(0x08,2, unit=sdmid)
+resp = client.read_input_registers(0x08,2, unit=mbid)
 lla1 = float(struct.unpack('>f',struct.pack('>HH',*resp.registers))[0])
 lla2 = float("%.1f" % lla1)
-f = open('/var/www/html/openWB/ramdisk/pva2', 'w')
+if numpv == 1:
+	f = open('/var/www/html/openWB/ramdisk/pva2', 'w')
+else:
+	f = open('/var/www/html/openWB/ramdisk/pv' + str(numpv) + 'a2', 'w')
 f.write(str(lla2))
 f.close()
 
 # ampere l3
-resp = client.read_input_registers(0x0A,2, unit=sdmid)
+resp = client.read_input_registers(0x0A,2, unit=mbid)
 lla1 = float(struct.unpack('>f',struct.pack('>HH',*resp.registers))[0])
 lla3 = float("%.1f" % lla1)
-f = open('/var/www/html/openWB/ramdisk/pva3', 'w')
+if numpv == 1:
+	f = open('/var/www/html/openWB/ramdisk/pva3', 'w')
+else:
+	f = open('/var/www/html/openWB/ramdisk/pv' + str(numpv)+ 'a3', 'w')
 f.write(str(lla3))
 f.close()
 
-resp = client.read_input_registers(0x0156,2, unit=sdmid)
+resp = client.read_input_registers(0x0156,2, unit=mbid)
 pvkwh = struct.unpack('>f',struct.pack('>HH',*resp.registers))[0]
-pvkwh = float("%.3f" % pvkwh) * 1000
-f = open('/var/www/html/openWB/ramdisk/pvkwh', 'w')
+pvkwh = float("%.3f" % pvkwh) / 1000
+if numpv == 1:
+	f = open('/var/www/html/openWB/ramdisk/pvkwh', 'w')
+else:
+	f = open('/var/www/html/openWB/ramdisk/pv' + str(numpv) + 'kwh', 'w')
 f.write(str(pvkwh))
 f.close()


### PR DESCRIPTION
Anpassung der PV-Kit Module. Die Module können jetzt Parameter für PV (1/2), IP, Port und Unit_id übernehmen.
Ohne Parameter werden die bisherigen Defaults verwendet.
Es können 1-4 Parameter übergeben werden

1. PV (1 oder 2)
2. IP
3. Port
4. UNIT_ID

In dieser Reihenfolge sind die Parameter auch beim Aufruf zu übergeben, um die entsprechende Variable im Programm zu überschreiben.

Da es sich hierbei auch um Standard Module der openWB handelt (PV-Kit), bitte gut testen. ein erster erfolgreicher Test des SDM630 Moduls duch einen User im Forum ist bereits erfolgt.

Ziel ist es, SDM630, Lovato, mpm3pm hinter einem Elfin/Protos ModbusTCP Gateway mit eigendefinierter IP/Port/unit_id zu betreiben, ohne eine weitere Kopie des immer gleichen Sourcecodes zu machen.

@benderl: bitte auch testen (lassen).