### PR TITLE
Check for RFID Tag on Go-e Charger also if it is second or third LP

### DIFF
--- a/modules/goelp2/main.sh
+++ b/modules/goelp2/main.sh
@@ -41,6 +41,12 @@ if [[ $? == "0" ]] ; then
 	if [[ $llkwh =~ $rekwh ]] ; then
 		echo $llkwh > /var/www/html/openWB/ramdisk/llkwhs1
 	fi
+	rfid=$(echo $output | jq -r '.uby')
+	oldrfid=$(</var/www/html/openWB/ramdisk/tmpgoelp2rfid)
+	if [[ $rfid != $oldrfid ]] ; then
+		echo $rfid > /var/www/html/openWB/ramdisk/readtag
+		echo $rfid > /var/www/html/openWB/ramdisk/tmpgoelp2rfid
+	fi
 	#car status 1 Ladestation bereit, kein Auto
 	#car status 2 Auto lädt
 	#car status 3 Warte auf Fahrzeug

--- a/modules/goelp3/main.sh
+++ b/modules/goelp3/main.sh
@@ -41,6 +41,12 @@ if [[ $? == "0" ]] ; then
 	if [[ $llkwh =~ $rekwh ]] ; then
 		echo $llkwh > /var/www/html/openWB/ramdisk/llkwhs2
 	fi
+	rfid=$(echo $output | jq -r '.uby')
+	oldrfid=$(</var/www/html/openWB/ramdisk/tmpgoelp3rfid)
+	if [[ $rfid != $oldrfid ]] ; then
+		echo $rfid > /var/www/html/openWB/ramdisk/readtag
+		echo $rfid > /var/www/html/openWB/ramdisk/tmpgoelp3rfid
+	fi
 	#car status 1 Ladestation bereit, kein Auto
 	#car status 2 Auto lädt
 	#car status 3 Warte auf Fahrzeug


### PR DESCRIPTION
Im Moment werden RFID Tags die an einem go-e Charger eingelesen werden nur verwendet, wenn es sich hierbei um den ersten Ladepunkt handelt.
Um den bzw. die Tag(s) auch einzulesen falls der oder die go-e Charger LP2 oder LP3 sind ist eine Anpassung der main.sh Dateien im jeweiligen modules Verzeichnis analog zum goelp1 notwendig.
Diese wurden mit diesem Request implementiert.
Getestet auf meiner openWB als LP1 sowie einem goe-Charger als LP2