### PR TITLE
Systeminfo per MQTT

### DIFF
--- a/runs/pubmqtt.sh
+++ b/runs/pubmqtt.sh
@@ -289,6 +289,7 @@ for mq in "${!mqttvar[@]}"; do
 done
 
 sysinfo=$(cd web/tools; sudo php programmloggerinfo.php 2>/dev/null)
+tempPubList="${tempPubList}\nopenWB/global/cpuModel=$(cat /proc/cpuinfo | grep -m 1 "model name" | sed "s/^.*: //")"
 tempPubList="${tempPubList}\nopenWB/global/cpuUse=$(echo ${sysinfo} | jq -r '.cpuuse')"
 tempPubList="${tempPubList}\nopenWB/global/cpuTemp=$(echo "scale=2; $(echo ${sysinfo} | jq -r '.cputemp') / 1000" | bc)"
 tempPubList="${tempPubList}\nopenWB/global/cpuFreq=$(($(echo ${sysinfo} | jq -r '.cpufreq') / 1000))"

--- a/runs/pubmqtt.sh
+++ b/runs/pubmqtt.sh
@@ -288,7 +288,7 @@ for mq in "${!mqttvar[@]}"; do
 	fi
 done
 
-sysinfo=$(php web/tools/programmloggerinfo.php 2>/dev/null)
+sysinfo=$(cd web/tools; sudo php programmloggerinfo.php 2>/dev/null)
 tempPubList="${tempPubList}\nopenWB/global/cpuUse=$(echo ${sysinfo} | jq -r '.cpuuse')"
 tempPubList="${tempPubList}\nopenWB/global/cpuTemp=$(echo "scale=2; $(echo ${sysinfo} | jq -r '.cputemp') / 1000" | bc)"
 tempPubList="${tempPubList}\nopenWB/global/cpuFreq=$(($(echo ${sysinfo} | jq -r '.cpufreq') / 1000))"

--- a/runs/pubmqtt.sh
+++ b/runs/pubmqtt.sh
@@ -288,7 +288,15 @@ for mq in "${!mqttvar[@]}"; do
 	fi
 done
 
-tempPubList="${tempPubList}\nopenWB/global/cpuTemp=$(echo "scale=2; `cat /sys/class/thermal/thermal_zone0/temp` / 1000" | bc)"
+sysinfo=$(php web/tools/programmloggerinfo.php 2>/dev/null)
+tempPubList="${tempPubList}\nopenWB/global/cpuUse=$(echo ${sysinfo} | jq -r '.cpuuse')"
+tempPubList="${tempPubList}\nopenWB/global/cpuTemp=$(echo "scale=2; $(echo ${sysinfo} | jq -r '.cputemp') / 1000" | bc)"
+tempPubList="${tempPubList}\nopenWB/global/cpuFreq=$(($(echo ${sysinfo} | jq -r '.cpufreq') / 1000))"
+tempPubList="${tempPubList}\nopenWB/global/memTotal=$(echo ${sysinfo} | jq -r '.memtot')"
+tempPubList="${tempPubList}\nopenWB/global/memUse=$(echo ${sysinfo} | jq -r '.memuse')"
+tempPubList="${tempPubList}\nopenWB/global/memFree=$(echo ${sysinfo} | jq -r '.memfree')"
+tempPubList="${tempPubList}\nopenWB/global/diskUse=$(echo ${sysinfo} | jq -r '.diskuse')"
+tempPubList="${tempPubList}\nopenWB/global/diskFree=$(echo ${sysinfo} | jq -r '.diskfree')"
 
 #echo "Publist:"
 #echo -e $tempPubList


### PR DESCRIPTION
Es geht um die Bereitstellung der Systemdaten per MQTT. Die Daten selber sind dabei identisch zum UI unter Einstellungen / System / System-Info.

Bisher wurden ähnliche Daten bereits unter verschiedene Pfaden veröffentlicht:
- openWB/system/Date
- openWB/system/IpAddress
- openWB/system/Uptime
- openWB/global/cpuTemp

Unter openwb/global werden die Informationen zur CPU, Speicher und SD-Karte ergänzt.
- openWB/global/cpuFreq
- openWB/global/cpuModel
- openWB/global/cpuUse
- openWB/global/memFree
- openWB/global/memTotal
- openWB/global/memUse
- openWB/global/diskFree
- openWB/global/diskUse