### PR TITLE
Add SolarLog Unterverbrauchszähler

### DIFF
--- a/modules/smarthome/solarlog/watt.py
+++ b/modules/smarthome/solarlog/watt.py
@@ -1,0 +1,48 @@
+#!/usr/bin/python3
+import sys
+import json
+import jq
+import os
+import requests
+
+devicenumber = str(sys.argv[1])      
+ipadr = os.environ.get('bezug_solarlog_ip') #IP-Adresse des SolarLog kommt vom PV Modul
+
+# ID des Zählers im SolarLog (SolarLog base hat 2 RS485 Schnittstellen und die Sortierung scheint B/A zu schein)
+# Daher am besten alle Werte mit folgendem cli commando abrufen und ggf mit der Webansicht http://ip/#ilang=DE&b=p_live_table abgleichen.
+# curl --request POST --url http://<ip des Solarlogs>/getjp --header 'Content-Type: application/json' --data '{"782":null}'
+# Die Zähler ID ist die Nummer vor dem Verbrauchswert.
+smid = int(sys.argv[2])         
+
+# Abfrage-URL, die das JSON liefert.
+jsonurl = "http://"+str(ipadr)+"/getjp"
+
+request_data_power = {'782':{str(smid):None}}
+request_data_powerc = {'777': {'0':None}} # need more filtering
+   
+#json Key in dem der aktuelle Leistungswert stehen
+jsonpower = '."782"."1"'               
+# json enthält immer eine Liste von Tagen und alle Werte, letzer Array entry ist heute, Filter per Device ID
+jsonpowerc = '."777"."0"[-1][1]['+str(smid)+']'
+
+try:
+    answer_power = json.loads(requests.post(jsonurl,json=request_data_power,timeout=3).content.decode('UTF-8'))
+    power = jq.compile(jsonpower).input(answer_power).first()
+    if (power==None):
+        power=0
+except:
+    power = 0
+    
+try:
+    answer_powerc = json.loads(requests.post(jsonurl,json=request_data_powerc,timeout=3).content.decode('UTF-8'))
+    powerc = jq.compile(jsonpowerc).input(answer_powerc).first()
+    if (powerc==None):
+        powerc=0
+except:
+    powerc = 0
+
+f1 = open('/var/www/html/openWB/ramdisk/smarthome_device_ret' + str(devicenumber), 'w')
+answer = '{"power":' + str(power) + ',"powerc":' + str(powerc) + '}'
+#print(answer)
+json.dump(answer, f1)
+f1.close()

--- a/web/settings/smarthomeconfig.php
+++ b/web/settings/smarthomeconfig.php
@@ -90,6 +90,7 @@ $numDevices = 9;
 											<option value="mystrom" data-option="mystrom">MyStrom</option>
 											<option value="viessmann" data-option="viessmann">Viessmann</option>
 											<option value="mqtt" data-option="mqtt">Mqtt</option>
+											<option value="solarlog" data-option="solarlog">SolarLog</option>
 											<option value="pyt" data-option="pyt">Pyt (veraltet, bitte andere Option wählen)</option>
 										</select>
 										<span class="form-text small device<?php echo $devicenum; ?>-option device<?php echo $devicenum; ?>-option-none hide">
@@ -119,10 +120,8 @@ $numDevices = 9;
 										</span>
 
 										<span class="form-text small device<?php echo $devicenum; ?>-option device<?php echo $devicenum; ?>-option-viessmann hide">
-											Vitalcal 200-s Wärmepumpe mit LON Kommunikationsmodul und Vitogate 300. Wenn die Einschaltbedingung erreicht ist wird Komfortfunktion "Einmalige Warmwasserbereitung" außerhalb des Zeitprogramms gestartet. Für die "Einmalige Warmwasserbereitung" wird der Warmwassertemperatur-Sollwert 2 genutzt. In der Wp kann eingestellt werden, ob für diese Funktion  die Elektroheizung (Heizstab) benutzt werden soll.
+											Vitocal 200-s Wärmepumpe mit LON Kommunikationsmodul und Vitogate 300. Wenn die Einschaltbedingung erreicht ist wird Komfortfunktion "Einmalige Warmwasserbereitung" außerhalb des Zeitprogramms gestartet. Für die "Einmalige Warmwasserbereitung" wird der Warmwassertemperatur-Sollwert 2 genutzt. In der Wp kann eingestellt werden, ob für diese Funktion  die Elektroheizung (Heizstab) benutzt werden soll.
 										</span>
-
-
 
 										<span class="form-text small device<?php echo $devicenum; ?>-option device<?php echo $devicenum; ?>-option-elwa hide">
 											Heizstab ELWA-E  der Firma my-PV<br>
@@ -153,6 +152,12 @@ $numDevices = 9;
 										</span>
 										<span class="form-text small device<?php echo $devicenum; ?>-option device<?php echo $devicenum; ?>-option-mystrom hide">
 											Mit diesem Typ werden SmartHome Geräte des Herstellers MyStrom unterstützt.<br>
+										</span>
+										<span class="form-text small device<?php echo $devicenum; ?>-option device<?php echo $devicenum; ?>-option-mystrom hide">
+											Ermöglicht die Einbindung von Unterverbrauchszählern aus Solarlog (z.B. Pro380, Pro1).<br>
+											<div class="card-text alert alert-info">
+												Die zugehörige IP Adresse ist im PV Modul einzustellen.
+											</div>
 										</span>
 									</div>
 								</div>
@@ -508,6 +513,18 @@ $numDevices = 9;
 									</div>
 								</div>
 							</div>
+
+							<div class="form-group device<?php echo $devicenum; ?>-option device<?php echo $devicenum; ?>-option-solarlog hide">
+								<hr class="border-secondary">
+								<div class="form-row mb-1">
+									<label class="col-md-4 col-form-label">Zähler ID</label>
+									<div class="col">
+										<input id="device_solarlog_uz<?php echo $devicenum; ?>" name="device_solarlog_uz" class="form-control" type="number" min="0" max="99" step="100" required="required" data-default="0" value="0" data-topicprefix="openWB/config/get/SmartHome/" data-topicsubgroup="Devices/<?php echo $devicenum; ?>/">
+										<span class="form-text small">ID des Zählers im SolarLog. SolarLog hat 2 RS485 Schnittstellen und die Sortierung scheint B,A zu sein. In der Webansicht http://solarlog.ip/#ilang=DE&b=p_live_table unter Verbrauchszähler bei 0 anfrangen zu zählen.</span>
+									</div>
+								</div>
+							</div>
+
 							<hr class="border-secondary">
 							<div class="form-group">
 								<div class="form-row mb-1">


### PR DESCRIPTION
 in SmartHome 2.0. Erlaubt das Einbinden von Unterverbrauchszählern, die im SolarLog via S0 oder ModBus verbunden sind (bspw. PRO380, Pro1)