### PR TITLE
Hinweistexte BYD am Plenticore angepasst

### DIFF
--- a/web/settings/modulconfigbat.php
+++ b/web/settings/modulconfigbat.php
@@ -161,7 +161,7 @@
 								<span class="text-info">openWB/set/houseBattery/%Soc</span> Ladestand des Speichers, int, 0-100
 							</div>
 						</div>
-						
+
 						<div id="divspeichersolarwatt" class="hide">
 							<div class="form-group">
 								<div class="form-row mb-1">
@@ -179,7 +179,7 @@
 											IP-Adresse 1: Energy Manager (immer angeben)<br>
 											IP-Adresse 2: Gateway (Zus&auml;tzlich, falls Abrufmethode Gateway)
 										</span>
-									</div>									
+									</div>
 								</div>
 							</div>
 							<script>
@@ -190,8 +190,8 @@
 										showSection('#divspeicherip2');
 									}
 								}
-								
-								$(function() {	
+
+								$(function() {
 									$('input[type=radio][name=solarwattmethod]').change(function(){
 										visibility_solarwatt_ip2();
 									});
@@ -224,7 +224,7 @@
 								Hier bitte die IP Adresse des ModbusGateway's eintragen.
 							</div>
 						</div>
-						
+
 						<div id="divspeicherfems" class="hide">
 							<div class="form-group">
 								<div class="form-row mb-1">
@@ -250,7 +250,7 @@
 								</div>
 							</div>
 						</div>
-						
+
 						<div id="divspeicherip2" class="hide">
 							<div class="form-group">
 								<div class="form-row mb-1">
@@ -287,10 +287,10 @@
 				<div class="card-body">
 					<div class="row">
 						<div class="col">
-						<pre><?php 
+						<pre><?php
 						   $lines=[];
 							exec('/var/www/html/openWB/modules/speicher_rct2/info.sh', $lines);
-							echo implode('<br>',$lines); 
+							echo implode('<br>',$lines);
 						  ?></pre>
 						</div>
 					</div>
@@ -586,6 +586,15 @@
 
 						<div id="divspeicherbydhv" class="hide">
 							<div class="form-group">
+								<div class="form-row mb-1">
+									<div class="col-md-4">
+									</div>
+									<div class="col">
+										<span class="form-text small">
+											Ist der BYD-Speicher am Kostal Plenticore angebunden, ist in diesem Fall das Batteriespeicher-Modul "Kostal Plenticore mit Speicher" auszuwählen. Der WR stellt alle Daten der angeschlossenen Batterie bereit.
+										</span>
+									</div>
+								</div>
 								<div class="form-row mb-1">
 									<label for="bydhvuser" class="col-md-4 col-form-label">Benutzername</label>
 									<div class="col">

--- a/web/settings/modulconfigpv.php
+++ b/web/settings/modulconfigpv.php
@@ -335,6 +335,9 @@
 										Gültige Werte: IP-Adresse des 1. Kostal Plenticore. An diesem muss (wenn vorhanden) der EM300/das KSEM und ggf. Speicher angeschlossen sein.
 										Modbus/Sunspec (TCP) muss im WR aktiviert sein (Port 1502, Unit-ID 71).
 									</span>
+									<span class="form-text small">
+										Am 1. Plenticore darf ein Speicher angebunden sein. In diesem Fall ist im Batteriespeicher-Modul "Kostal Plenticore mit Speicher" auszuwählen. Der WR stellt alle Daten der angeschlossenen Batterie bereit.
+									</span>
 								</div>
 							</div>
 							<div class="form-row mb-1">
@@ -354,6 +357,9 @@
 										Gültige Werte: IP-Adresse des 2. Kostal Plenticore oder "none". An diesem WR darf kein Speicher angeschlossen sein.
 										Wenn nur ein WR genutzt wird, muss der Wert "none" gesetzt werden, ansonsten muss Modbus/Sunspec (TCP) im WR aktiviert sein (Port 1502, Unit-ID 71).
 									</span>
+									<span class="form-text small">
+										Am 2. Plenticore darf kein Speicher angebunden sein.
+									</span>
 								</div>
 								</div>
 								<div class="form-row mb-1">
@@ -372,6 +378,9 @@
 									<span class="form-text small">
 										Gültige Werte: IP-Adresse des 3. Kostal Plenticore oder "none". An diesem WR darf kein Speicher angeschlossen sein.
 										Wenn nur ein WR genutzt wird, muss der Wert "none" gesetzt werden, ansonsten muss Modbus/Sunspec (TCP) im WR aktiviert sein (Port 1502, Unit-ID 71).
+									</span>
+									<span class="form-text small">
+										Am 3. Plenticore darf kein Speicher angebunden sein.
 									</span>
 								</div>
 							</div>


### PR DESCRIPTION
Da es bei der Kombi Plenticore + BYD anscheinend zu Problemen bei der korrekten Modul-Konfig kam, wurden die Hinweistexte in den Modulen angepasst.