### PR TITLE
create python library with logger and config

### DIFF
--- a/lib/openwb/config.py
+++ b/lib/openwb/config.py
@@ -1,0 +1,33 @@
+from os.path import dirname, realpath, join
+
+OPENWB_ROOT = dirname(dirname(dirname(realpath(__file__))))
+"""Contains the root directory of openWB without trailing slash (usually /var/www/html/openWB)"""
+RAMDISK_PATH = join(OPENWB_ROOT, "ramdisk")
+"""Contains the path to the ramdisk without trailing slash (usually /var/www/html/openWB/ramdisk)"""
+
+
+class Config:
+    """A utility class to access the openWB configuration.
+
+    To use:
+
+    >>> config = Config()
+    >>> config["maximalstromstaerke"]
+    '32'
+
+    `Config()` returns a singleton, so the config file will be read only once, even if calling `Config()` multiple times
+    """
+    __instance = None
+
+    class __Config:
+        def __init__(self):
+            with open(join(OPENWB_ROOT, "openwb.conf"), "r") as f:
+                self.__values = dict(tuple(line.rstrip().split("=", 1)) for line in f)
+
+        def __getitem__(self, item: str) -> str:
+            return self.__values[item]
+
+    def __new__(cls):
+        if Config.__instance is None:
+            Config.__instance = Config.__Config()
+        return Config.__instance

--- a/lib/openwb/logger.py
+++ b/lib/openwb/logger.py
@@ -1,0 +1,50 @@
+import enum
+from datetime import datetime
+from enum import Enum, IntEnum
+from os.path import join
+
+from .config import Config, RAMDISK_PATH
+
+
+class LogFile(Enum):
+    MAIN = "/var/log/openWB.log"
+    EVSOC = join(RAMDISK_PATH, "soc.log")
+    PV = join(RAMDISK_PATH, "nurpv.log")
+    MQTT = join(RAMDISK_PATH, "mqtt.log")
+    RFID = join(RAMDISK_PATH, "rfid.log")
+    SMARTHOME = join(RAMDISK_PATH, "smarthome.log")
+    CHARGESTAT = join(RAMDISK_PATH, "ladestatus.log")
+
+
+@enum.unique
+class LogLevel(IntEnum):
+    INFO = 0
+    DEBUG = 1
+    TRACE = 2
+
+
+class Logger:
+    def __init__(self, log_file: LogFile = LogFile.MAIN, module: str = None, log_level: LogLevel = None):
+        if log_level is None:
+            try:
+                self.logLevel = LogLevel(int(Config()["debug"]))
+            except:
+                self.logLevel = LogLevel.TRACE
+        else:
+            self.logLevel = log_level
+        self.logFile = log_file
+        self.module = "" if str is None else f"{module}: "
+
+    def log(self, level: LogLevel, message: str):
+        if level <= self.logLevel:
+            with open(self.logFile.value, "a") as fd:
+                fd.write(f"{datetime.now().strftime('%Y-%m-%d %H:%M:%S')}: {self.module}{message}\n")
+
+    def info(self, message: str):
+        self.log(LogLevel.INFO, message)
+
+    def debug(self, message: str):
+        self.log(LogLevel.DEBUG, message)
+
+    def trace(self, message: str):
+        self.log(LogLevel.TRACE, message)

--- a/modules/soc_evnotify/main.sh
+++ b/modules/soc_evnotify/main.sh
@@ -66,7 +66,7 @@ if (( soctimer < 4 )); then
 else
 	openwbDebugLog ${DMOD} 1 "Lp$CHARGEPOINT: Requesting SoC"
 	echo 0 > $soctimerfile
-	pythonOut=$(python3 "$SCRIPT_DIR/evnotify.py" "$akey" "$token" "$CHARGEPOINT" "$DEBUGLEVEL" 2>&1)
+	pythonOut=$(python3 "$SCRIPT_DIR/evnotify.py" "$CHARGEPOINT" 2>&1)
 	exitCode=$?
 	[ $exitCode -eq 0 ] || openwbDebugLog ${DMOD} 0 "Lp$CHARGEPOINT: Calling python failed ($exitCode): $pythonOut"
 fi


### PR DESCRIPTION
There are a few things that are shared across a big number of scripts. I propose to create a shared library in order to de-duplicate code and encourage common patterns (e.g. for log outputs a common date/time format). (Similar to the `helperFunctions.sh`, but for python and not for bash).

One such thing shared across a lot of code is logging. Thus I started by creating a `Logger` that could be used application wide in all scripts. For starters I am using the library in the EVNotify SoC-Module.