### PR TITLE
Erneute Anpassung max Preis für preisbasiertes Laden

### DIFF
--- a/web/themes/EvenDarker/theme.html
+++ b/web/themes/EvenDarker/theme.html
@@ -649,7 +649,7 @@
 				<div class="form-row form-group mb-1 vaRow regularTextSize">
 					<label for="MaxPriceForCharging" class="col-3 col-form-label text-right">max. Preis:</label>
 					<div class="col">
-						<input type="range" class="form-control-range rangeInput" id="MaxPriceForCharging" min="-25" max="50" step="0.1" value="0" data-topicprefix="openWB/global/awattar/">
+						<input type="range" class="form-control-range rangeInput" id="MaxPriceForCharging" min="-25" max="95" step="0.1" value="0" data-topicprefix="openWB/global/awattar/">
 					</div>
 					<label for="MaxPriceForCharging" class="col-3 col-form-label valueLabel" suffix="ct/kWh"></label>
 				</div>

--- a/web/themes/Gauges/theme.html
+++ b/web/themes/Gauges/theme.html
@@ -670,7 +670,7 @@
 				<div class="form-row form-group mb-1 vaRow regularTextSize">
 					<label for="MaxPriceForCharging" class="col-3 col-form-label text-right">max. Preis:</label>
 					<div class="col">
-						<input type="range" class="form-control-range rangeInput" id="MaxPriceForCharging" min="-25" max="50" step="0.1" value="0" data-topicprefix="openWB/global/awattar/">
+						<input type="range" class="form-control-range rangeInput" id="MaxPriceForCharging" min="-25" max="95" step="0.1" value="0" data-topicprefix="openWB/global/awattar/">
 					</div>
 					<label for="MaxPriceForCharging" class="col-3 col-form-label valueLabel" suffix="ct/kWh"></label>
 				</div>

--- a/web/themes/colors/theme.html
+++ b/web/themes/colors/theme.html
@@ -273,7 +273,7 @@
 							<div class="form-row form-group mb-1 vaRow regularTextSize">
 								<label for="MaxPriceForCharging" class="col-3 col-form-label text-right">max. Preis:</label>
 								<div class="col">
-									<input type="range" class="form-control-range rangeInput" id="MaxPriceForCharging" min="-25" max="50"
+									<input type="range" class="form-control-range rangeInput" id="MaxPriceForCharging" min="-25" max="95"
 										step="0.1" value="0" data-topicprefix="openWB/global/awattar/">
 								</div>
 								<label for="MaxPriceForCharging" class="col-3 col-form-label valueLabel" suffix="ct/kWh"></label>

--- a/web/themes/dark/theme.html
+++ b/web/themes/dark/theme.html
@@ -646,7 +646,7 @@
 				<div class="form-row form-group mb-1 vaRow regularTextSize">
 					<label for="MaxPriceForCharging" class="col-3 col-form-label text-right">max. Preis:</label>
 					<div class="col">
-						<input type="range" class="form-control-range rangeInput" id="MaxPriceForCharging" min="-25" max="50" step="0.1" value="0" data-topicprefix="openWB/global/awattar/">
+						<input type="range" class="form-control-range rangeInput" id="MaxPriceForCharging" min="-25" max="95" step="0.1" value="0" data-topicprefix="openWB/global/awattar/">
 					</div>
 					<label for="MaxPriceForCharging" class="col-3 col-form-label valueLabel" suffix="ct/kWh"></label>
 				</div>


### PR DESCRIPTION
Aufgrund der extrem teuren Strompreise wurde die obere Grenze des Sliders erneut angehoben.