### PR TITLE
BMW has renamed JSON field "chargingSystemStatus"

### DIFF
--- a/modules/soc_i3/index.php
+++ b/modules/soc_i3/index.php
@@ -14,7 +14,7 @@ class Battery_API {
 	private $auth;
 	private $token;
 	private $json;
-	
+
 	function __construct ( $chargepoint, $user, $password, $vin ) {
 
 		$this->auth = array(
@@ -43,7 +43,7 @@ class Battery_API {
 		);
 	}
 
-	
+
 	function get_cached_token() {
 		return json_decode(
 			@file_get_contents(
@@ -173,8 +173,8 @@ class Battery_API {
 		$updateTime = date( 'd.m.Y H:i', $updateTimestamp );
 		$electricRange = intval( $attributes->beRemainingRangeElectricKm );
 		$chargingLevel = intval( $attributes->chargingLevelHv );
-		$chargingActive = intval( $attributes->chargingSystemStatus === 'CHARGINGACTIVE' );
-		$chargingError = intval( $attributes->chargingSystemStatus === 'CHARGINGERROR' );
+		$chargingActive = intval( $attributes->charging_status === 'CHARGINGACTIVE' );
+		$chargingError = intval( $attributes->charging_status === 'CHARGINGERROR' );
 		//$chargingTimeRemaining = intval( $attributes->chargingTimeRemaining );
 		//$chargingTimeRemaining = ( $chargingTimeRemaining ? ( date( 'H:i', mktime( 0, $chargingTimeRemaining ) ) ) : '0:00' );
 


### PR DESCRIPTION
It seems the new name is "charging_status". Without the change query for SoC still works but reports
```
PHP Notice:  Undefined property: stdClass::$chargingSystemStatus in /var/www/html/openWB/modules/soc_i3/index.php on line 176
PHP Notice:  Undefined property: stdClass::$chargingSystemStatus in /var/www/html/openWB/modules/soc_i3/index.php on line 177
```
every time.

**Additional notice:**  
BMW is using a LetsEncrypt certificate for its server(s). Due to expiry of cross-signing certificate, an "apt update && apt upgrade -y" was necessary to get trust for the new LetsEncrypt root CA !

@snaptec How will this be handled for openWBs without root access? I don't think any update UI feature is available for OS updates yet.

Separate issue https://github.com/snaptec/openWB/issues/1595 has been created for the root CA update.