### PR TITLE
Bezug Powerwall fix

### DIFF
--- a/modules/bezug_powerwall/main.sh
+++ b/modules/bezug_powerwall/main.sh
@@ -16,7 +16,7 @@ else
     MYLOGFILE="$RAMDISKDIR/evu_json.log"
 fi
 
-sudo python3 /var/www/html/openWB/modules/bezug_powerwall/powerwall.py "${OPENWBBASEDIR}" "${speicherpwloginneeded}" "${speicherpwuser}" "${speicherpwpass}" "${speicherpwip}" >>$MYLOGFILE 2>&1
+python3 /var/www/html/openWB/modules/bezug_powerwall/powerwall.py "${OPENWBBASEDIR}" "${speicherpwloginneeded}" "${speicherpwuser}" "${speicherpwpass}" "${speicherpwip}" >>$MYLOGFILE 2>&1
 ret=$?
 
 openwbDebugLog ${DMOD} 2 "RET: ${ret}"


### PR DESCRIPTION
sudo entfernt

2021-10-01 17:23:56: RET: 1 (LV2) at 22 main modules/bezug_powerwall/main.sh
TypeError: int() argument must be a string, a bytes-like object or a number, not 'NoneType'
Debug = int(os.environ.get('debug'))
File "/var/www/html/openWB/modules/bezug_powerwall/powerwall.py", line 11, in <module>
Traceback (most recent call last):

https://openwb.de/forum/viewtopic.php?p=46739#p46739