### PR TITLE
Optimierung Fronius WR mit S0-Zähler

### DIFF
--- a/modules/bezug_fronius_s0/fronius_s0.py
+++ b/modules/bezug_fronius_s0/fronius_s0.py
@@ -1,6 +1,7 @@
 #!/usr/bin/env python3
 # coding: utf8
-
+from datetime import datetime, timezone
+import os
 import re
 import requests
 import sys
@@ -13,7 +14,21 @@ import traceback
 primo = str(sys.argv[1])
 ip_address = str(sys.argv[2])
 
-response = requests.get('http://'+ip_address+'/solar_api/v1/GetPowerFlowRealtimeData.fcgi', timeout = 5).json()
+Debug = int(os.environ.get('debug'))
+myPid = str(os.getpid())
+
+def DebugLog(level, message):
+    if Debug >= level:
+        local_time = datetime.now(timezone.utc).astimezone()
+        print(local_time.strftime(format="%Y-%m-%d %H:%M:%S") + ": PID: " + myPid + ": " + message)
+
+DebugLog(2, 'Fronius S0 Primo: ' + primo)
+DebugLog(2, 'Fronius SM IP: ' + ip_address)
+
+response_fi = requests.get('http://'+ip_address+'/solar_api/v1/GetPowerFlowRealtimeData.fcgi', timeout = 5)
+response = response_fi.json()
+DebugLog(1, 'response_fi: ' + str(response_fi))
+DebugLog(2, 'response_fi_data: ' + str(response))
 try:
     if primo == str(1):
         wattbezug=int(response["Body"]["Data"]["Site"]["P_Grid"])
@@ -45,11 +60,14 @@ f.close()
 # bei Smartmeter im Verbrauchszweig  entspricht das dem Gesamtverbrauch
 params = (('Scope', 'System'),)
 
-kwhtmp = requests.get('http://'+ip_address+'/solar_api/v1/GetMeterRealtimeData.cgi', params=params, timeout = 5).json()
+response_s0 = requests.get('http://'+ip_address+'/solar_api/v1/GetMeterRealtimeData.cgi', params=params, timeout = 5)
+response = response_s0.json()
+DebugLog(1, 'response_s0: ' + str(response_fi))
+DebugLog(2, 'response_s0_data: ' + str(response))
 # jq-Funktion funktioniert hier leider nicht,  wegen "0" als Bezeichnung
 try:
-    for location in kwhtmp["Body"]["Data"]:
-        ikwh = str(kwhtmp["Body"]["Data"][location]["EnergyReal_WAC_Minus_Absolute"])
+    for location in response["Body"]["Data"]:
+        ikwh = str(response["Body"]["Data"][location]["EnergyReal_WAC_Minus_Absolute"])
 except:
     traceback.print_exc()
 ikwh = ikwh.replace(" ", "")
@@ -67,8 +85,8 @@ f.close()
 # bei Smartmeter im Verbrauchsweig immer 0
 #ekwh=$(echo ${kwhtmp##*EnergyReal_WAC_Plus_Absolute} | sed 's/,.*//' | tr -d ' ' | tr -d ':' | tr -d '\"')
 try:
-    for location in kwhtmp["Body"]["Data"]:
-        ekwh = str(kwhtmp["Body"]["Data"][location]["EnergyReal_WAC_Plus_Absolute"])
+    for location in response["Body"]["Data"]:
+        ekwh = str(response["Body"]["Data"][location]["EnergyReal_WAC_Plus_Absolute"])
 except:
     traceback.print_exc()
 ekwh = ekwh.split(",")[0]

--- a/modules/bezug_fronius_s0/main.sh
+++ b/modules/bezug_fronius_s0/main.sh
@@ -1,5 +1,29 @@
 #!/bin/bash
+OPENWBBASEDIR=$(cd `dirname $0`/../../ && pwd)
+RAMDISKDIR="$OPENWBBASEDIR/ramdisk"
+MODULEDIR=$(cd `dirname $0` && pwd)
+#DMOD="EVU"
+DMOD="MAIN"
 
-sudo python3 /var/www/html/openWB/modules/bezug_fronius_s0/fronius_s0.py $froniusprimo $wrfroniusip
+if [ $DMOD == "MAIN" ]; then
+    MYLOGFILE="$RAMDISKDIR/openWB.log"
+else
+    MYLOGFILE="$RAMDISKDIR/evu_json.log"
+fi
+
+# check if config file is already in env
+if [[ -z "$debug" ]]; then
+	echo "bezug_fronius_s0: Seems like openwb.conf is not loaded. Reading file."
+	# try to load config
+	. $OPENWBBASEDIR/loadconfig.sh
+	# load helperFunctions
+	. $OPENWBBASEDIR/helperFunctions.sh
+fi
+
+ret=$(python3 /var/www/html/openWB/modules/bezug_fronius_s0/fronius_s0.py "${froniusprimo}" "${wrfroniusip}" &>>$MYLOGFILE)
+ret=$?
+
+openwbDebugLog ${DMOD} 2 "RET: ${ret}"
+
 wattbezug=$(</var/www/html/openWB/ramdisk/wattbezug)
 echo $wattbezug


### PR DESCRIPTION
Wenn die Abfrage der Zählerdaten eines Fronius WR mit S0-Zähler keine absoluten Werte für Netzbezug und -einspeisung liefert, können sie als Näherung aus den Netzdaten des WR selber berechnet werden.

Es wird die aktuelle Netzleistung als konstant für das letzte Regelintervall (10s) angenommen und entsprechend zur bezogenen bzw. eingespeisten Energie hinzugerechnet.

Siehe Diskussionen:

- https://openwb.de/forum/viewtopic.php?f=4&t=4290
- https://openwb.de/forum/viewtopic.php?f=9&t=4393