### PR TITLE
fix bezug_powerwall cookie handling

### DIFF
--- a/modules/bezug_powerwall/powerwall.py
+++ b/modules/bezug_powerwall/powerwall.py
@@ -20,7 +20,7 @@ speicherpwip = str(sys.argv[5])
 ramdiskdir = base_dir+"/ramdisk"
 module = "EVU"
 logfile = ramdiskdir+"/openWB.log"
-cookie_file = ramdiskdir+"/powerwall_cookie.txt"
+cookie_file = ramdiskdir+"/powerwall_bezug_cookie.txt"
 cookie = ""
 
 
@@ -79,8 +79,9 @@ if speicherpwloginneeded == 1:
                 f.write(str(requests.utils.dict_from_cookiejar(cookie)))
     else:
         DebugLog("Using saved login cookie.")
-    with open(cookie_file, "r") as f:
-        cookie = f.read()
+        with open(cookie_file, "r") as f:
+            # cookie = f.read()
+            cookie = requests.utils.cookiejar_from_dict(f.read())
 
 answer = requests.get("https://"+speicherpwip+"/api/meters/aggregates", cookies = cookie, verify=False, timeout=5).json()
 try:


### PR DESCRIPTION
- separate cookie files for shell and python skripts (maybe different format!)
- fix reading saved cookie from file