### PR TITLE
fix powerwall typo

### DIFF
--- a/modules/bezug_powerwall/powerwall.py
+++ b/modules/bezug_powerwall/powerwall.py
@@ -58,7 +58,7 @@ if speicherpwloginneeded == 1:
         edited = os.stat(cookie_file).st_mtime
         now = time.time()
         edit_diff = now - edited
-        if edit_diff < 3600:
+        if edit_diff > 3600:
             DebugLog("Deleting saved login cookie after 1 hour as it may not be valid anymore.")
             os.remove(cookie_file)
     if os.path.isfile(cookie_file) == False:


### PR DESCRIPTION
cookie file was always deleted due to false comparison of time diff