### PR TITLE
fix: call python3 instead of python and log error if call fails

### DIFF
--- a/modules/soc_evnotify/main.sh
+++ b/modules/soc_evnotify/main.sh
@@ -66,5 +66,7 @@ if (( soctimer < 4 )); then
 else
 	openwbDebugLog ${DMOD} 1 "Lp$CHARGEPOINT: Requesting SoC"
 	echo 0 > $soctimerfile
-	python "$SCRIPT_DIR/evnotify.py" "$akey" "$token" "$CHARGEPOINT" "$DEBUGLEVEL"
+	pythonOut=$(python3 "$SCRIPT_DIR/evnotify.py" "$akey" "$token" "$CHARGEPOINT" "$DEBUGLEVEL" 2>&1)
+	exitCode=$?
+	[ $exitCode -eq 0 ] || openwbDebugLog ${DMOD} 0 "Lp$CHARGEPOINT: Calling python failed ($exitCode): $pythonOut"
 fi


### PR DESCRIPTION
My previous PR #1602 does not work. Nothing is logged. I suspect that maybe on openWB `python` links to `python2`. However my script needs `python3`. At least I found that many other script explicitly call `python3`.

This PR changes that to also call `python3`. At the same time I also improved error logging further: In case the python-call fails, an error is logged as well.