### PR TITLE
Fix: Also catch `ValueError` when importing

### DIFF
--- a/packages/helpermodules/log.py
+++ b/packages/helpermodules/log.py
@@ -10,7 +10,7 @@ from datetime import datetime, timezone
 
 try:
     from . import compatibility
-except ImportError:
+except (ImportError, ValueError):
     from helpermodules import compatibility
 
 debug_logger = None

--- a/packages/modules/alpha_ess/bat.py
+++ b/packages/modules/alpha_ess/bat.py
@@ -6,7 +6,7 @@ try:
     from ..common import modbus
     from ..common.abstract_component import AbstractBat
     from ..common.component_state import BatState
-except ImportError:
+except (ImportError, ValueError):
     from helpermodules import log
     from modules.common import modbus
     from modules.common.abstract_component import AbstractBat

--- a/packages/modules/alpha_ess/counter.py
+++ b/packages/modules/alpha_ess/counter.py
@@ -8,7 +8,7 @@ try:
     from ..common.abstract_component import AbstractCounter
     from ..common.component_state import CounterState
     from ..common.module_error import ModuleError
-except ImportError:
+except (ImportError, ValueError):
     from helpermodules import log
     from modules.common import modbus
     from modules.common.abstract_component import AbstractCounter

--- a/packages/modules/alpha_ess/device.py
+++ b/packages/modules/alpha_ess/device.py
@@ -11,7 +11,7 @@ try:
     from . import bat
     from . import counter
     from . import inverter
-except ImportError:
+except (ImportError, ValueError):
     from helpermodules import log
     from modules.common import modbus
     from modules.common import abstract_device

--- a/packages/modules/alpha_ess/inverter.py
+++ b/packages/modules/alpha_ess/inverter.py
@@ -6,7 +6,7 @@ try:
     from ..common.abstract_component import AbstractInverter
     from ..common.component_state import InverterState
     from ..common.module_error import ModuleError
-except ImportError:
+except (ImportError, ValueError):
     from helpermodules import log
     from modules.common import modbus
     from modules.common.abstract_component import AbstractInverter

--- a/packages/modules/common/abstract_component.py
+++ b/packages/modules/common/abstract_component.py
@@ -10,7 +10,7 @@ try:
     from ..common import store
     from ..common.module_error import ModuleError, ModuleErrorLevel
     from component_state import BatState, CounterState, InverterState
-except ImportError:
+except (ImportError, ValueError):
     from helpermodules import log
     from modules.common import modbus
     from modules.common import lovato

--- a/packages/modules/common/abstract_device.py
+++ b/packages/modules/common/abstract_device.py
@@ -4,7 +4,7 @@ try:
     from ...helpermodules import log
     from ..common import modbus
     from ..common.module_error import ModuleError
-except ImportError:
+except (ImportError, ValueError):
     from helpermodules import log
     from modules.common import modbus
     from modules.common.module_error import ModuleError

--- a/packages/modules/common/lovato.py
+++ b/packages/modules/common/lovato.py
@@ -5,7 +5,7 @@ from typing import List, Tuple
 try:
     from ..common import modbus
     from ..common.module_error import ModuleError, ModuleErrorLevel
-except ImportError:
+except (ImportError, ValueError):
     # for 1.9 compatibility
     from modules.common import modbus
     from modules.common.module_error import ModuleError, ModuleErrorLevel

--- a/packages/modules/common/modbus.py
+++ b/packages/modules/common/modbus.py
@@ -15,7 +15,7 @@ from pymodbus.payload import BinaryPayloadDecoder
 try:
     from ...helpermodules import log
     from ..common.module_error import ModuleError, ModuleErrorLevel
-except ImportError:
+except (ImportError, ValueError):
     from helpermodules import log
     from modules.common.module_error import ModuleError, ModuleErrorLevel
 

--- a/packages/modules/common/module_error.py
+++ b/packages/modules/common/module_error.py
@@ -5,7 +5,7 @@ try:
     from ...helpermodules import compatibility
     from ...helpermodules import log
     from ...helpermodules import pub
-except ImportError:
+except (ImportError, ValueError):
     # for 1.9 compatibility
     from helpermodules import compatibility
     from helpermodules import log

--- a/packages/modules/common/mpm3pm.py
+++ b/packages/modules/common/mpm3pm.py
@@ -3,7 +3,7 @@ from typing import List, Tuple
 try:
     from ..common import modbus
     from ..common.module_error import ModuleError, ModuleErrorLevel
-except ImportError:
+except (ImportError, ValueError):
     # for 1.9 compatibility
     from modules.common import modbus
     from modules.common.module_error import ModuleError, ModuleErrorLevel

--- a/packages/modules/common/sdm630.py
+++ b/packages/modules/common/sdm630.py
@@ -4,7 +4,7 @@ from typing import List, Tuple
 try:
     from ..common import modbus
     from ..common.module_error import ModuleError, ModuleErrorLevel
-except ImportError:
+except (ImportError, ValueError):
     # for 1.9 compatibility
     from modules.common import modbus
     from modules.common.module_error import ModuleError, ModuleErrorLevel

--- a/packages/modules/common/simcount.py
+++ b/packages/modules/common/simcount.py
@@ -15,7 +15,7 @@ try:
     from ...helpermodules import compatibility
     from ...helpermodules import log
     from ...helpermodules import pub
-except ImportError:
+except (ImportError, ValueError):
     # for 1.9 compatibility
     from helpermodules import compatibility
     from helpermodules import log

--- a/packages/modules/common/store.py
+++ b/packages/modules/common/store.py
@@ -9,7 +9,7 @@ try:
     from ...helpermodules import log
     from ...helpermodules import pub
     from component_state import BatState, CounterState, InverterState
-except ImportError:
+except (ImportError, ValueError):
     # for 1.9 compatibility
     import sys
     sys.path.insert(0, str(Path(__file__).resolve().parents[2]))

--- a/packages/modules/openwb/counter.py
+++ b/packages/modules/openwb/counter.py
@@ -6,7 +6,7 @@ try:
     from ..common import modbus
     from ..common.module_error import ModuleError, ModuleErrorLevel
     from ..openwb_flex.counter import EvuKitFlex
-except ImportError:
+except (ImportError, ValueError):
     from helpermodules import log
     from modules.common import modbus
     from modules.common.module_error import ModuleError, ModuleErrorLevel

--- a/packages/modules/openwb/device.py
+++ b/packages/modules/openwb/device.py
@@ -6,7 +6,7 @@ try:
     from ...helpermodules import log
     from . import counter
     from. import inverter
-except ImportError:
+except (ImportError, ValueError):
     from helpermodules import log
     from modules.common import modbus
     from modules.common import abstract_device

--- a/packages/modules/openwb/inverter.py
+++ b/packages/modules/openwb/inverter.py
@@ -5,7 +5,7 @@ try:
     from ..common import modbus
     from ..common.module_error import ModuleError, ModuleErrorLevel
     from ..openwb_flex.inverter import PvKitFlex
-except ImportError:
+except (ImportError, ValueError):
     from helpermodules import log
     from modules.common import modbus
     from modules.common.module_error import ModuleError, ModuleErrorLevel

--- a/packages/modules/openwb_flex/counter.py
+++ b/packages/modules/openwb_flex/counter.py
@@ -4,7 +4,7 @@ try:
     from ..common import modbus
     from ..common.abstract_component import AbstractCounter
     from ..common.component_state import CounterState
-except ImportError:
+except (ImportError, ValueError):
     from helpermodules import log
     from modules.common import modbus
     from modules.common.abstract_component import AbstractCounter

--- a/packages/modules/openwb_flex/device.py
+++ b/packages/modules/openwb_flex/device.py
@@ -7,7 +7,7 @@ try:
     from ..common import abstract_device
     from . import counter
     from . import inverter
-except ImportError:
+except (ImportError, ValueError):
     from helpermodules import log
     from modules.common import modbus
     from modules.common import abstract_device

--- a/packages/modules/openwb_flex/inverter.py
+++ b/packages/modules/openwb_flex/inverter.py
@@ -6,7 +6,7 @@ try:
     from ..common import modbus
     from ..common.abstract_component import AbstractInverter
     from ..common.component_state import InverterState
-except ImportError:
+except (ImportError, ValueError):
     from helpermodules import log
     from modules.common import modbus
     from modules.common.abstract_component import AbstractInverter


### PR DESCRIPTION
Follow-up für #1695 ... Das war leider noch nicht ganz fertig. Einen Fehler habe ich noch gefunden.

Nämlich habe ich gerade noch gelernt, dass "attempted relative import beyond top-level package" ein `ValueError` und kein `ImportError` ist. Mysterious aus meiner Sicht, aber was will man machen.

Das sollte es jetzt hoffentlich gewesen sein. Nur mergen, wenn der automatische Check grün wird, sonst stimmt noch was nicht...