### PR TITLE
fixup for #1765: unused parameter "debug level" prevents evnotify from working

### DIFF
--- a/modules/soc_evnotify/main.sh
+++ b/modules/soc_evnotify/main.sh
@@ -66,7 +66,7 @@ if (( soctimer < 4 )); then
 else
 	openwbDebugLog ${DMOD} 1 "Lp$CHARGEPOINT: Requesting SoC"
 	echo 0 > $soctimerfile
-	pythonOut=$(python3 "$SCRIPT_DIR/evnotify.py" "$akey" "$token" "$CHARGEPOINT" "$DEBUGLEVEL" 2>&1)
+	pythonOut=$(python3 "$SCRIPT_DIR/evnotify.py" "$akey" "$token" "$CHARGEPOINT" 2>&1)
 	exitCode=$?
 	[ $exitCode -eq 0 ] || openwbDebugLog ${DMOD} 0 "Lp$CHARGEPOINT: Calling python failed ($exitCode): $pythonOut"
 fi


### PR DESCRIPTION
Da habe ich in der #1765 doch noch was falsch gemacht... Da ist noch ein Parameter zu viel, deswegen läuft EVNotify nicht. Im Log sagt es:
```
2021-12-03 20:13:36: Lp1: Calling python failed (1): unable to parse arguments. Expected: <akey> <token> <charge point>
ValueError: too many values to unpack (expected 3) (LV0)
    akey, token, charge_point_str = sys.argv[1:]
  File "/var/www/html/openWB/modules/soc_evnotify/evnotify.py", line 7, in <module>
```
Dieser PR behebt das... Hoffe ich ^^