### PR TITLE
enable all python scripts to import from the "package"-directory without fiddling with sys.path individually

### DIFF
--- a/helperFunctions.sh
+++ b/helperFunctions.sh
@@ -101,4 +101,8 @@ openwbDebugLog() {
 	fi
 }
 
+# Enable all python scripts to import from the "package"-directory without fiddling with sys.path individually
+SCRIPT_DIR=$(cd $(dirname "${BASH_SOURCE[0]}") && pwd)
+export PYTHONPATH="$SCRIPT_DIR/packages"
+
 export -f openwbDebugLog


### PR DESCRIPTION
Currently the script in the "modules"-directory cannot use any of the useful shared libraries in the "packages"-directory without hassle. E.g. it would be useful for modules to use the new logging library by writing
```python
from helpermodules import log

log.MainLogger().debug("here is my debug message")
```
currently this is only possible by inserting the "packages"-directory to `sys.path` first. It would be easier if that would be the default.

This PR will add the packages path to `PYTHONPATH` in the helperFunctions.sh. Since that file is always sourced (so far as I can tell) that would make the modules in the "packages"-directory available globally without the need to fiddle with `sys.path` in any individual file that wants to use it.