### PR TITLE
update with HTTP Post only

### DIFF
--- a/web/settings/executeupdate.php
+++ b/web/settings/executeupdate.php
@@ -1,5 +1,6 @@
 <?php
 if ($_SERVER['REQUEST_METHOD'] !== 'POST') {
+	error_log('Diese Seite muss als HTTP-POST aufgerufen werden.');
 	exit('Diese Seite muss als HTTP-POST aufgerufen werden.');
 }
 ?>

--- a/web/settings/executeupdate.php
+++ b/web/settings/executeupdate.php
@@ -1,3 +1,8 @@
+<?php
+if ($_SERVER['REQUEST_METHOD'] !== 'POST') {
+	exit('Diese Seite muss als HTTP-POST aufgerufen werden.');
+}
+?>
 <!DOCTYPE html>
 <html lang="de">
 
@@ -77,7 +82,7 @@
 
 				infoText.text("Update der openWB angefordert...");
 
-				$.get({ url: "settings/updatePerformNow.php", cache: false }).done(function() {
+				$.post({ url: "settings/updatePerformNow.php", cache: false }).done(function() {
 					infoText.text("Update läuft... bitte warten, die Weiterleitung erfolgt automatisch.");
 					infoText.removeClass("alert-info");
 					infoText.addClass("alert-success");

--- a/web/settings/saveupdate.php
+++ b/web/settings/saveupdate.php
@@ -1,5 +1,6 @@
 <?php
 if ($_SERVER['REQUEST_METHOD'] !== 'POST') {
+	error_log('Diese Seite muss als HTTP-POST aufgerufen werden.');
 	exit('Diese Seite muss als HTTP-POST aufgerufen werden.');
 }
 ?>

--- a/web/settings/saveupdate.php
+++ b/web/settings/saveupdate.php
@@ -1,3 +1,8 @@
+<?php
+if ($_SERVER['REQUEST_METHOD'] !== 'POST') {
+	exit('Diese Seite muss als HTTP-POST aufgerufen werden.');
+}
+?>
 <!DOCTYPE html>
 <html lang="de">
 
@@ -79,14 +84,16 @@
 			fwrite($fp, $key.'='.$value."\n");
 		}
 		fclose($fp);
+		?>
+		<form action="settings/executeupdate.php" method="post" id="execute_update_form"></form>
+		<script>$('#execute_update_form').submit()</script>
+		<?php
 	} catch ( Exception $e ) {
 		$msg = $e->getMessage();
 		echo "<script>alert('$msg');</script>";
 		// return to theme on error
 		echo "<script>window.location.href='index.php';</script>";
 	}
-	// if successfully saved to config, start update
-	echo "<script>window.location.href='settings/executeupdate.php';</script>";
 ?>
 	</body>
 </html>

--- a/web/settings/updatePerformNow.php
+++ b/web/settings/updatePerformNow.php
@@ -1,3 +1,6 @@
 <?php
+if ($_SERVER['REQUEST_METHOD'] !== 'POST') {
+	exit('Diese Seite muss als HTTP-POST aufgerufen werden.');
+}
 exec("/var/www/html/openWB/runs/update.sh > /dev/null &");
 ?>

--- a/web/settings/updatePerformNow.php
+++ b/web/settings/updatePerformNow.php
@@ -1,5 +1,6 @@
 <?php
 if ($_SERVER['REQUEST_METHOD'] !== 'POST') {
+	error_log('Diese Seite muss als HTTP-POST aufgerufen werden.');
 	exit('Diese Seite muss als HTTP-POST aufgerufen werden.');
 }
 exec("/var/www/html/openWB/runs/update.sh > /dev/null &");


### PR DESCRIPTION
GET Requests sollten keine Seiteneffekte haben. Browser schützen vor Situationen in denen Seiteneffekte durch versehentliches Auslösen von anderen Requestarten ausgelöst werden (Verwendung des Zurück-Buttons im Browser, aber auch Anklicken von Links oder auch böse cross-site Angriffe).

Das Update in openWB wird per GET ausgelöst. Das ist schlecht, denn es produziert einen erheblichen Seiteneffekt. Es sollte per POST gehen.

Mit diesem PR baue ich das so um, dass Updates per POST ausgelöst werden.

**DAS IST UNGETESTET!!!** (Ja ich denke ich sollte allmälich nach SSH fragen, damit ich sowas testen kann).

**!!!!!!!!!!!**

Wenn es nicht funktioniert, dann kann man auch kein weiteres Update machen um es zu beheben. **Daher muss das vor einem merge unbedingt jemand testen (!!!!)**

**!!!!!!!!!!!!**

Siehe auch dieser Forenbeitrag: https://www.openwb.de/forum/viewtopic.php?p=51367#p51367