### PR TITLE
Fix for dark/standard theme: update pricechart on max price change

### DIFF
--- a/web/themes/dark/processAllMqttMsg.js
+++ b/web/themes/dark/processAllMqttMsg.js
@@ -94,6 +94,7 @@ function processETProviderMessages(mqttmsg, mqttpayload) {
 	}
 	else if ( mqttmsg == 'openWB/global/awattar/MaxPriceForCharging' ) {
 		setInputValue('MaxPriceForCharging', mqttpayload);
+		loadElectricityPriceChart();
 	}
 	else if ( mqttmsg == 'openWB/global/awattar/ActualPriceForCharging' ) {
 		$('#aktuellerStrompreis').text(parseFloat(mqttpayload).toLocaleString(undefined, {maximumFractionDigits: 2}) + ' ct/kWh');


### PR DESCRIPTION
Lädt das Price Chart neu, wenn der maximale Preis auf einem anderen Screen, z.B. Display, geändert wurde. Farben werden damit jetzt korrekt angezeigt, wenn der Maxpreis auf dem Display geändert wurde.