### PR TITLE
Refactor SolarEdge: Clean-up code

### DIFF
--- a/modules/wr_solaredge/main.sh
+++ b/modules/wr_solaredge/main.sh
@@ -1,4 +1,6 @@
 #!/bin/bash
+OPENWBBASEDIR=$(cd `dirname $0`/../../ && pwd)
+RAMDISKDIR="${OPENWBBASEDIR}/ramdisk"
 
 Solaredgebatwr="0"
 if [[ $solaredgespeicherip == $solaredgepvip ]]  ; then
@@ -7,8 +9,7 @@ fi
 if [[ $solaredgewr2ip != "none" ]]; then
 	python /var/www/html/openWB/modules/wr_solaredge/solaredge2wr.py $solaredgepvip $solaredgepvslave1 $Solaredgebatwr $solaredgewr2ip $wr1extprod
 else
-	python /var/www/html/openWB/modules/wr_solaredge/solaredgeall.py $solaredgepvip $solaredgepvslave1 $solaredgepvslave2 $solaredgepvslave3 $solaredgepvslave4 $Solaredgebatwr $wr1extprod $solaredgezweiterspeicher $solaredgesubbat
+	python3 /var/www/html/openWB/modules/wr_solaredge/solaredgeall.py $solaredgepvip $solaredgepvslave1 $solaredgepvslave2 $solaredgepvslave3 $solaredgepvslave4 $Solaredgebatwr $wr1extprod $solaredgezweiterspeicher $solaredgesubbat >> "${RAMDISKDIR}/openWB.log" 2>&1
 fi
 
-pvwatt=$(</var/www/html/openWB/ramdisk/pvwatt)
-echo $pvwatt
+cat /var/www/html/openWB/ramdisk/pvwatt

--- a/modules/wr_solaredge/solaredgeall.py
+++ b/modules/wr_solaredge/solaredgeall.py
@@ -1,50 +1,75 @@
 #!/usr/bin/env python3
 import math
-import sys
 from statistics import mean
+from typing import List
 
+from helpermodules.cli import run_using_positional_cli_args
 from modules.common.component_state import InverterState, BatState
 from modules.common.modbus import ModbusClient, ModbusDataType
 from modules.common.store import get_inverter_value_store, get_bat_value_store
 
 # Sunspec (API) documentation: https://www.solaredge.com/sites/default/files/sunspec-implementation-technical-note.pdf
 
-ipaddress = str(sys.argv[1])
-slave_ids = list(map(int, filter(lambda id: id.isnumeric(), sys.argv[2:6])))
-batwrsame = int(sys.argv[6])
-extprodakt = int(sys.argv[7])
-zweiterspeicher = int(sys.argv[8])
-subbat = int(sys.argv[9])
 
-client = ModbusClient(ipaddress)
+def update_solar_edge(client: ModbusClient,
+                      slave_ids: List[int],
+                      batwrsame: int,
+                      extprodakt: int,
+                      zweiterspeicher: int,
+                      subbat: int):
+    storage_slave_ids = slave_ids[0: 1 + zweiterspeicher]
+    storage_powers = []
+    if batwrsame == 1:
+        soc = mean(
+            client.read_holding_registers(62852, ModbusDataType.FLOAT_32, unit=slave_id) for slave_id in
+            storage_slave_ids
+        )
+        storage_powers = [
+            client.read_holding_registers(62836, ModbusDataType.FLOAT_32, unit=slave_id) for slave_id in
+            storage_slave_ids
+        ]
+        get_bat_value_store(1).set(BatState(power=sum(storage_powers), soc=soc))
 
-storage_slave_ids = slave_ids[0: 1 + zweiterspeicher]
-storage_powers = []
-if batwrsame == 1:
-    soc = mean(
-        client.read_holding_registers(62852, ModbusDataType.FLOAT_32, unit=slave_id) for slave_id in storage_slave_ids
-    )
-    storage_powers = [
-        client.read_holding_registers(62836, ModbusDataType.FLOAT_32, unit=slave_id) for slave_id in storage_slave_ids
-    ]
-    get_bat_value_store(1).set(BatState(power=sum(storage_powers), soc=soc))
+    total_energy = 0
+    total_power = 0
 
-total_energy = 0
-total_power = 0
+    for slave_id in slave_ids:
+        # 40083 = AC Power value (Watt), 40084 = AC Power scale factor
+        power_base, power_scale = client.read_holding_registers(40083, [ModbusDataType.INT_16] * 2, unit=slave_id)
+        total_power -= power_base * math.pow(10, power_scale)
+        # 40093 = AC Lifetime Energy production (Watt hours)
+        total_energy += client.read_holding_registers(40093, ModbusDataType.INT_32, unit=slave_id)
 
-for slave_id in slave_ids:
-    # 40083 = AC Power value (Watt), 40084 = AC Power scale factor
-    power_base, power_scale = client.read_holding_registers(40083, [ModbusDataType.INT_16] * 2, unit=slave_id)
-    total_power -= power_base * math.pow(10, power_scale)
-    # 40093 = AC Lifetime Energy production (Watt hours)
-    total_energy += client.read_holding_registers(40093, ModbusDataType.INT_32, unit=slave_id)
+    if extprodakt == 1:
+        # 40380 = "Meter 2/Total Real Power (sum of active phases)" (Watt)
+        total_power -= client.read_holding_registers(40380, ModbusDataType.INT_16, unit=slave_ids[0])
+    if subbat == 1:
+        total_power -= sum(min(p, 0) for p in storage_powers)
+    else:
+        total_power -= sum(storage_powers)
 
-if extprodakt == 1:
-    # 40380 = "Meter 2/Total Real Power (sum of active phases)" (Watt)
-    total_power -= client.read_holding_registers(40380, ModbusDataType.INT_16, unit=slave_ids[0])
-if subbat == 1:
-    total_power -= sum(min(p, 0) for p in storage_powers)
-else:
-    total_power -= sum(storage_powers)
+    get_inverter_value_store(1).set(InverterState(counter=total_energy, power=total_power))
 
-get_inverter_value_store(1).set(InverterState(counter=total_energy, power=total_power))
+
+def update_solar_edge_cli(ipaddress: str,
+                          slave_id0: str,
+                          slave_id1: str,
+                          slave_id2: str,
+                          slave_id3: str,
+                          batwrsame: int,
+                          extprodakt: int,
+                          zweiterspeicher: int,
+                          subbat: int):
+    with ModbusClient(ipaddress) as client:
+        update_solar_edge(
+            client,
+            list(map(int, filter(lambda id: id.isnumeric(), [slave_id0, slave_id1, slave_id2, slave_id3]))),
+            batwrsame,
+            extprodakt,
+            zweiterspeicher,
+            subbat
+        )
+
+
+if __name__ == '__main__':
+    run_using_positional_cli_args(update_solar_edge_cli)

--- a/modules/wr_solaredge/solaredgeall.py
+++ b/modules/wr_solaredge/solaredgeall.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python3
 import sys
 # import os
 # import time

--- a/modules/wr_solaredge/solaredgeall.py
+++ b/modules/wr_solaredge/solaredgeall.py
@@ -6,24 +6,8 @@ from modules.common.modbus import ModbusClient, ModbusDataType
 
 # Sunspec (API) documentation: https://www.solaredge.com/sites/default/files/sunspec-implementation-technical-note.pdf
 
-
 ipaddress = str(sys.argv[1])
-try:
-    slave1id = int(sys.argv[2])
-except:
-    slave1id=0
-try:
-    slave2id = int(sys.argv[3])
-except:
-    slave2id=0
-try:
-    slave3id = int(sys.argv[4])
-except:
-    slave3id=0
-try:
-    slave4id = int(sys.argv[5])
-except:
-    slave4id=0
+slave_ids = list(map(int, filter(lambda id: id.isnumeric(), sys.argv[2:6])))
 batwrsame = int(sys.argv[6])
 extprodakt = int(sys.argv[7])
 zweiterspeicher = int(sys.argv[8])
@@ -37,10 +21,10 @@ client = ModbusClient(ipaddress)
 storagepower = 0
 storage2power = 0
 if batwrsame == 1:
-    soc = client.read_holding_registers(62852, ModbusDataType.FLOAT_32, unit=slave1id)
+    soc = client.read_holding_registers(62852, ModbusDataType.FLOAT_32, unit=slave_ids[0])
     try:
         if zweiterspeicher == 1:
-            soc2 = client.read_holding_registers(62852, ModbusDataType.FLOAT_32, unit=slave2id)
+            soc2 = client.read_holding_registers(62852, ModbusDataType.FLOAT_32, unit=slave_ids[1])
             fsoc=(soc+soc2)/2
         else:
             fsoc=soc
@@ -49,10 +33,10 @@ if batwrsame == 1:
     f = open('/var/www/html/openWB/ramdisk/speichersoc', 'w')
     f.write(str(fsoc))
     f.close()
-    storagepower = client.read_holding_registers(62836, ModbusDataType.FLOAT_32, unit=slave1id)
+    storagepower = client.read_holding_registers(62836, ModbusDataType.FLOAT_32, unit=slave_ids[0])
     try:
         if zweiterspeicher == 1:
-            storage2power = client.read_holding_registers(62836, ModbusDataType.FLOAT_32, unit=slave2id)
+            storage2power = client.read_holding_registers(62836, ModbusDataType.FLOAT_32, unit=slave_ids[1])
     except:
         storage2power = 0
     final=storagepower+storage2power
@@ -60,46 +44,20 @@ if batwrsame == 1:
     f.write(str(final))
     f.close()
 
-try:
+total_energy = 0
+total_power = 0
+
+for slave_id in slave_ids:
     # 40083 = AC Power value (Watt), 40084 = AC Power scale factor
-    power_base, power_scale = client.read_holding_registers(40083, [ModbusDataType.INT_16] * 2, unit=slave1id)
-    fwr1watt = -power_base * math.pow(10, power_scale)
+    power_base, power_scale = client.read_holding_registers(40083, [ModbusDataType.INT_16] * 2, unit=slave_id)
+    total_power -= power_base * math.pow(10, power_scale)
     # 40093 = AC Lifetime Energy production (Watt hours)
-    final = client.read_holding_registers(40093, ModbusDataType.INT_32, unit=slave1id)
-except:
-    fwr1watt=0
-if slave2id != 0:
-    try:
-        power_base, power_scale = client.read_holding_registers(40083, [ModbusDataType.INT_16] * 2, unit=slave2id)
-        fwr2watt = -power_base * math.pow(10, power_scale)
-        final += client.read_holding_registers(40093, ModbusDataType.INT_32, unit=slave2id)
-    except:
-        fwr2watt=0
-else:
-    fwr2watt=0
-if slave3id != 0:
-    try:
-        power_base, power_scale = client.read_holding_registers(40083, [ModbusDataType.INT_16] * 2, unit=slave3id)
-        fwr2watt = -power_base * math.pow(10, power_scale)
-        final += client.read_holding_registers(40093, ModbusDataType.INT_32, unit=slave3id)
-    except:
-        fwr3watt=0
-else:
-    fwr3watt=0
-if slave4id != 0:
-    try:
-        power_base, power_scale = client.read_holding_registers(40083, [ModbusDataType.INT_16] * 2, unit=slave4id)
-        fwr2watt = -power_base * math.pow(10, power_scale)
-        final += client.read_holding_registers(40093, ModbusDataType.INT_32, unit=slave4id)
-    except:
-        fwr4watt=0
-else:
-    fwr4watt=0
+    total_energy += client.read_holding_registers(40093, ModbusDataType.INT_32, unit=slave_id)
 
 if extprodakt == 1:
     try:
         # 40380 = "Meter 2/Total Real Power (sum of active phases)" (Watt)
-        extprod = -client.read_holding_registers(40380, ModbusDataType.INT_16, unit=slave1id)
+        extprod = -client.read_holding_registers(40380, ModbusDataType.INT_16, unit=slave_ids[0])
     except:
         extprod = 0
 else:
@@ -109,18 +67,18 @@ if subbat == 1:
         storagepower=0
     if storage2power > 0:
         storage2power=0
-    allwatt=fwr1watt+fwr2watt+fwr3watt+fwr4watt-storagepower-storage2power+extprod
+    allwatt = total_power - storagepower - storage2power + extprod
 else:
-    allwatt=fwr1watt+fwr2watt+fwr3watt+fwr4watt-storagepower-storage2power+extprod
+    allwatt = total_power - storagepower - storage2power + extprod
 if allwatt > 0:
     allwatt=0
 f = open('/var/www/html/openWB/ramdisk/pvwatt', 'w')
 f.write(str(allwatt))
 f.close()
 f = open('/var/www/html/openWB/ramdisk/pvkwh', 'w')
-f.write(str(final))
+f.write(str(total_energy))
 f.close()
-pvkwhk= final / 1000
+pvkwhk= total_energy / 1000
 f = open('/var/www/html/openWB/ramdisk/pvkwhk', 'w')
 f.write(str(pvkwhk))
 f.close()

--- a/packages/modules/common/component_state.py
+++ b/packages/modules/common/component_state.py
@@ -2,7 +2,7 @@ from typing import List
 
 
 class BatState:
-    def __init__(self, imported: float, exported: float, power: float, soc: float = 0):
+    def __init__(self, imported: float = 0, exported: float = 0, power: float = 0, soc: float = 0):
         self.imported = imported
         self.exported = exported
         self.power = power


### PR DESCRIPTION
Da ich selber einen SolarEdge-WR habe ich mir mal den Code zu Gemüte geführt, der den SE-Wechselrichter abfragt. Also kleine "Vorbereitung" auf dann demnächst die Anpassung des Codes für die neue API habe ich den Code erstmal ordentlich aufgeräumt. Sonst blick ja niemand durch ;-).

Code ist jetzt runter von ursprünglich 237 Zeilen auf 72 Zeilen. Sollte sich aber inhaltlich genau so verhalten wie der alte auch.

Ich habe PR auf mehrere commits aufgeteilt, damit man die einzelnen Schritte die ich durchgeführt habe nachvollziehen kann.

Mein Wechselrichter hat allerdings eine ganze einfache Konfiguration. Keine Batterie, keine weiteren slaves... Wäre natürlich nicht falsch, wenn das jemand testen würde, der ein komplexeres Setup hat.

Und dann finde ich vielleicht noch raus, was die ganzen anderen Dateien in `modules/wr_solaredge` können. Sind das vergessene Überbleibsel von irgendwann mal und können weg?