### PR TITLE
PV Gesamt-Anlagendaten (automatische Nachführung für Monatsertrag und Jahresertrag)

### DIFF
--- a/loadvars.sh
+++ b/loadvars.sh
@@ -1168,14 +1168,14 @@ loadvars(){
 		echo $pvallwh > /var/www/html/openWB/ramdisk/pvallwh
 	fi
 	# monthly / yearly fuer status rechnen (csv aus cronnight und laufend)
-  pvdaily=$(</var/www/html/openWB/ramdisk/daily_pvkwhk)
-  pvyearlycsv=$(</var/www/html/openWB/ramdisk/yearly_pvkwhk_csv)
-  pvmonthlycsv=$(</var/www/html/openWB/ramdisk/monthly_pvkwhk_csv)
-  pvyearly=$(echo "$pvdaily + $pvyearlycsv" |bc)
-  pvmonthly=$(echo "$pvdaily + $pvmonthlycsv" |bc)
-  echo $pvyearly > /var/www/html/openWB/ramdisk/yearly_pvkwhk
-  echo $pvmonthly > /var/www/html/openWB/ramdisk/monthly_pvkwhk
-  # rechnen ende
+	pvdaily=$(</var/www/html/openWB/ramdisk/daily_pvkwhk)
+	pvyearlycsv=$(</var/www/html/openWB/ramdisk/yearly_pvkwhk_csv)
+	pvmonthlycsv=$(</var/www/html/openWB/ramdisk/monthly_pvkwhk_csv)
+	pvyearly=$(echo "$pvdaily + $pvyearlycsv" |bc)
+	pvmonthly=$(echo "$pvdaily + $pvmonthlycsv" |bc)
+	echo $pvyearly > /var/www/html/openWB/ramdisk/yearly_pvkwhk
+	echo $pvmonthly > /var/www/html/openWB/ramdisk/monthly_pvkwhk
+	# rechnen ende
 	if [[ $speichermodul == "speicher_e3dc" ]] || [[ $speichermodul == "speicher_huawei" ]] || [[ $speichermodul == "speicher_tesvoltsma" ]] || [[ $speichermodul == "speicher_solarwatt" ]] || [[ $speichermodul == "speicher_rct" ]]|| [[ $speichermodul == "speicher_sungrow" ]] || [[ $speichermodul == "speicher_lgessv1" ]] || [[ $speichermodul == "speicher_bydhv" ]] || [[ $speichermodul == "speicher_kostalplenticore" ]] || [[ $speichermodul == "speicher_powerwall" ]] || [[ $speichermodul == "speicher_sbs25" ]] || [[ $speichermodul == "speicher_solaredge" ]] || [[ $speichermodul == "speicher_sonneneco" ]] || [[ $speichermodul == "speicher_varta" ]] || [[ $speichermodul == "speicher_saxpower" ]] || [[ $speichermodul == "speicher_victron" ]] || [[ $speichermodul == "speicher_fronius" ]] ; then
 		ra='^-?[0-9]+$'
 		watt2=$(</var/www/html/openWB/ramdisk/speicherleistung)

--- a/loadvars.sh
+++ b/loadvars.sh
@@ -1167,7 +1167,15 @@ loadvars(){
 		pvallwh=$(echo "$pvkwh + $pv2kwh" |bc)
 		echo $pvallwh > /var/www/html/openWB/ramdisk/pvallwh
 	fi
-
+	# monthly / yearly fuer status rechnen (csv aus cronnight und laufend)
+  pvdaily=$(</var/www/html/openWB/ramdisk/daily_pvkwhk)
+  pvyearlycsv=$(</var/www/html/openWB/ramdisk/yearly_pvkwhk_csv)
+  pvmonthlycsv=$(</var/www/html/openWB/ramdisk/monthly_pvkwhk_csv)
+  pvyearly=$(echo "$pvdaily + $pvyearlycsv" |bc)
+  pvmonthly=$(echo "$pvdaily + $pvmonthlycsv" |bc)
+  echo $pvyearly > /var/www/html/openWB/ramdisk/yearly_pvkwhk
+  echo $pvmonthly > /var/www/html/openWB/ramdisk/monthly_pvkwhk
+  # rechnen ende
 	if [[ $speichermodul == "speicher_e3dc" ]] || [[ $speichermodul == "speicher_huawei" ]] || [[ $speichermodul == "speicher_tesvoltsma" ]] || [[ $speichermodul == "speicher_solarwatt" ]] || [[ $speichermodul == "speicher_rct" ]]|| [[ $speichermodul == "speicher_sungrow" ]] || [[ $speichermodul == "speicher_lgessv1" ]] || [[ $speichermodul == "speicher_bydhv" ]] || [[ $speichermodul == "speicher_kostalplenticore" ]] || [[ $speichermodul == "speicher_powerwall" ]] || [[ $speichermodul == "speicher_sbs25" ]] || [[ $speichermodul == "speicher_solaredge" ]] || [[ $speichermodul == "speicher_sonneneco" ]] || [[ $speichermodul == "speicher_varta" ]] || [[ $speichermodul == "speicher_saxpower" ]] || [[ $speichermodul == "speicher_victron" ]] || [[ $speichermodul == "speicher_fronius" ]] ; then
 		ra='^-?[0-9]+$'
 		watt2=$(</var/www/html/openWB/ramdisk/speicherleistung)

--- a/loadvars.sh
+++ b/loadvars.sh
@@ -1028,7 +1028,7 @@ loadvars(){
 	echo $hausverbrauch > /var/www/html/openWB/ramdisk/hausverbrauch
 	fronius_sm_bezug_meterlocation=$(</var/www/html/openWB/ramdisk/fronius_sm_bezug_meterlocation)
 	usesimbezug=0
-	if [[ $wattbezugmodul == "bezug_e3dc" ]] || [[ $wattbezugmodul == "bezug_huawei" ]] || [[ $wattbezugmodul == "bezug_solarwatt" ]]|| [[ $wattbezugmodul == "bezug_rct" ]]|| [[ $wattbezugmodul == "bezug_sungrow" ]] || [[ $wattbezugmodul == "bezug_varta" ]] || [[ $wattbezugmodul == "bezug_lgessv1" ]] || [[ $wattbezugmodul == "bezug_kostalpiko" ]] || [[ $wattbezugmodul == "bezug_kostalplenticoreem300haus" ]] || [[ $wattbezugmodul == "bezug_sbs25" ]] || [[ $wattbezugmodul == "bezug_solarlog" ]] || [[ $wattbezugmodul == "bezug_sonneneco" ]] || [[ $fronius_sm_bezug_meterlocation == "1" ]]; then
+	if [[ $wattbezugmodul == "bezug_e3dc" ]] || [[ $wattbezugmodul == "bezug_huawei" ]] || [[ $wattbezugmodul == "bezug_solarwatt" ]]|| [[ $wattbezugmodul == "bezug_rct" ]]|| [[ $wattbezugmodul == "bezug_varta" ]] || [[ $wattbezugmodul == "bezug_lgessv1" ]] || [[ $wattbezugmodul == "bezug_kostalpiko" ]] || [[ $wattbezugmodul == "bezug_kostalplenticoreem300haus" ]] || [[ $wattbezugmodul == "bezug_sbs25" ]] || [[ $wattbezugmodul == "bezug_solarlog" ]] || [[ $wattbezugmodul == "bezug_sonneneco" ]] || [[ $fronius_sm_bezug_meterlocation == "1" ]]; then
 		usesimbezug=1
 	fi
 	if [[ $usesimbezug == "1" ]]; then
@@ -1082,7 +1082,7 @@ loadvars(){
 	if [[ $pvwattmodul == "wr_fronius" ]] && [[ $wrfroniusisgen24 == "1" ]]; then
 		usesimpv=1
 	fi
-	if [[ $pvwattmodul == "wr_kostalpiko" ]] || [[ $pvwattmodul == "wr_rct" ]]|| [[ $pvwattmodul == "wr_solarwatt" ]] || [[ $pvwattmodul == "wr_shelly" ]] || [[ $pvwattmodul == "wr_sungrow" ]] || [[ $pvwattmodul == "wr_huawei" ]] || [[ $pvwattmodul == "wr_lgessv1" ]]|| [[ $pvwattmodul == "wr_kostalpikovar2" ]]; then
+	if [[ $pvwattmodul == "wr_kostalpiko" ]] || [[ $pvwattmodul == "wr_rct" ]]|| [[ $pvwattmodul == "wr_solarwatt" ]] || [[ $pvwattmodul == "wr_shelly" ]] || [[ $pvwattmodul == "wr_huawei" ]] || [[ $pvwattmodul == "wr_lgessv1" ]]|| [[ $pvwattmodul == "wr_kostalpikovar2" ]]; then
 		usesimpv=1
 	fi
 	if [[ $usesimpv == "1" ]]; then
@@ -1168,15 +1168,15 @@ loadvars(){
 		echo $pvallwh > /var/www/html/openWB/ramdisk/pvallwh
 	fi
 	# monthly / yearly fuer status rechnen (csv aus cronnight und laufend)
-	pvdaily=$(</var/www/html/openWB/ramdisk/daily_pvkwhk)
-	pvyearlycsv=$(</var/www/html/openWB/ramdisk/yearly_pvkwhk_csv)
-	pvmonthlycsv=$(</var/www/html/openWB/ramdisk/monthly_pvkwhk_csv)
-	pvyearly=$(echo "$pvdaily + $pvyearlycsv" |bc)
-	pvmonthly=$(echo "$pvdaily + $pvmonthlycsv" |bc)
-	echo $pvyearly > /var/www/html/openWB/ramdisk/yearly_pvkwhk
-	echo $pvmonthly > /var/www/html/openWB/ramdisk/monthly_pvkwhk
-	# rechnen ende
-	if [[ $speichermodul == "speicher_e3dc" ]] || [[ $speichermodul == "speicher_huawei" ]] || [[ $speichermodul == "speicher_tesvoltsma" ]] || [[ $speichermodul == "speicher_solarwatt" ]] || [[ $speichermodul == "speicher_rct" ]]|| [[ $speichermodul == "speicher_sungrow" ]] || [[ $speichermodul == "speicher_lgessv1" ]] || [[ $speichermodul == "speicher_bydhv" ]] || [[ $speichermodul == "speicher_kostalplenticore" ]] || [[ $speichermodul == "speicher_powerwall" ]] || [[ $speichermodul == "speicher_sbs25" ]] || [[ $speichermodul == "speicher_solaredge" ]] || [[ $speichermodul == "speicher_sonneneco" ]] || [[ $speichermodul == "speicher_varta" ]] || [[ $speichermodul == "speicher_saxpower" ]] || [[ $speichermodul == "speicher_victron" ]] || [[ $speichermodul == "speicher_fronius" ]] ; then
+  pvdaily=$(</var/www/html/openWB/ramdisk/daily_pvkwhk)
+  pvyearlycsv=$(</var/www/html/openWB/ramdisk/yearly_pvkwhk_csv)
+  pvmonthlycsv=$(</var/www/html/openWB/ramdisk/monthly_pvkwhk_csv)
+  pvyearly=$(echo "$pvdaily + $pvyearlycsv" |bc)
+  pvmonthly=$(echo "$pvdaily + $pvmonthlycsv" |bc)
+  echo $pvyearly > /var/www/html/openWB/ramdisk/yearly_pvkwhk
+  echo $pvmonthly > /var/www/html/openWB/ramdisk/monthly_pvkwhk
+  # rechnen ende
+	if [[ $speichermodul == "speicher_e3dc" ]] || [[ $speichermodul == "speicher_huawei" ]] || [[ $speichermodul == "speicher_tesvoltsma" ]] || [[ $speichermodul == "speicher_solarwatt" ]] || [[ $speichermodul == "speicher_rct" ]]|| [[ $speichermodul == "speicher_lgessv1" ]] || [[ $speichermodul == "speicher_bydhv" ]] || [[ $speichermodul == "speicher_kostalplenticore" ]] || [[ $speichermodul == "speicher_powerwall" ]] || [[ $speichermodul == "speicher_sbs25" ]] || [[ $speichermodul == "speicher_solaredge" ]] || [[ $speichermodul == "speicher_sonneneco" ]] || [[ $speichermodul == "speicher_varta" ]] || [[ $speichermodul == "speicher_fronius" ]] ; then
 		ra='^-?[0-9]+$'
 		watt2=$(</var/www/html/openWB/ramdisk/speicherleistung)
 		if [[ -e /var/www/html/openWB/ramdisk/speicherwatt0pos ]]; then

--- a/runs/initRamdisk.sh
+++ b/runs/initRamdisk.sh
@@ -245,6 +245,7 @@ initRamdisk(){
 	echo 0 > $RamdiskPath/daily_pvkwhk1
 	echo 0 > $RamdiskPath/daily_pvkwhk2
 	echo 0 > $RamdiskPath/monthly_pvkwhk
+	echo 0 > $RamdiskPath/monthly_pvkwhk_csv
 	echo 0 > $RamdiskPath/monthly_pvkwhk1
 	echo 0 > $RamdiskPath/monthly_pvkwhk2
 	echo 0 > $RamdiskPath/nurpv70dynstatus
@@ -268,6 +269,7 @@ initRamdisk(){
 	echo 0 > $RamdiskPath/pvwatt1
 	echo 0 > $RamdiskPath/pvwatt2
 	echo 0 > $RamdiskPath/yearly_pvkwhk
+	echo 0 > $RamdiskPath/yearly_pvkwhk_csv
 	echo 0 > $RamdiskPath/yearly_pvkwhk1
 	echo 0 > $RamdiskPath/yearly_pvkwhk2
 

--- a/runs/initRamdisk.sh
+++ b/runs/initRamdisk.sh
@@ -448,7 +448,6 @@ initRamdisk(){
 	do
 		for f in \
 			"pluggedladunglp${i}startkwh:openWB/lp/${i}/plugStartkWh:0" \
-			"manual_soc_lp${i}:openWB/lp/${i}/manualSoc:0" \
 			"pluggedladungaktlp${i}:openWB/lp/${i}/pluggedladungakt:0" \
 			"lp${i}phasen::0" \
 			"lp${i}enabled::1" \


### PR DESCRIPTION
Neu werden in der Statusseite die Felder  Monatsertrag und Jahresertrag (unter PV Gesamt-Anlagendaten) von openWB gerechnet (wie schon vorher das Feld Tagesertrag). Der Jahresertrag  und der Monatsertrag wird im Cronnighlty basierend auf den csv Files errechnet und während dem Tag laufend mit dem Tagesertrag ergänzt.