### PR TITLE
add automatic CLI args parser

### DIFF
--- a/modules/soc_manual/soc_manual.py
+++ b/modules/soc_manual/soc_manual.py
@@ -1,7 +1,7 @@
 import argparse
 import logging
-import sys
 
+from helpermodules.cli import run_using_positional_cli_args
 from helpermodules.log import setup_logging_stdout
 from modules.common.store import ramdisk_write, ramdisk_read_float
 
@@ -52,14 +52,9 @@ def run(charge_point: int, battery_size: float, efficiency: float):
     ramdisk_write(file_soc, soc_new * 100, digits=0)
 
 
-def run_command_line():
-    parser = argparse.ArgumentParser(description='Calculate SoC based on kWh charged')
-    parser.add_argument("charge_point", type=int)
-    parser.add_argument("efficiency", type=float)
-    parser.add_argument("battery_size", type=float)
-    args = parser.parse_args()
-    run(charge_point=args.charge_point, efficiency=args.efficiency / 100, battery_size=args.battery_size)
+def run_command_line(charge_point: int, efficiency: float, battery_size: float):
+    run(charge_point, battery_size, efficiency / 100)
 
 
 if __name__ == '__main__':
-    run_command_line()
+    run_using_positional_cli_args(run_command_line)

--- a/packages/helpermodules/cli/__init__.py
+++ b/packages/helpermodules/cli/__init__.py
@@ -1,0 +1,1 @@
+from helpermodules.cli._run_using_positional_cli_args import run_using_positional_cli_args

--- a/packages/helpermodules/cli/_run_using_positional_cli_args.py
+++ b/packages/helpermodules/cli/_run_using_positional_cli_args.py
@@ -1,0 +1,19 @@
+import argparse
+import inspect
+from typing import Callable, Union
+
+NoneType = type(None)
+
+
+def run_using_positional_cli_args(function: Callable):
+    arg_spec = inspect.getfullargspec(function)
+    parser = argparse.ArgumentParser()
+    for argument_name in arg_spec.args:
+        type = arg_spec.annotations[argument_name]
+        if hasattr(type, "__origin__") and type.__origin__ is Union:
+            type_arg, = filter(lambda candidate: candidate is not NoneType, type.__args__)
+            parser.add_argument(argument_name, nargs='?', type=type_arg)
+        else:
+            parser.add_argument(argument_name, type=type)
+    args = parser.parse_args()
+    function(*[getattr(args, argument_name) for argument_name in arg_spec.args])

--- a/packages/helpermodules/cli/_run_using_positional_cli_args_test.py
+++ b/packages/helpermodules/cli/_run_using_positional_cli_args_test.py
@@ -1,0 +1,63 @@
+import sys
+from typing import Optional
+from unittest.mock import Mock
+
+import pytest
+
+from helpermodules.cli import run_using_positional_cli_args
+
+
+def create_int_arg_function(mock: Mock):
+    def int_arg(arg: int):
+        mock(arg)
+    return int_arg
+
+
+def create_float_arg_function(mock: Mock):
+    def float_arg(arg: float):
+        mock(arg)
+    return float_arg
+
+
+def create_str_arg_function(mock: Mock):
+    def str_arg(arg: str):
+        mock(arg)
+    return str_arg
+
+
+def create_optional_arg_function(mock: Mock):
+    def optional_arg(arg: Optional[int]):
+        mock(arg)
+    return optional_arg
+
+
+def create_multi_arg_function(mock: Mock):
+    def multi_arg(arg_str: str, arg_int: int, optional_str: Optional[str], optional_int: Optional[int]):
+        mock((arg_str, arg_int, optional_str, optional_int))
+    return multi_arg
+
+
+@pytest.mark.parametrize(
+    "function_factory,argv,arg_parsed", [
+        (create_int_arg_function, ["42"], 42),
+        (create_float_arg_function, ["12.34"], 12.34),
+        (create_str_arg_function, ["some string"], "some string"),
+        (create_optional_arg_function, [], None),
+        (create_optional_arg_function, ["21"], 21),
+        (create_multi_arg_function, ["some string", "42"], ("some string", 42, None, None)),
+        (create_multi_arg_function, ["some string", "42", "other str"], ("some string", 42, "other str", None)),
+        (create_multi_arg_function, ["some string", "42", "other str", "21"], ("some string", 42, "other str", 21)),
+    ]
+)
+def test_run_using_cli_args_int_arg(monkeypatch, function_factory, argv, arg_parsed):
+    # setup
+    argv.insert(0, "dummy")
+    monkeypatch.setattr(sys, "argv", argv)
+    mock = Mock()
+    function = function_factory(mock)
+
+    # execution
+    run_using_positional_cli_args(function)
+
+    # evaluation
+    mock.assert_called_once_with(arg_parsed)


### PR DESCRIPTION
Dieser PR fügt ein kleine Hilfsfunktion hinzu, die das parsen der CLI-args vereinfachen soll. Für das erste wird das ganze im SoC-Modul verwendet mit dem ich das ganze auch im Livebetrieb getestet habe.

Beispiel
-----------
Auszüge davon wie `packages/modules/openwb/device.py` aufgerufen wird:

modules/wr2_ethlovato/main.sh:
```bash
python3 ${OPENWBBASEDIR}/packages/modules/openwb/device.py "inverter" "${pvkitversion}" "2">>${MYLOGFILE} 2>&1
```
modules/speicher_mpm3pm/main.sh:
```bash
python3 ${OPENWBBASEDIR}/packages/modules/openwb/device.py "bat" "${speicherkitversion}" >>${MYLOGFILE} 2>&1
```
Man sieht hier die Anforderung: Es gibt 3 Argumente, das dritte ist Optional.

In Python selbst werden dann die Argumente wie folgt geparst:
```python
def read_legacy(argv: List[str]):
    # [..]
    component_type = argv[1]
    version = int(argv[2])
    try:
        num = int(argv[3])
    except IndexError:
        num = None


if __name__ == "__main__":
    # [..]
    read_legacy(sys.argv)
```

Ziele
------
Es stellen sich mir zwei Fragen:
1. Geht das kürzer?
2. Was kann schief gehen?

Zu 1): Ja, es geht kürzer. Mit diesem PR hier wäre es wie folgt möglich:
```python
def read_legacy(component_type: str, version: int, num: Optional[int]):
    # [..]

if __name__ == "__main__":
    # [..]
    run_using_positional_cli_args(read_legacy)
```
Also eindeutig schonmal ein ganzes Stück kürzer :-).

Zu 2): Was ist, wenn jemand ein Fehler im Script macht?
1. Argument weggelassen.
    **Alt**:
    ```
    $ PYTHONPATH=packages python3 packages/modules/openwb/device.py "bat"
    2021-12-10 08:39:51: PID: 11290: root: Fehler im Modul openwb
    Traceback (most recent call last):
      File "packages/modules/openwb/device.py", line 93, in <module>
        read_legacy(sys.argv)
      File "packages/modules/openwb/device.py", line 66, in read_legacy
        version = int(argv[2])
    IndexError: list index out of range
    ```
    **Neu**:
    ```
    $ PYTHONPATH=packages python3 packages/modules/openwb/device.py "bat"
    usage: device.py [-h] component_type version [num]
    device.py: error: the following arguments are required: version
    ```
2. Falscher Typ für das Argument:
    **Alt**:
    ```
    $ PYTHONPATH=packages python3 packages/modules/openwb/device.py "bat" "not an int"
    2021-12-10 08:38:43: PID: 11199: root: Fehler im Modul openwb
    Traceback (most recent call last):
      File "packages/modules/openwb/device.py", line 93, in <module>
        read_legacy(sys.argv)
      File "packages/modules/openwb/device.py", line 66, in read_legacy
        version = int(argv[2])
    ValueError: invalid literal for int() with base 10: 'not an int'
    ```
   **Neu**:
   ```
   $ PYTHONPATH=packages python3 packages/modules/openwb/device.py "bat" "not an int"
   usage: device.py [-h] component_type version [num]
   device.py: error: argument version: invalid int value: 'not an int'
   ```

Der Kern der Aussage: Wenn irgendwas schief gehen sollte, bekommt man mit dem Code den dieser PR hier bietet eine deutlich präzisere Fehlermeldung ins Log gespült und das ganze mit weniger Code.

Als kleiner Bonus kann man jedes Script mt `-h` Aufrufen um eine Hilfe zu bekommen:
```
$ PYTHONPATH=packages python3 packages/modules/openwb/device.py -h
usage: device.py [-h] component_type version [num]

positional arguments:
  component_type
  version
  num

optional arguments:
  -h, --help      show this help message and exit
```