### PR TITLE
shelly plus und shelly in Smarthome

### DIFF
--- a/modules/smarthome/shelly/watt.py
+++ b/modules/smarthome/shelly/watt.py
@@ -35,24 +35,61 @@ temp1 = '0.0'
 temp2 = '0.0'
 aktpower = 0
 relais = 0
+gen = '1'
 
+# test dic
+g_dictionary = {"gen": 1}
+
+a_dictionary = {"switch:0":{"id": 0, "source": "init", "output": True, "apower": 55.000, "voltage": 218.794,"aenergy": {"total":4327.45,"minute_ts":1637430901},"temperature":{"tC":49.1, "tF":120.3}}}
+
+# test dic ende
+# lesen endpoint, gen bestimmem. gen 1 hat unter Umstaenden keinen Eintrag
+fname =   '/var/www/html/openWB/ramdisk/smarthome_device_ret' + str(devicenumber) + '_shelly_info'
+fnameg =   '/var/www/html/openWB/ramdisk/smarthome_device_ret' + str(devicenumber) + '_shelly_infog'
+if os.path.isfile(fnameg):
+    f = open(fnameg, 'r')
+    gen=str(f.read())
+    f.close()
+else:   
+    answergen= json.loads(str(urllib.request.urlopen("http://"+str(ipadr)+"/shelly", timeout=3).read().decode("utf-8")))
+    #answergen.update(g_dictionary)
+    f = open(fname, 'w')
+    json.dump(answergen,f)
+    f.close()
+    if 'gen' in answergen:
+        gen = str(int(answergen['gen']))
+    f = open(fnameg, 'w')
+    f.write(str(gen))
+    f.close()
 # Versuche Daten von Shelly abzurufen.
 try:
-    answer = json.loads(str(urllib.request.urlopen("http://"+str(ipadr)+"/status", timeout=3).read().decode("utf-8")))
+    if (gen == "1"):
+        answer = json.loads(str(urllib.request.urlopen("http://"+str(ipadr)+"/status", timeout=3).read().decode("utf-8")))
+        #answer.update(a_dictionary)  
+        # fake new gen
+        #gen = '2'
+    else:
+        answer = json.loads(str(urllib.request.urlopen("http://"+str(ipadr)+"/rpc/Shelly.GetStatus", timeout=3).read().decode("utf-8")))
     f = open('/var/www/html/openWB/ramdisk/smarthome_device_ret' + str(devicenumber) + '_shelly', 'w')
     f.write(str(answer))
     f.close()
 except:
     print("failed to connect to device on " +  ipadr + ", setting all values to 0")
-
+#answer.update(a_dictionary)
 # Versuche Werte aus der Antwort zu extrahieren.
 try:
-    aktpower = totalPowerFromShellyJson(answer)
+    if (gen == "1"):
+        aktpower = totalPowerFromShellyJson(answer)
+    else:
+        aktpower = int(answer['switch:0'] ['apower'])
 except:
     pass
 
 try:
-    relais = int(answer['relays'][0]['ison'])
+    if (gen == "1"):
+        relais = int(answer['relays'][0]['ison'])
+    else:
+        relais = int(answer['switch:0'] ['output'])
 except:
     pass
 


### PR DESCRIPTION
Neu wird beim Shelly einmalig (pro reboot) die Version (Gen 1 oder Gen 2) abgefragt. Die Leistung und der Switchstatus sind bei Gen 2 von shelly anders übergeben.