### PR TITLE
[Kia/Hyundai] - Parameter Anpassung

### DIFF
--- a/web/settings/modulconfiglp.php
+++ b/web/settings/modulconfiglp.php
@@ -1029,9 +1029,9 @@
 										<div class="form-row mb-1">
 											<label for="kia_adv_cachevalid" class="col-md-4 col-form-label">Cache G&uuml;ltigkeit</label>
 											<div class="col">
-												<input class="form-control" type="number" min="0" step="1" name="kia_adv_cachevalid" id="kia_adv_cachevalid" value="<?php echo $kia_adv_cachevalidold ?>">
+												<input class="form-control" type="number" min="-15" step="1" name="kia_adv_cachevalid" id="kia_adv_cachevalid" value="<?php echo $kia_adv_cachevalidold ?>">
 												<span class="form-text small">
-													Gültigkeitsdauer des letzten Status in Minuten, z.B. nach Abstellen des Autos oder Abruf in der App (0=Abruf immer vom Auto; Default: 10)<br>
+													Gültigkeitsdauer des letzten Status in Minuten, z.B. nach Abstellen des Autos oder Abruf in der App (0: Abruf immer vom Auto; Default: 10)<br>
 												</span>
 											</div>
 										</div>
@@ -3827,7 +3827,7 @@
 										<div class="form-row mb-1">
 											<label for="kia_adv_cachevalid2" class="col-md-4 col-form-label">Cache G&uuml;ltigkeit</label>
 											<div class="col">
-												<input class="form-control" type="number" min="0" step="1" name="kia_adv_cachevalid2" id="kia_adv_cachevalid2" value="<?php echo $kia_adv_cachevalid2old ?>">
+												<input class="form-control" type="number" min="-15" step="1" name="kia_adv_cachevalid2" id="kia_adv_cachevalid2" value="<?php echo $kia_adv_cachevalid2old ?>">
 												<span class="form-text small">
 													Gültigkeitsdauer des letzten Status in Minuten, z.B. nach Abstellen des Autos oder Abruf in der App (0=Abruf immer vom Auto; Default: 10)<br>
 												</span>


### PR DESCRIPTION
Cache-Gültigkeit kann jetzt negativ gesetzt werden, um Abruf vom Auto auch bei fehlerhaften Antworten zu erzwingen