### PR TITLE
Fix style errors reported by flake8

### DIFF
--- a/packages/helpermodules/compatibility.py
+++ b/packages/helpermodules/compatibility.py
@@ -1,5 +1,6 @@
 from pathlib import Path
 
+
 def is_ramdisk_in_use() -> bool:
     """ prüft, ob die Daten in der Ramdisk liegen (v1.x), sonst wird mit dem Broker (2.x) gearbeitet.
     """

--- a/packages/helpermodules/log.py
+++ b/packages/helpermodules/log.py
@@ -7,11 +7,10 @@ import traceback
 import subprocess
 import sys
 from datetime import datetime, timezone
-from pathlib import Path
 
 try:
     from . import compatibility
-except:
+except ImportError:
     from helpermodules import compatibility
 
 debug_logger = None
@@ -66,9 +65,9 @@ class MainLogger:
             """
             try:
                 local_time = datetime.now(timezone.utc).astimezone()
-                myPid = str(os.getpid())
-                print(local_time.strftime(format="%Y-%m-%d %H:%M:%S") + ": PID: " + myPid + ": " + message)
-            except:
+                my_pid = str(os.getpid())
+                print(local_time.strftime(format="%Y-%m-%d %H:%M:%S") + ": PID: " + my_pid + ": " + message)
+            except Exception:
                 traceback.print_exc()
 
     instance = None

--- a/packages/helpermodules/pub.py
+++ b/packages/helpermodules/pub.py
@@ -3,23 +3,27 @@
 
 import json
 import os
+from typing import Optional
+
 import paho.mqtt.client as mqtt
 import paho.mqtt.publish as publish
 
 from . import log
 
-client = None
+client = None  # type: Optional[mqtt.Client]
 
 
 def setup_connection():
-    """ öffnet die Verbindugn zum Broker. Bei Verbindungsabbruch wird automatisch versucht, eine erneute Verbindung herzustellen.
+    """Öffnet die Verbindung zum Broker.
+
+    Bei Verbindungsabbruch wird automatisch versucht, eine erneute Verbindung herzustellen.
     """
     try:
         global client
         client = mqtt.Client("openWB-python-bulkpublisher-" + str(os.getpid()))
         client.connect("localhost", 1886)
         client.loop_start()
-    except Exception as e:
+    except Exception:
         log.MainLogger().exception("Fehler im pub-Modul")
 
 
@@ -39,7 +43,7 @@ def pub(topic, payload):
             client.publish(topic, payload, qos=0, retain=True)
         else:
             client.publish(topic, payload=json.dumps(payload), qos=0, retain=True)
-    except Exception as e:
+    except Exception:
         log.MainLogger().exception("Fehler im pub-Modul")
 
 
@@ -49,7 +53,7 @@ def delete_connection():
     try:
         client.loop_stop()
         client.disconnect
-    except Exception as e:
+    except Exception:
         log.MainLogger().exception("Fehler im pub-Modul")
 
 
@@ -68,9 +72,9 @@ def pub_single(topic, payload, hostname="localhost", no_json=False):
         Kompabilität mit isss, die ramdisk verwenden.
     """
     try:
-        if no_json == True:
+        if no_json:
             publish.single(topic, payload, hostname=hostname, retain=True)
         else:
             publish.single(topic, json.dumps(payload), hostname=hostname, retain=True)
-    except Exception as e:
+    except Exception:
         log.MainLogger().exception("Fehler im pub-Modul")

--- a/packages/modules/alpha_ess/bat.py
+++ b/packages/modules/alpha_ess/bat.py
@@ -6,7 +6,7 @@ try:
     from ..common import modbus
     from ..common.abstract_component import AbstractBat
     from ..common.component_state import BatState
-except:
+except ImportError:
     from helpermodules import log
     from modules.common import modbus
     from modules.common.abstract_component import AbstractBat
@@ -43,13 +43,17 @@ class AlphaEssBat(AbstractBat):
         current = self.client.read_holding_registers(0x0101, modbus.ModbusDataType.INT_16, unit=sdmid)
 
         power = voltage * current * -1 / 100
-        log.MainLogger().debug("Alpha Ess Leistung[W]: "+str(power)+", Speicher-Register: Spannung[V] "+str(voltage)+" Strom[A] "+str(current))
+        log.MainLogger().debug(
+            "Alpha Ess Leistung[W]: %f, Speicher-Register: Spannung[V]: %f, Strom[A]: %f" % (power, voltage, current)
+        )
         time.sleep(0.1)
         soc_reg = self.client.read_holding_registers(0x0102, modbus.ModbusDataType.INT_16, unit=sdmid)
         soc = int(soc_reg * 0.1)
 
         topic_str = "openWB/set/system/device/" + str(self.device_id)+"/component/"+str(self.data["config"]["id"])+"/"
-        imported, exported = self.sim_count.sim_count(power, topic=topic_str, data=self.data["simulation"], prefix="speicher")
+        imported, exported = self.sim_count.sim_count(
+            power, topic=topic_str, data=self.data["simulation"], prefix="speicher"
+        )
         bat_state = BatState(
             power=power,
             soc=soc,

--- a/packages/modules/alpha_ess/counter.py
+++ b/packages/modules/alpha_ess/counter.py
@@ -8,7 +8,7 @@ try:
     from ..common.abstract_component import AbstractCounter
     from ..common.component_state import CounterState
     from ..common.module_error import ModuleError
-except:
+except ImportError:
     from helpermodules import log
     from modules.common import modbus
     from modules.common.abstract_component import AbstractCounter
@@ -72,7 +72,7 @@ class AlphaEssCounter(AbstractCounter):
                 frequency=50
             )
             return counter_state
-        except ModuleError as e:
+        except ModuleError:
             raise
         except Exception as e:
             self.process_error(e)
@@ -103,7 +103,7 @@ class AlphaEssCounter(AbstractCounter):
                 frequency=50
             )
             return counter_state
-        except ModuleError as e:
+        except ModuleError:
             raise
         except Exception as e:
             self.process_error(e)

--- a/packages/modules/alpha_ess/device.py
+++ b/packages/modules/alpha_ess/device.py
@@ -2,7 +2,7 @@
 """ Modul zum Auslesen von Alpha Ess Speichern, Zählern und Wechselrichtern.
 """
 import sys
-from typing import List, Union
+from typing import List
 
 try:
     from ...helpermodules import log
@@ -11,7 +11,7 @@ try:
     from . import bat
     from . import counter
     from . import inverter
-except:
+except ImportError:
     from helpermodules import log
     from modules.common import modbus
     from modules.common import abstract_device
@@ -39,7 +39,7 @@ class Device(abstract_device.AbstractDevice):
         try:
             client = modbus.ModbusClient("192.168.193.125", 8899)
             super().__init__(device, client)
-        except Exception as e:
+        except Exception:
             log.MainLogger().exception("Fehler im Modul "+device["name"])
 
     def add_component(self, component_config: dict) -> None:
@@ -57,7 +57,7 @@ def read_legacy(argv: List[str]) -> None:
     version = int(argv[2])
     try:
         num = int(argv[3])
-    except:
+    except ValueError:
         num = None
 
     device_config = get_default_config()
@@ -66,7 +66,10 @@ def read_legacy(argv: List[str]) -> None:
     if component_type in COMPONENT_TYPE_TO_MODULE:
         component_config = COMPONENT_TYPE_TO_MODULE[component_type].get_default_config()
     else:
-        raise Exception("illegal component type "+component_type+". Allowed values: "+','.join(COMPONENT_TYPE_TO_MODULE.keys()))
+        raise Exception(
+            "illegal component type " + component_type + ". Allowed values: " +
+            ','.join(COMPONENT_TYPE_TO_MODULE.keys())
+        )
     component_config["id"] = num
     component_config["configuration"]["version"] = version
     dev.add_component(component_config)
@@ -79,5 +82,5 @@ def read_legacy(argv: List[str]) -> None:
 if __name__ == "__main__":
     try:
         read_legacy(sys.argv)
-    except:
+    except Exception:
         log.MainLogger().exception("Fehler im Alpha Ess Skript")

--- a/packages/modules/alpha_ess/inverter.py
+++ b/packages/modules/alpha_ess/inverter.py
@@ -1,5 +1,4 @@
 #!/usr/bin/env python3
-import time
 
 try:
     from ...helpermodules import log
@@ -7,7 +6,7 @@ try:
     from ..common.abstract_component import AbstractInverter
     from ..common.component_state import InverterState
     from ..common.module_error import ModuleError
-except:
+except ImportError:
     from helpermodules import log
     from modules.common import modbus
     from modules.common.abstract_component import AbstractInverter
@@ -58,7 +57,10 @@ class AlphaEssInverter(AbstractInverter):
 
     def __get_power(self, unit: int, reg_p: int) -> int:
         try:
-            powers = [self.client.read_holding_registers(address, modbus.ModbusDataType.INT_32, unit=unit) for address in [reg_p, 0x041F, 0x0423, 0x0427]]
+            powers = [
+                self.client.read_holding_registers(address, modbus.ModbusDataType.INT_32, unit=unit)
+                for address in [reg_p, 0x041F, 0x0423, 0x0427]
+            ]
             powers[0] = abs(powers[0])
             power = sum(powers) * -1
             log.MainLogger().debug("Alpha Ess Leistung: "+str(power)+", WR-Register: " + str(powers))

--- a/packages/modules/common/abstract_component.py
+++ b/packages/modules/common/abstract_component.py
@@ -1,5 +1,5 @@
 from abc import abstractmethod
-from typing import List, Union
+from typing import Union
 try:
     from ...helpermodules import log
     from ..common import modbus
@@ -10,7 +10,7 @@ try:
     from ..common import store
     from ..common.module_error import ModuleError, ModuleErrorLevel
     from component_state import BatState, CounterState, InverterState
-except:
+except ImportError:
     from helpermodules import log
     from modules.common import modbus
     from modules.common import lovato
@@ -23,16 +23,23 @@ except:
 
 
 class AbstractComponent:
-    def __init__(self, device_id: int, component_config: dict, client: Union[modbus.ModbusClient, mpm3pm.Mpm3pm, lovato.Lovato, sdm630.Sdm630]) -> None:
+    def __init__(
+        self,
+        device_id: int,
+        component_config: dict,
+        client: Union[modbus.ModbusClient, mpm3pm.Mpm3pm, lovato.Lovato, sdm630.Sdm630]
+    ) -> None:
         try:
             self.device_id = device_id
             self.client = client
             self.data = {"config": component_config,
                          "simulation": {}}
-            self.value_store = (store.ValueStoreFactory().get_storage(component_config["type"]))(self.data["config"]["id"])
+            self.value_store = (store.ValueStoreFactory().get_storage(component_config["type"]))(
+                self.data["config"]["id"]
+            )
             simcount_factory = simcount.SimCountFactory().get_sim_counter()
             self.sim_count = simcount_factory()
-        except Exception as e:
+        except Exception:
             log.MainLogger().exception("Fehler im Modul "+self.data["config"]["name"])
 
     @abstractmethod
@@ -50,13 +57,19 @@ class AbstractComponent:
             self.process_error(e)
             raise ModuleError("", ModuleErrorLevel.ERROR)
         else:
-            ModuleError("Kein Fehler.", ModuleErrorLevel.NO_ERROR).store_error(self.data["config"]["id"], self.data["config"]["type"], self.data["config"]["name"])
+            ModuleError("Kein Fehler.", ModuleErrorLevel.NO_ERROR).store_error(
+                self.data["config"]["id"], self.data["config"]["type"], self.data["config"]["name"]
+            )
             return state
 
     def process_error(self, e):
-        ModuleError(str(type(e))+" "+str(e), ModuleErrorLevel.ERROR).store_error(self.data["config"]["id"], self.data["config"]["type"], self.data["config"]["name"])
+        ModuleError(str(type(e))+" "+str(e), ModuleErrorLevel.ERROR).store_error(
+            self.data["config"]["id"], self.data["config"]["type"], self.data["config"]["name"]
+        )
 
-    def kit_version_factory(self, version: int, id: int, tcp_client: modbus.ModbusClient) -> Union[mpm3pm.Mpm3pm, lovato.Lovato, sdm630.Sdm630]:
+    def kit_version_factory(self, version: int, id: int, tcp_client: modbus.ModbusClient) -> Union[
+        mpm3pm.Mpm3pm, lovato.Lovato, sdm630.Sdm630
+    ]:
         try:
             if version == 0:
                 return mpm3pm.Mpm3pm(id, tcp_client)
@@ -71,7 +84,10 @@ class AbstractComponent:
 
 
 class AbstractBat(AbstractComponent):
-    def __init__(self, device_id: int, component_config: dict, client: Union[modbus.ModbusClient, mpm3pm.Mpm3pm, lovato.Lovato, sdm630.Sdm630]) -> None:
+    def __init__(self,
+                 device_id: int,
+                 component_config: dict,
+                 client: Union[modbus.ModbusClient, mpm3pm.Mpm3pm, lovato.Lovato, sdm630.Sdm630]) -> None:
         super().__init__(device_id, component_config, client)
 
     @abstractmethod
@@ -83,7 +99,10 @@ class AbstractBat(AbstractComponent):
 
 
 class AbstractCounter(AbstractComponent):
-    def __init__(self, device_id: int, component_config: dict, client: Union[modbus.ModbusClient, mpm3pm.Mpm3pm, lovato.Lovato, sdm630.Sdm630]) -> None:
+    def __init__(self,
+                 device_id: int,
+                 component_config: dict,
+                 client: Union[modbus.ModbusClient, mpm3pm.Mpm3pm, lovato.Lovato, sdm630.Sdm630]) -> None:
         super().__init__(device_id, component_config, client)
 
     @abstractmethod
@@ -95,7 +114,10 @@ class AbstractCounter(AbstractComponent):
 
 
 class AbstractInverter(AbstractComponent):
-    def __init__(self, device_id: int, component_config: dict, client: Union[modbus.ModbusClient, mpm3pm.Mpm3pm, lovato.Lovato, sdm630.Sdm630]) -> None:
+    def __init__(self,
+                 device_id: int,
+                 component_config: dict,
+                 client: Union[modbus.ModbusClient, mpm3pm.Mpm3pm, lovato.Lovato, sdm630.Sdm630]) -> None:
         super().__init__(device_id, component_config, client)
 
     @abstractmethod

--- a/packages/modules/common/abstract_device.py
+++ b/packages/modules/common/abstract_device.py
@@ -4,7 +4,7 @@ try:
     from ...helpermodules import log
     from ..common import modbus
     from ..common.module_error import ModuleError
-except:
+except ImportError:
     from helpermodules import log
     from modules.common import modbus
     from modules.common.module_error import ModuleError
@@ -19,21 +19,25 @@ class AbstractDevice:
             self.data = {"config": device,
                          "components": {}}
             self.client = client
-        except:
+        except Exception:
             log.MainLogger().exception("Fehler im Modul "+device["name"])
 
     def instantiate_component(self, component_config: dict, factory) -> None:
         try:
-            self.data["components"]["component"+str(component_config["id"])] = factory(self.data["config"]["id"], component_config, self.client)
-        except:
+            self.data["components"]["component"+str(component_config["id"])] = factory(
+                self.data["config"]["id"], component_config, self.client
+            )
+        except Exception:
             log.MainLogger().exception("Fehler im Modul "+self.data["config"]["name"])
 
     def component_factory(self, component_type: str):
         try:
             if component_type in self.COMPONENT_TYPE_TO_CLASS:
                 return self.COMPONENT_TYPE_TO_CLASS[component_type]
-            raise Exception("illegal component type "+component_type+". Allowed values: "+','.join(self.COMPONENT_TYPE_TO_CLASS.keys()))
-        except Exception as e:
+            raise Exception("illegal component type "+component_type+". Allowed values: "+','.join(
+                self.COMPONENT_TYPE_TO_CLASS.keys()
+            ))
+        except Exception:
             log.MainLogger().exception("Fehler im Modul "+self.data["config"]["name"])
 
     @abstractmethod
@@ -47,8 +51,14 @@ class AbstractDevice:
                 for component in self.data["components"]:
                     self.data["components"][component].update_values()
             else:
-                log.MainLogger().warning(self.data["config"]["name"]+": Es konnten keine Werte gelesen werden, da noch keine Komponenten konfiguriert wurden.")
+                log.MainLogger().warning(
+                    self.data["config"]["name"] +
+                    ": Es konnten keine Werte gelesen werden, da noch keine Komponenten konfiguriert wurden."
+                )
         except ModuleError:
-            log.MainLogger().error("Beim Auslesen eines Moduls ist ein Fehler aufgetreten. Auslesen des Devices "+self.data["config"]["name"]+" beendet.")
-        except:
+            log.MainLogger().error(
+                "Beim Auslesen eines Moduls ist ein Fehler aufgetreten. Auslesen des Devices %s beendet." %
+                self.data["config"]["name"]
+            )
+        except Exception:
             log.MainLogger().exception("Fehler im Modul "+self.data["config"]["name"])

--- a/packages/modules/common/component_state.py
+++ b/packages/modules/common/component_state.py
@@ -10,7 +10,15 @@ class BatState:
 
 
 class CounterState:
-    def __init__(self, voltages: List[float], currents: List[float], powers: List[float], power_factors: List[float], imported: float, exported: float, power_all: float, frequency: float):
+    def __init__(self,
+                 voltages: List[float],
+                 currents: List[float],
+                 powers: List[float],
+                 power_factors: List[float],
+                 imported: float,
+                 exported: float,
+                 power_all: float,
+                 frequency: float):
         self.voltages = voltages
         self.currents = currents
         self.powers = powers

--- a/packages/modules/common/lovato.py
+++ b/packages/modules/common/lovato.py
@@ -4,11 +4,9 @@ from typing import List, Tuple
 
 try:
     from ..common import modbus
-    from ...helpermodules import log
     from ..common.module_error import ModuleError, ModuleErrorLevel
-except:
+except ImportError:
     # for 1.9 compatibility
-    from helpermodules import log
     from modules.common import modbus
     from modules.common.module_error import ModuleError, ModuleErrorLevel
 
@@ -16,7 +14,7 @@ except:
 class Lovato:
     def __init__(self, modbus_id: int, client: modbus.ModbusClient) -> None:
         self.client = client
-        unit=self.id = modbus_id
+        self.id = modbus_id
 
     def __process_error(self, e):
         if isinstance(e, ModuleError):
@@ -38,7 +36,9 @@ class Lovato:
 
     def get_power(self) -> Tuple[List[float], float]:
         try:
-            power_per_phase = self.client.read_input_registers(0x0013, [modbus.ModbusDataType.FLOAT_32]*3, unit=self.id) / 100
+            power_per_phase = self.client.read_input_registers(
+                0x0013, [modbus.ModbusDataType.FLOAT_32]*3, unit=self.id
+            ) / 100
             power_all = self.client.read_input_registers(0x000C, modbus.ModbusDataType.FLOAT_32, unit=self.id)
             return power_per_phase, power_all
         except Exception as e:
@@ -52,7 +52,7 @@ class Lovato:
 
     def get_power_factor(self) -> List[float]:
         try:
-            return self.client.read_input_registers(0x0025,[ modbus.ModbusDataType.FLOAT_32]*3, unit=self.id) / 10000
+            return self.client.read_input_registers(0x0025, [modbus.ModbusDataType.FLOAT_32]*3, unit=self.id) / 10000
         except Exception as e:
             self.__process_error(e)
 

--- a/packages/modules/common/modbus.py
+++ b/packages/modules/common/modbus.py
@@ -1,19 +1,21 @@
 #!/usr/bin/env python3
-""" Das Modul baut eine Modbus-TCP-Verbindung auf. Es gibt verschiedene Funktionen, um die gelesenen Register zu formatieren.
+"""Modul für einfache Modbusoperationen.
+
+Das Modul baut eine Modbus-TCP-Verbindung auf. Es gibt verschiedene Funktionen, um die gelesenen Register zu
+formatieren.
 """
-import codecs
 from enum import Enum
+from typing import Callable, Iterable, Union
+
+import pymodbus
 from pymodbus.client.sync import ModbusTcpClient
 from pymodbus.constants import Endian
 from pymodbus.payload import BinaryPayloadDecoder
-from typing import Callable, Iterable, List, Union
-import pymodbus
-import struct
 
 try:
     from ...helpermodules import log
     from ..common.module_error import ModuleError, ModuleErrorLevel
-except:
+except ImportError:
     from helpermodules import log
     from modules.common.module_error import ModuleError, ModuleErrorLevel
 
@@ -82,10 +84,16 @@ class ModbusClient:
             return result if multi_request else result[0]
         except pymodbus.exceptions.ConnectionException as e:
             raise ModuleError(
-                "TCP-Client konnte keine Verbindung aufbauen. Bitte Einstellungen (IP-Adresse, ..) und Hardware-Anschluss pruefen.", ModuleErrorLevel.ERROR) from e
+                "TCP-Client konnte keine Verbindung aufbauen. Bitte Einstellungen (IP-Adresse, ..) und " +
+                "Hardware-Anschluss pruefen.",
+                ModuleErrorLevel.ERROR
+            ) from e
         except pymodbus.exceptions.ModbusIOException as e:
             raise ModuleError(
-                "TCP-Client konnte keinen Wert abfragen. Falls vorhanden, parallele Verbindungen, zB. node red, beenden und bei anhaltender Fehlermeldung Zaehler neustarten.", ModuleErrorLevel.WARNING) from e
+                "TCP-Client konnte keinen Wert abfragen. Falls vorhanden, parallele Verbindungen, zB. node red," +
+                "beenden und bei anhaltender Fehlermeldung Zaehler neustarten.",
+                ModuleErrorLevel.WARNING
+            ) from e
         except Exception as e:
             raise ModuleError(__name__+" "+str(type(e))+" " +
                               str(e), ModuleErrorLevel.ERROR) from e

--- a/packages/modules/common/module_error.py
+++ b/packages/modules/common/module_error.py
@@ -5,12 +5,12 @@ try:
     from ...helpermodules import compatibility
     from ...helpermodules import log
     from ...helpermodules import pub
-except:
+except ImportError:
     # for 1.9 compatibility
-    import sys
     from helpermodules import compatibility
     from helpermodules import log
     from helpermodules import pub
+
 
 class ModuleErrorLevel(Enum):
     NO_ERROR = 0
@@ -25,7 +25,10 @@ class ModuleError(Exception):
 
     def store_error(self, component_num: int, component_type: str, component_name: str) -> None:
         try:
-            log.MainLogger().debug(component_name+": FaultState "+str(self.fault_state)+", FaultStr "+self.fault_str+", Traceback: \n"+traceback.format_exc())
+            log.MainLogger().debug(
+                component_name+": FaultState "+str(self.fault_state)+", FaultStr "+self.fault_str+", Traceback: \n" +
+                traceback.format_exc()
+            )
             ramdisk = compatibility.is_ramdisk_in_use()
             if ramdisk:
                 if component_type == "counter":
@@ -42,5 +45,5 @@ class ModuleError(Exception):
             else:
                 pub.pub("openWB/set/"+component_type+"/"+str(component_num)+"/get/fault_str", self.fault_str)
                 pub.pub("openWB/set/"+component_type+"/"+str(component_num)+"/get/fault_state", self.fault_state.value)
-        except:
+        except Exception:
             log.MainLogger().exception("Fehler im Modul module_error")

--- a/packages/modules/common/mpm3pm.py
+++ b/packages/modules/common/mpm3pm.py
@@ -3,7 +3,7 @@ from typing import List, Tuple
 try:
     from ..common import modbus
     from ..common.module_error import ModuleError, ModuleErrorLevel
-except:
+except ImportError:
     # for 1.9 compatibility
     from modules.common import modbus
     from modules.common.module_error import ModuleError, ModuleErrorLevel
@@ -12,7 +12,7 @@ except:
 class Mpm3pm:
     def __init__(self, modbus_id: int, client: modbus.ModbusClient) -> None:
         self.client = client
-        unit=self.id = modbus_id
+        self.id = modbus_id
 
     def __process_error(self, e):
         if isinstance(e, ModuleError):

--- a/packages/modules/common/sdm630.py
+++ b/packages/modules/common/sdm630.py
@@ -1,11 +1,10 @@
 #!/usr/bin/env python3
-import sys
 from typing import List, Tuple
 
 try:
     from ..common import modbus
     from ..common.module_error import ModuleError, ModuleErrorLevel
-except:
+except ImportError:
     # for 1.9 compatibility
     from modules.common import modbus
     from modules.common.module_error import ModuleError, ModuleErrorLevel
@@ -56,7 +55,7 @@ class Sdm630:
 
     def get_frequency(self) -> float:
         try:
-            frequency= self.client.read_input_registers(0x46, modbus.ModbusDataType.FLOAT_32, unit=self.id)
+            frequency = self.client.read_input_registers(0x46, modbus.ModbusDataType.FLOAT_32, unit=self.id)
             if frequency > 100:
                 frequency = frequency / 10
             return frequency

--- a/packages/modules/common/simcount.py
+++ b/packages/modules/common/simcount.py
@@ -2,28 +2,30 @@
 Berechnet die importierte und exportierte Leistung, wenn der Zähler / PV-Modul / Speicher diese nicht liefert.
 """
 import os
-import paho.mqtt.subscribe as subscribe
 import re
 import signal
 import sys
 import time
 import typing
-from pathlib import Path
+
+import paho.mqtt.subscribe as subscribe
 
 try:
     from ..common.module_error import ModuleError, ModuleErrorLevel
     from ...helpermodules import compatibility
     from ...helpermodules import log
     from ...helpermodules import pub
-except:
+except ImportError:
     # for 1.9 compatibility
     from helpermodules import compatibility
     from helpermodules import log
     from helpermodules import pub
     from modules.common.module_error import ModuleError, ModuleErrorLevel
-    
-def process_error( e):
+
+
+def process_error(e):
     raise ModuleError(__name__+" "+str(type(e))+" "+str(e), ModuleErrorLevel.ERROR) from e
+
 
 class SimCountFactory:
     def get_sim_counter(self):
@@ -35,7 +37,9 @@ class SimCountFactory:
 
 
 class SimCountLegacy:
-    def sim_count(self, power_present: float, topic: str = "", data: dict = {}, prefix: str = "") -> typing.Tuple[float, float]:
+    def sim_count(
+        self, power_present: float, topic: str = "", data: dict = {}, prefix: str = ""
+    ) -> typing.Tuple[float, float]:
         """ emulate import export
 
         Parameters
@@ -60,18 +64,20 @@ class SimCountLegacy:
                 power_previous = int(float(self.read_ramdisk_file(prefix+'wh0')))
                 try:
                     counter_import_present = int(float(self.read_ramdisk_file(prefix+'watt0pos')))
-                except:
+                except Exception:
                     counter_import_present = int(self.restore("watt0pos", prefix))
                 counter_import_previous = counter_import_present
                 try:
                     counter_export_present = int(float(self.read_ramdisk_file(prefix+'watt0neg')))
-                except:
+                except Exception:
                     counter_export_present = int(self.restore("watt0neg", prefix))
                 if counter_export_present < 0:
                     # runs/simcount.py speichert das Zwischenergebnis des Exports negativ ab.
                     counter_export_present = counter_export_present * -1
                 counter_export_previous = counter_export_present
-                log.MainLogger().debug("simcount Zwischenergebnisse letzte Berechnung: Import: "+str(counter_import_previous)+" Export: "+str(counter_export_previous)+" Power: "+str(power_previous))
+                log.MainLogger().debug("simcount Zwischenergebnisse letzte Berechnung: Import: " + str(
+                    counter_import_previous) + " Export: " + str(counter_export_previous) + " Power: " + str(
+                    power_previous))
                 start_new = False
             self.write_ramdisk_file(prefix+'sec0', "%22.6f" % timestamp_present)
             self.write_ramdisk_file(prefix+'wh0', power_present)
@@ -84,13 +90,21 @@ class SimCountLegacy:
                 imp_exp = calculate_import_export(seconds_since_previous, power_previous, power_present)
                 counter_export_present = counter_export_present + imp_exp[1]
                 counter_import_present = counter_import_present + imp_exp[0]
-                log.MainLogger().debug("simcount aufsummierte Energie: Bezug[Ws]: "+str(counter_import_present)+", Einspeisung[Ws]: "+str(counter_export_present))
+                log.MainLogger().debug(
+                    "simcount aufsummierte Energie: Bezug[Ws]: " + str(counter_import_present) + ", Einspeisung[Ws]: " +
+                    str(counter_export_present)
+                )
                 wattposkh = counter_import_present/3600
                 wattnegkh = counter_export_present/3600
-                log.MainLogger().info("simcount Ergebnis: Bezug[Wh]: "+str(wattposkh)+", Einspeisung[Wh]: "+str(wattnegkh))
+                log.MainLogger().info(
+                    "simcount Ergebnis: Bezug[Wh]: " + str(wattposkh) + ", Einspeisung[Wh]: " + str(wattnegkh)
+                )
 
                 topic = self.__get_topic(prefix)
-                log.MainLogger().debug("simcount Zwischenergebnisse atkuelle Berechnung: Import: "+str(counter_import_present)+" Export: "+str(counter_export_present)+" Power: "+str(power_present))
+                log.MainLogger().debug(
+                    "simcount Zwischenergebnisse atkuelle Berechnung: Import: " + str(counter_import_present) +
+                    " Export: " + str(counter_export_present) + " Power: " + str(power_present)
+                )
                 self.write_ramdisk_file(prefix+'watt0pos', counter_import_present)
                 if counter_import_present != counter_import_previous:
                     pub.pub_single("openWB/"+topic+"/WHImported_temp", counter_import_present, no_json=True)
@@ -101,7 +115,7 @@ class SimCountLegacy:
         except Exception as e:
             process_error(e)
 
-    def __get_topic(self, prefix:str) -> str:
+    def __get_topic(self, prefix: str) -> str:
         """ ermittelt das zum Präfix gehörende Topic."""
         try:
             if prefix == "bezug":
@@ -148,7 +162,7 @@ class SimCountLegacy:
             signal.alarm(0)
             temp = int(float(temp.payload.decode("utf-8")))
             ra = '^-?[0-9]+$'
-            if re.search(ra, str(temp)) == None:
+            if re.search(ra, str(temp)) is None:
                 temp = "0"
             self.write_ramdisk_file(prefix+value, temp)
             if value == "watt0pos":
@@ -164,7 +178,9 @@ class SimCountLegacy:
 
 
 class SimCount:
-    def sim_count(self, power_present: float, topic: str = "", data: dict = {}, prefix: str = "") -> typing.Tuple[float, float]:
+    def sim_count(
+        self, power_present: float, topic: str = "", data: dict = {}, prefix: str = ""
+    ) -> typing.Tuple[float, float]:
         """ emulate import export
 
         Parameters
@@ -193,7 +209,10 @@ class SimCount:
                     counter_export_present = int(data["present_exported"])
                 else:
                     counter_export_present = 0
-                log.MainLogger().debug("Fortsetzen der Simulation: Importzaehler: "+str(counter_import_present)+"Ws, Export-Zaehler: "+str(counter_export_present)+"Ws")
+                log.MainLogger().debug(
+                    "Fortsetzen der Simulation: Importzaehler: " + str(counter_import_present)+"Ws, Export-Zaehler: " +
+                    str(counter_export_present) + "Ws"
+                )
                 start_new = False
             pub.pub(topic+"simulation/timestamp_present", "%22.6f" % timestamp_present)
             pub.pub(topic+"simulation/power_present", power_present)
@@ -209,11 +228,19 @@ class SimCount:
                 imp_exp = calculate_import_export(seconds_since_previous, power_previous, power_present)
                 counter_export_present = counter_export_present + imp_exp[1]
                 counter_import_present = counter_import_present + imp_exp[0]
-                log.MainLogger().debug("simcount aufsummierte Energie: Bezug[Ws]: "+str(counter_import_present)+", Einspeisung[Ws]: "+str(counter_export_present))
+                log.MainLogger().debug(
+                    "simcount aufsummierte Energie: Bezug[Ws]: " + str(counter_import_present) + ", Einspeisung[Ws]: " +
+                    str(counter_export_present)
+                )
                 wattposkh = counter_import_present/3600
                 wattnegkh = counter_export_present/3600
-                log.MainLogger().info("simcount Ergebnis: Bezug[Wh]: "+str(wattposkh)+", Einspeisung[Wh]: "+str(wattnegkh))
-                log.MainLogger().debug("simcount Zwischenergebnisse atkuelle Berechnung: Import: "+str(counter_import_present)+" Export: "+str(counter_export_present)+" Power: "+str(power_present))
+                log.MainLogger().info(
+                    "simcount Ergebnis: Bezug[Wh]: " + str(wattposkh) + ", Einspeisung[Wh]: " + str(wattnegkh)
+                )
+                log.MainLogger().debug(
+                    "simcount Zwischenergebnisse atkuelle Berechnung: Import: " + str(counter_import_present) +
+                    " Export: " + str(counter_export_present) + " Power: " + str(power_present)
+                )
                 pub.pub(topic+"simulation/present_imported", counter_import_present)
                 pub.pub(topic+"simulation/present_exported", counter_export_present)
                 return wattposkh, wattnegkh
@@ -224,13 +251,19 @@ class SimCount:
 Number = typing.Union[int, float]
 
 
-def calculate_import_export(seconds_since_previous: Number, power1: Number, power2: Number) -> typing.Tuple[Number, Number]:
+def calculate_import_export(
+    seconds_since_previous: Number, power1: Number, power2: Number
+) -> typing.Tuple[Number, Number]:
     try:
-        log.MainLogger().debug("simcount Berechnungsgrundlage: vergangene Zeit [s]"+str(seconds_since_previous)+", vorherige Leistung[W]: "+str(power1)+", aktuelle Leistung[W]: "+str(power2))
+        log.MainLogger().debug(
+            "simcount Berechnungsgrundlage: vergangene Zeit [s]" + str(seconds_since_previous) +
+            ", vorherige Leistung[W]: " + str(power1) + ", aktuelle Leistung[W]: " + str(power2)
+        )
         power_low = min(power1, power2)
         power_high = max(power1, power2)
         gradient = (power_high - power_low) / seconds_since_previous
-        # Berechnung der Gesamtfläche (ohne Beträge, Fläche unterhalb der x-Achse reduziert die Fläche oberhalb der x-Achse)
+        # Berechnung der Gesamtfläche (ohne Beträge, Fläche unterhalb der x-Achse reduziert die Fläche oberhalb der
+        # x-Achse)
         def energy_function(seconds): return .5 * gradient * seconds ** 2 + power_low * seconds
 
         energy_total = energy_function(seconds_since_previous)

--- a/packages/modules/common/simcount_test.py
+++ b/packages/modules/common/simcount_test.py
@@ -7,7 +7,12 @@ from testutils.mock import ignore_logging
 
 
 class Params:
-    def __init__(self, name: str, seconds: int, power_previous: int, power_present: int, expected_energy: Tuple[Number, Number]):
+    def __init__(self,
+                 name: str,
+                 seconds: int,
+                 power_previous: int,
+                 power_present: int,
+                 expected_energy: Tuple[Number, Number]):
         self.name = name
         self.seconds = seconds
         self.power_previous = power_previous

--- a/packages/modules/common/store.py
+++ b/packages/modules/common/store.py
@@ -1,7 +1,7 @@
 from abc import abstractmethod
-from collections.abc import Iterable 
+from collections.abc import Iterable
 from pathlib import Path
-from typing import Callable, List, Union
+from typing import Callable, Union
 
 try:
     from ..common.module_error import ModuleError, ModuleErrorLevel
@@ -9,7 +9,7 @@ try:
     from ...helpermodules import log
     from ...helpermodules import pub
     from component_state import BatState, CounterState, InverterState
-except:
+except ImportError:
     # for 1.9 compatibility
     import sys
     sys.path.insert(0, str(Path(__file__).resolve().parents[2]))
@@ -38,6 +38,7 @@ def write_to_file(file: str, value, digits: Union[int, None] = None) -> None:
     except Exception as e:
         process_error(e)
 
+
 def get_rounding_function_by_digits(digits: Union[int, None]) -> Callable:
     if digits is None:
         return lambda value: value
@@ -48,7 +49,7 @@ def get_rounding_function_by_digits(digits: Union[int, None]) -> Callable:
 
 
 def pub_to_broker(topic: str, value, digits: Union[int, None] = None) -> None:
-    rounding = get_rounding_function_by_digits(digits)    
+    rounding = get_rounding_function_by_digits(digits)
     try:
         if isinstance(value, list):
             pub.pub(topic, [rounding(v) for v in value])
@@ -56,6 +57,7 @@ def pub_to_broker(topic: str, value, digits: Union[int, None] = None) -> None:
             pub.pub(topic, rounding(value))
     except Exception as e:
         process_error(e)
+
 
 class ValueStore:
     @abstractmethod
@@ -166,7 +168,16 @@ class InverterValueStoreBroker(ValueStore):
         except Exception as e:
             process_error(e)
 
-value_store_classes = Union[BatteryValueStoreRamdisk, BatteryValueStoreBroker, CounterValueStoreRamdisk, CounterValueStoreBroker, InverterValueStoreRamdisk, InverterValueStoreBroker]
+
+value_store_classes = Union[
+    BatteryValueStoreRamdisk,
+    BatteryValueStoreBroker,
+    CounterValueStoreRamdisk,
+    CounterValueStoreBroker,
+    InverterValueStoreRamdisk,
+    InverterValueStoreBroker
+]
+
 
 class ValueStoreFactory:
     def get_storage(self, component_type: str) -> value_store_classes:

--- a/packages/modules/openwb/counter.py
+++ b/packages/modules/openwb/counter.py
@@ -6,7 +6,7 @@ try:
     from ..common import modbus
     from ..common.module_error import ModuleError, ModuleErrorLevel
     from ..openwb_flex.counter import EvuKitFlex
-except:
+except ImportError:
     from helpermodules import log
     from modules.common import modbus
     from modules.common.module_error import ModuleError, ModuleErrorLevel
@@ -42,6 +42,6 @@ class EvuKit(EvuKitFlex):
             self.data["config"]["configuration"]["id"] = id
 
             super().__init__(device_id, self.data["config"], tcp_client)
-        except Exception as e:
+        except Exception:
             log.MainLogger().exception("Fehler im Modul " +
                                        self.data["config"]["components"]["component0"]["name"])

--- a/packages/modules/openwb/device.py
+++ b/packages/modules/openwb/device.py
@@ -6,7 +6,7 @@ try:
     from ...helpermodules import log
     from . import counter
     from. import inverter
-except:
+except ImportError:
     from helpermodules import log
     from modules.common import modbus
     from modules.common import abstract_device
@@ -32,7 +32,7 @@ class Device(abstract_device.AbstractDevice):
     def __init__(self, device: dict) -> None:
         try:
             super().__init__(device, client=None)
-        except Exception as e:
+        except Exception:
             log.MainLogger().exception(
                 "Fehler im Modul "+self.data["config"]["name"])
 
@@ -57,7 +57,7 @@ class Device(abstract_device.AbstractDevice):
             else:
                 raise Exception("illegal component type "+component_type +
                                 ". Allowed values: "+','.join(self.COMPONENT_TYPE_TO_CLASS.keys()))
-        except:
+        except Exception:
             log.MainLogger().exception(
                 "Fehler im Modul "+self.data["config"]["name"])
 
@@ -74,7 +74,7 @@ def read_legacy(argv: List[str]):
     version = int(sys.argv[2])
     try:
         num = int(argv[3])
-    except:
+    except ValueError:
         num = None
 
     device_config = get_default_config()
@@ -98,5 +98,5 @@ def read_legacy(argv: List[str]):
 if __name__ == "__main__":
     try:
         read_legacy(sys.argv)
-    except:
+    except Exception:
         log.MainLogger().exception("Fehler im Modul openwb")

--- a/packages/modules/openwb/inverter.py
+++ b/packages/modules/openwb/inverter.py
@@ -5,7 +5,7 @@ try:
     from ..common import modbus
     from ..common.module_error import ModuleError, ModuleErrorLevel
     from ..openwb_flex.inverter import PvKitFlex
-except:
+except ImportError:
     from helpermodules import log
     from modules.common import modbus
     from modules.common.module_error import ModuleError, ModuleErrorLevel
@@ -39,6 +39,6 @@ class PvKit(PvKitFlex):
             self.data["config"]["configuration"]["id"] = id
 
             super().__init__(device_id, self.data["config"], tcp_client)
-        except Exception as e:
+        except Exception:
             log.MainLogger().exception("Fehler im Modul " +
                                        self.data["config"]["components"]["component0"]["name"])

--- a/packages/modules/openwb_flex/counter.py
+++ b/packages/modules/openwb_flex/counter.py
@@ -4,7 +4,7 @@ try:
     from ..common import modbus
     from ..common.abstract_component import AbstractCounter
     from ..common.component_state import CounterState
-except:
+except ImportError:
     from helpermodules import log
     from modules.common import modbus
     from modules.common.abstract_component import AbstractCounter

--- a/packages/modules/openwb_flex/device.py
+++ b/packages/modules/openwb_flex/device.py
@@ -7,7 +7,7 @@ try:
     from ..common import abstract_device
     from . import counter
     from . import inverter
-except:
+except ImportError:
     from helpermodules import log
     from modules.common import modbus
     from modules.common import abstract_device
@@ -41,7 +41,7 @@ class Device(abstract_device.AbstractDevice):
             port = device["configuration"]["port"]
             client = modbus.ModbusClient(ip_address, port)
             super().__init__(device, client)
-        except Exception as e:
+        except Exception:
             log.MainLogger().exception("Fehler im Modul "+device["name"])
 
     def add_component(self, component_config: dict) -> None:
@@ -65,7 +65,7 @@ def read_legacy(argv: List[str]):
     id = int(argv[5])
     try:
         num = int(argv[6])
-    except:
+    except ValueError:
         num = None
 
     device_config = get_default_config()
@@ -95,5 +95,5 @@ def read_legacy(argv: List[str]):
 if __name__ == "__main__":
     try:
         read_legacy(sys.argv)
-    except Exception as e:
+    except Exception:
         log.MainLogger().exception("Fehler im Modul openwb_flex")

--- a/packages/modules/openwb_flex/inverter.py
+++ b/packages/modules/openwb_flex/inverter.py
@@ -6,7 +6,7 @@ try:
     from ..common import modbus
     from ..common.abstract_component import AbstractInverter
     from ..common.component_state import InverterState
-except:
+except ImportError:
     from helpermodules import log
     from modules.common import modbus
     from modules.common.abstract_component import AbstractInverter
@@ -29,7 +29,9 @@ def get_default_config() -> dict:
 class PvKitFlex(AbstractInverter):
     def __init__(self, device_id: int, component_config: dict, tcp_client: modbus.ModbusClient) -> None:
         try:
-            client = self.kit_version_factory(component_config["configuration"]["version"], component_config["configuration"]["id"], tcp_client)
+            client = self.kit_version_factory(
+                component_config["configuration"]["version"], component_config["configuration"]["id"], tcp_client
+            )
             super().__init__(device_id, component_config, client)
             self.tcp_client = tcp_client
         except Exception as e:
@@ -44,15 +46,15 @@ class PvKitFlex(AbstractInverter):
         version = self.data["config"]["configuration"]["version"]
         if version == 1:
             power_all = sum(power_per_phase)
-        if (power_all > 10):
+        if power_all > 10:
             power_all = power_all*-1
         currents = self.client.get_current()
 
         log.MainLogger().debug("PV-Kit Leistung[W]: "+str(power_all))
         self.tcp_client.close_connection()
         inverter_state = InverterState(
-            power=power_all, 
-            counter=counter, 
+            power=power_all,
+            counter=counter,
             currents=currents
         )
         return inverter_state


### PR DESCRIPTION
Dieser PR behebt die folgenden Dinge über die `flake8` meckert:
```
packages/modules/openwb/inverter.py:8:1: E722 do not use bare 'except'
packages/modules/openwb/inverter.py:42:9: F841 local variable 'e' is assigned to but never used
packages/modules/openwb/device.py:9:1: E722 do not use bare 'except'
packages/modules/openwb/device.py:35:9: F841 local variable 'e' is assigned to but never used
packages/modules/openwb/device.py:60:9: E722 do not use bare 'except'
packages/modules/openwb/device.py:77:5: E722 do not use bare 'except'
packages/modules/openwb/device.py:101:5: E722 do not use bare 'except'
packages/modules/openwb/counter.py:9:1: E722 do not use bare 'except'
packages/modules/openwb/counter.py:45:9: F841 local variable 'e' is assigned to but never used
packages/modules/openwb_flex/inverter.py:9:1: E722 do not use bare 'except'
packages/modules/openwb_flex/inverter.py:32:121: E501 line too long (144 > 120 characters)
packages/modules/openwb_flex/inverter.py:54:29: W291 trailing whitespace
packages/modules/openwb_flex/inverter.py:55:29: W291 trailing whitespace
packages/modules/openwb_flex/device.py:10:1: E722 do not use bare 'except'
packages/modules/openwb_flex/device.py:44:9: F841 local variable 'e' is assigned to but never used
packages/modules/openwb_flex/device.py:68:5: E722 do not use bare 'except'
packages/modules/openwb_flex/device.py:98:5: F841 local variable 'e' is assigned to but never used
packages/modules/openwb_flex/counter.py:7:1: E722 do not use bare 'except'
packages/modules/common/sdm630.py:2:1: F401 'sys' imported but unused
packages/modules/common/sdm630.py:8:1: E722 do not use bare 'except'
packages/modules/common/sdm630.py:59:22: E225 missing whitespace around operator
packages/modules/common/abstract_device.py:7:1: E722 do not use bare 'except'
packages/modules/common/abstract_device.py:22:9: E722 do not use bare 'except'
packages/modules/common/abstract_device.py:27:121: E501 line too long (144 > 120 characters)
packages/modules/common/abstract_device.py:28:9: E722 do not use bare 'except'
packages/modules/common/abstract_device.py:35:121: E501 line too long (136 > 120 characters)
packages/modules/common/abstract_device.py:36:9: F841 local variable 'e' is assigned to but never used
packages/modules/common/abstract_device.py:50:121: E501 line too long (159 > 120 characters)
packages/modules/common/abstract_device.py:52:121: E501 line too long (154 > 120 characters)
packages/modules/common/abstract_device.py:53:9: E722 do not use bare 'except'
packages/modules/common/modbus.py:2:121: E501 line too long (125 > 120 characters)
packages/modules/common/modbus.py:4:1: F401 'codecs' imported but unused
packages/modules/common/modbus.py:9:1: F401 'typing.List' imported but unused
packages/modules/common/modbus.py:11:1: F401 'struct' imported but unused
packages/modules/common/modbus.py:16:1: E722 do not use bare 'except'
packages/modules/common/modbus.py:85:121: E501 line too long (163 > 120 characters)
packages/modules/common/modbus.py:88:121: E501 line too long (208 > 120 characters)
packages/modules/common/store.py:2:37: W291 trailing whitespace
packages/modules/common/store.py:4:1: F401 'typing.List' imported but unused
packages/modules/common/store.py:12:1: E722 do not use bare 'except'
packages/modules/common/store.py:41:1: E302 expected 2 blank lines, found 1
packages/modules/common/store.py:51:55: W291 trailing whitespace
packages/modules/common/store.py:60:1: E302 expected 2 blank lines, found 1
packages/modules/common/store.py:169:1: E305 expected 2 blank lines after class or function definition, found 1
packages/modules/common/store.py:169:121: E501 line too long (182 > 120 characters)
packages/modules/common/store.py:171:1: E302 expected 2 blank lines, found 1
packages/modules/common/store.py:182:29: W292 no newline at end of file
packages/modules/common/component_state.py:13:121: E501 line too long (188 > 120 characters)
packages/modules/common/module_error.py:8:1: E722 do not use bare 'except'
packages/modules/common/module_error.py:10:5: F401 'sys' imported but unused
packages/modules/common/module_error.py:15:1: E302 expected 2 blank lines, found 1
packages/modules/common/module_error.py:28:121: E501 line too long (158 > 120 characters)
packages/modules/common/module_error.py:45:9: E722 do not use bare 'except'
packages/modules/common/mpm3pm.py:6:1: E722 do not use bare 'except'
packages/modules/common/mpm3pm.py:15:9: F841 local variable 'unit' is assigned to but never used
packages/modules/common/mpm3pm.py:15:13: E225 missing whitespace around operator
packages/modules/common/lovato.py:9:1: E722 do not use bare 'except'
packages/modules/common/lovato.py:11:5: F401 'helpermodules.log' imported but unused
packages/modules/common/lovato.py:19:9: F841 local variable 'unit' is assigned to but never used
packages/modules/common/lovato.py:19:13: E225 missing whitespace around operator
packages/modules/common/lovato.py:41:121: E501 line too long (126 > 120 characters)
packages/modules/common/lovato.py:55:59: E231 missing whitespace after ','
packages/modules/common/lovato.py:55:61: E201 whitespace after '['
packages/modules/common/simcount_test.py:10:121: E501 line too long (129 > 120 characters)
packages/modules/common/abstract_component.py:2:1: F401 'typing.List' imported but unused
packages/modules/common/abstract_component.py:13:1: E722 do not use bare 'except'
packages/modules/common/abstract_component.py:26:121: E501 line too long (152 > 120 characters)
packages/modules/common/abstract_component.py:32:121: E501 line too long (123 > 120 characters)
packages/modules/common/abstract_component.py:35:9: F841 local variable 'e' is assigned to but never used
packages/modules/common/abstract_component.py:53:121: E501 line too long (163 > 120 characters)
packages/modules/common/abstract_component.py:57:121: E501 line too long (165 > 120 characters)
packages/modules/common/abstract_component.py:59:121: E501 line too long (144 > 120 characters)
packages/modules/common/abstract_component.py:74:121: E501 line too long (152 > 120 characters)
packages/modules/common/abstract_component.py:86:121: E501 line too long (152 > 120 characters)
packages/modules/common/abstract_component.py:98:121: E501 line too long (152 > 120 characters)
packages/modules/common/simcount.py:11:1: F401 'pathlib.Path' imported but unused
packages/modules/common/simcount.py:18:1: E722 do not use bare 'except'
packages/modules/common/simcount.py:24:1: W293 blank line contains whitespace
packages/modules/common/simcount.py:25:1: E302 expected 2 blank lines, found 1
packages/modules/common/simcount.py:25:19: E201 whitespace after '('
packages/modules/common/simcount.py:28:1: E302 expected 2 blank lines, found 1
packages/modules/common/simcount.py:38:121: E501 line too long (128 > 120 characters)
packages/modules/common/simcount.py:63:17: E722 do not use bare 'except'
packages/modules/common/simcount.py:68:17: E722 do not use bare 'except'
packages/modules/common/simcount.py:74:121: E501 line too long (198 > 120 characters)
packages/modules/common/simcount.py:87:121: E501 line too long (162 > 120 characters)
packages/modules/common/simcount.py:90:121: E501 line too long (123 > 120 characters)
packages/modules/common/simcount.py:93:121: E501 line too long (197 > 120 characters)
packages/modules/common/simcount.py:104:33: E231 missing whitespace after ':'
packages/modules/common/simcount.py:151:41: E711 comparison to None should be 'if cond is None:'
packages/modules/common/simcount.py:167:121: E501 line too long (128 > 120 characters)
packages/modules/common/simcount.py:196:121: E501 line too long (168 > 120 characters)
packages/modules/common/simcount.py:212:121: E501 line too long (162 > 120 characters)
packages/modules/common/simcount.py:215:121: E501 line too long (123 > 120 characters)
packages/modules/common/simcount.py:216:121: E501 line too long (197 > 120 characters)
packages/modules/common/simcount.py:227:121: E501 line too long (124 > 120 characters)
packages/modules/common/simcount.py:229:121: E501 line too long (191 > 120 characters)
packages/modules/common/simcount.py:233:121: E501 line too long (124 > 120 characters)
packages/modules/alpha_ess/inverter.py:2:1: F401 'time' imported but unused
packages/modules/alpha_ess/inverter.py:10:1: E722 do not use bare 'except'
packages/modules/alpha_ess/inverter.py:61:121: E501 line too long (154 > 120 characters)
packages/modules/alpha_ess/bat.py:9:1: E722 do not use bare 'except'
packages/modules/alpha_ess/bat.py:46:121: E501 line too long (143 > 120 characters)
packages/modules/alpha_ess/bat.py:52:121: E501 line too long (126 > 120 characters)
packages/modules/alpha_ess/device.py:5:1: F401 'typing.Union' imported but unused
packages/modules/alpha_ess/device.py:14:1: E722 do not use bare 'except'
packages/modules/alpha_ess/device.py:42:9: F841 local variable 'e' is assigned to but never used
packages/modules/alpha_ess/device.py:60:5: E722 do not use bare 'except'
packages/modules/alpha_ess/device.py:69:121: E501 line too long (128 > 120 characters)
packages/modules/alpha_ess/device.py:82:5: E722 do not use bare 'except'
packages/modules/alpha_ess/counter.py:11:1: E722 do not use bare 'except'
packages/modules/alpha_ess/counter.py:75:9: F841 local variable 'e' is assigned to but never used
packages/modules/alpha_ess/counter.py:106:9: F841 local variable 'e' is assigned to but never used
packages/helpermodules/compatibility.py:3:1: E302 expected 2 blank lines, found 1
packages/helpermodules/pub.py:15:121: E501 line too long (125 > 120 characters)
packages/helpermodules/pub.py:22:5: F841 local variable 'e' is assigned to but never used
packages/helpermodules/pub.py:42:5: F841 local variable 'e' is assigned to but never used
packages/helpermodules/pub.py:52:5: F841 local variable 'e' is assigned to but never used
packages/helpermodules/pub.py:71:20: E712 comparison to True should be 'if cond is True:' or 'if cond:'
packages/helpermodules/pub.py:75:5: F841 local variable 'e' is assigned to but never used
packages/helpermodules/log.py:10:1: F401 'pathlib.Path' imported but unused
packages/helpermodules/log.py:14:1: E722 do not use bare 'except'
packages/helpermodules/log.py:71:13: E722 do not use bare 'except'
```