### PR TITLE
Improve error logging if EVNotify SoC cannot be retrieved

### DIFF
--- a/modules/soc_evnotify/evnotify.py
+++ b/modules/soc_evnotify/evnotify.py
@@ -1,0 +1,60 @@
+import sys
+from datetime import datetime
+import requests
+
+RAMDISK_PATH = "/var/www/html/openWB/ramdisk/"
+debuglevel = 2
+
+
+def log(level: int, msg: str):
+    if debuglevel >= level:
+        with open(RAMDISK_PATH + "soc.log", "a") as fd:
+            fd.write("%s: EVNotify: %s\n" % (datetime.now().strftime("%Y-%m-%d %H:%M:%S"), msg))
+
+
+def write_to_ramdisk_file(filename: str, content: str):
+    with open(RAMDISK_PATH + filename, 'w') as f:
+        f.write(content)
+        f.write("\n")
+
+
+def write_float_to_ramdisk_file(filename: str, content: float):
+    write_to_ramdisk_file(filename, str(round(content)))
+
+
+def load_evnotify_soc(akey: str, token: str):
+    response = requests.get("https://app.evnotify.de/soc", params={"akey": akey, "token": token})
+    response.raise_for_status()
+    json = response.json()
+    if "soc_display" in json and isinstance(json["soc_display"], (int, float)):
+        return json["soc_display"]
+    raise Exception("Expected response with number property soc_display. Got: " + response.text)
+
+
+def chargepoint_number_to_string(chargepoint: str):
+    if chargepoint == "1":
+        return ""
+    else:
+        return chargepoint
+
+
+def refresh_soc(akey: str, token: str, chargepoint: str):
+    try:
+        soc = load_evnotify_soc(akey, token)
+    except Exception as e:
+        log(0, "Lp%s: Failed to retrieve SoC: %s" % (chargepoint, e))
+        return
+
+    log(1, "Lp%s: SoC from Server: %d" % (chargepoint, soc))
+    if soc >= 100:
+        write_float_to_ramdisk_file("soc" + chargepoint_number_to_string(chargepoint), soc)
+    else:
+        log(0, "Lp%s: SoC=%f is invalid!" % (chargepoint, soc))
+
+
+if __name__ == '__main__':
+    debuglevelArg = sys.argv[4]
+    if debuglevelArg.isdigit():
+        debuglevel = int(debuglevelArg)
+
+    refresh_soc(sys.argv[1], sys.argv[2], sys.argv[3])

--- a/modules/soc_evnotify/main.sh
+++ b/modules/soc_evnotify/main.sh
@@ -1,4 +1,5 @@
 #!/bin/bash
+SCRIPT_DIR=$(cd $(dirname "${BASH_SOURCE[0]}") && pwd)
 OPENWBBASEDIR=$(cd `dirname $0`/../../ && pwd)
 RAMDISKDIR="$OPENWBBASEDIR/ramdisk"
 MODULEDIR=$(cd `dirname $0` && pwd)
@@ -65,15 +66,5 @@ if (( soctimer < 4 )); then
 else
 	openwbDebugLog ${DMOD} 1 "Lp$CHARGEPOINT: Requesting SoC"
 	echo 0 > $soctimerfile
-	answer=$(curl -s -X GET 'https://app.evnotify.de/soc?akey='$akey'&token='$token)
-	# extract the soc value
-	soc=$(echo $answer | jq .soc_display)
-	openwbDebugLog ${DMOD} 1 "Lp$CHARGEPOINT: SoC from Server: $soc"
-	# parse to int to be able to check in condition - to determine if valid or not
-	isvalid=$(echo $soc | cut -d "." -f 1 | cut -d "," -f 1)
-	if (( isvalid >= 0 && isvalid != null)); then
-		echo $isvalid > $socfile
-	else
-		openwbDebugLog ${DMOD} 0 "Lp$CHARGEPOINT: SoC is invalid!"
-	fi
+	python "$SCRIPT_DIR/evnotify.py" "$akey" "$token" "$CHARGEPOINT" "$DEBUGLEVEL"
 fi


### PR DESCRIPTION
It looks like in the moment EVNotify integration with openWB [is broken](https://openwb.de/forum/viewtopic.php?f=9&t=4107). I have no idea why. I check the source code and if I try to imitate what it is doing locally it works fine.

However the current implementation does not give good log messages. Like what is the actual response from EVNotify? Was there maybe a non 2xx response?

This PR does not fix the underlying problem, but improves error logging if something is wrong. Hopefully it helps to identify the problem linked and other similar problems in the future.

Note that I only tested the code isolated in my stubbed development environment. It still needs to be tested on an actual system.