### PR TITLE
WR2 Shelly...

### DIFF
--- a/loadvars.sh
+++ b/loadvars.sh
@@ -492,14 +492,16 @@ loadvars(){
 		speichersoc=$(echo $speichersoc | sed 's/\..*$//')
 		speichervorhanden="1"
 		echo 1 > /var/www/html/openWB/ramdisk/speichervorhanden
-		if [[ $speichermodul == "speicher_e3dc" ]] ; then
+		if [[ $pvwattmodul == "none" ]] && [[ $speichermodul == "speicher_e3dc" ]] ; then
 			pvwatt=$(</var/www/html/openWB/ramdisk/pvwatt)
+			echo $pvwatt > /var/www/html/openWB/ramdisk/pvallwatt
 			echo 1 > /var/www/html/openWB/ramdisk/pv1vorhanden
 			pv1vorhanden="1"
 
 		fi
 		if [[ $speichermodul == "speicher_sonneneco" ]] ; then
 			pvwatt=$(</var/www/html/openWB/ramdisk/pvwatt)
+			echo $pvwatt > /var/www/html/openWB/ramdisk/pvallwatt
 			echo 1 > /var/www/html/openWB/ramdisk/pv1vorhanden
 			pv1vorhanden="1"
 		fi
@@ -1058,9 +1060,12 @@ loadvars(){
 	if [[ $pvwattmodul == "wr_kostalpiko" ]] || [[ $pvwattmodul == "wr_siemens" ]] || [[ $pvwattmodul == "wr_rct" ]]|| [[ $pvwattmodul == "wr_solarwatt" ]] || [[ $pvwattmodul == "wr_shelly" ]] || [[ $pvwattmodul == "wr_sungrow" ]] || [[ $pvwattmodul == "wr_huawei" ]] || [[ $pvwattmodul == "wr_powerdog" ]] || [[ $pvwattmodul == "wr_lgessv1" ]]|| [[ $pvwattmodul == "wr_kostalpikovar2" ]]; then
 		usesimpv=1
 	fi
+	if [[ $pv2wattmodul == "wr2_shelly" ]]; then
+		usesimpv=1
+	fi
 	if [[ $usesimpv == "1" ]]; then
 		ra='^-?[0-9]+$'
-		watt3=$(</var/www/html/openWB/ramdisk/pvwatt)
+		watt3=$(</var/www/html/openWB/ramdisk/pvallwatt)
 		if [[ -e /var/www/html/openWB/ramdisk/pvwatt0pos ]]; then
 			importtemp=$(</var/www/html/openWB/ramdisk/pvwatt0pos)
 		else
@@ -1082,6 +1087,12 @@ loadvars(){
 			echo $exporttemp > /var/www/html/openWB/ramdisk/pvwatt0neg
 		fi
 		sudo python /var/www/html/openWB/runs/simcount.py $watt3 pv pvposkwh pvkwh
+		if [[ $pv2vorhanden == "1" ]]; then
+			temppvkwh=$(</var/www/html/openWB/ramdisk/pvkwh)
+			echo $temppvkwh > /var/www/html/openWB/ramdisk/pvallwh
+			echo $temppvkwh > /var/www/html/openWB/ramdisk/pv2kwh
+		fi
+
 		importtemp1=$(</var/www/html/openWB/ramdisk/pvwatt0pos)
 		exporttemp1=$(</var/www/html/openWB/ramdisk/pvwatt0neg)
 		if [[ $importtemp !=  $importtemp1 ]]; then

--- a/modules/wr2_shelly/main.sh
+++ b/modules/wr2_shelly/main.sh
@@ -1,0 +1,5 @@
+#!/bin/bash
+
+sudo python3 /var/www/html/openWB/modules/wr2_shelly/shellywr.py $pv2ip pv2watt 
+pvwatt2=$(</var/www/html/openWB/ramdisk/pv2watt)
+echo $pvwatt2

--- a/modules/wr2_shelly/shellywr.py
+++ b/modules/wr2_shelly/shellywr.py
@@ -1,0 +1,45 @@
+#!/usr/bin/python3
+import sys
+import os
+import time
+import json
+import getopt
+import socket
+import struct
+import codecs
+import binascii
+import urllib.request
+
+def totalPowerFromShellyJson(answer):
+    if 'meters' in answer:
+        meters = answer['meters'] # shelly
+    else:
+        meters = answer['emeters'] # shellyEM & shelly3EM
+    total = 0
+    # shellyEM has one meter, shelly3EM has three meters:
+    for meter in meters:
+        total = total + meter['power']
+    return int(total)
+    
+ipadr=str(sys.argv[1])
+fname=str(sys.argv[2])
+
+aktpower = 0
+
+# Versuche Daten von Shelly abzurufen.
+try:
+    answer = json.loads(str(urllib.request.urlopen("http://"+str(ipadr)+"/status", timeout=3).read().decode("utf-8")))
+    f = open('/var/www/html/openWB/ramdisk/shelly_wr_ret.' + str(ipadr) , 'w')
+    f.write(str(answer))
+    f.close()
+except:
+    pass
+# Versuche Werte aus der Antwort zu extrahieren.
+try:
+    aktpower = totalPowerFromShellyJson(answer) * -1
+except:
+    aktpower = 0
+
+f1 = open('/var/www/html/openWB/ramdisk/' + str(fname), 'w')
+f1.write(str(aktpower))
+f1.close()

--- a/web/settings/modulconfigpv.php
+++ b/web/settings/modulconfigpv.php
@@ -1047,6 +1047,7 @@
 										<option <?php if($pv2wattmodulold == "wr2_mqtt") echo "selected" ?> value="wr2_mqtt">MQTT</option>
 										<option <?php if($pv2wattmodulold == "wr2_pvkitflex") echo "selected" ?> value="wr2_pvkitflex">openWB PV Kit flexible IP</option>
 										<option <?php if($pv2wattmodulold == "wr2_ethsdm120") echo "selected" ?> value="wr2_ethsdm120">SDM120 an Netzwerk Modbus Adapter</option>
+										<option <?php if($pv2wattmodulold == "wr2_shelly") echo "selected" ?> value="wr2_shelly">Shelly</option>
 									</optgroup>
 								</select>
 							</div>
@@ -1282,6 +1283,9 @@
 								}
 								if($('#pv2wattmodul').val() == 'wr2_solarlog')   {
 									showSection('#pv2solarlogdiv');
+								}
+								if($('#pv2wattmodul').val() == 'wr2_shelly') {
+									showSection('#pv2ipdiv');
 								}
 							}
 							$(function() {


### PR DESCRIPTION
Neu wird am WR2 auch shelly unterstützt. Zusätzlich wurde die automatische Zählerstanderzeugung für PV (Simcount) angepasst:
Wenn zwei WR vorhanden sind, und  einer der beiden WR keinen Zählerstand liefert, wird simcount für beide WR auf der gesamten Pv Leistung gerechnet.
Als Input für Simcount dient neu pvallwatt (Summe aus pvwatt und pv2watt), der gerechnete Zähler wird dann auf pvkw, pvallwh und pv2kwh kopiert. Der shelly zugriff wurde auf python3 umgestellt (nur WR2)
E3DC PV Leistung wird nur noch dann genommen wenn kein WR definiert ist.