### PR TITLE
Fix FEMS broken by changes on Dec 10

### DIFF
--- a/modules/speicher_fems/fems.py
+++ b/modules/speicher_fems/fems.py
@@ -27,11 +27,11 @@ if Debug >= 2:
 def write_ramdisk(value, file):
     try:
         if file == "speichersoc":
-            if re.search("^[-+]?[0-9]+\.?[0-9]*$", value) == None:
+            if re.search("^[-+]?[0-9]+\.?[0-9]*$", str(value)) == None:
                 value = "0"
         if Debug >= 1:
             DebugLog(file+': ' + str(value))
-        with open("/var/www/html/openWB/ramdisk/"+file, "") as f:
+        with open("/var/www/html/openWB/ramdisk/"+file, "w") as f:
             f.write(str(value))
     except:
         traceback.print_exc()
@@ -40,7 +40,7 @@ def write_ramdisk(value, file):
 
 if multifems == "0":
     try:
-        response = requests.get("http://x:"+femskacopw+"@"+femsip+":8084/rest/channel/ess0/(Soc|ActiveChargeEnergy|ActiveDischargeEnergy)").json()
+        response = requests.get("http://"+femsip+":8084/rest/channel/ess0/(Soc|ActiveChargeEnergy|ActiveDischargeEnergy)", auth=("x", femskacopw)).json()
     except:
         traceback.print_exc()
         exit(1)
@@ -54,7 +54,7 @@ if multifems == "0":
             write_ramdisk(singleValue["value"], "speicherekwh")
 else:
     try:
-        response = requests.get("http://x:"+femskacopw+"@"+femsip+":8084/rest/channel/ess2/(Soc|ActiveChargeEnergy|ActiveDischargeEnergy)").json()
+        response = requests.get("http://"+femsip+":8084/rest/channel/ess2/(Soc|ActiveChargeEnergy|ActiveDischargeEnergy)", auth=("x", femskacopw)).json()
     except:
         traceback.print_exc()
         exit(1)
@@ -68,7 +68,7 @@ else:
             write_ramdisk(singleValue["value"], "speicherekwh")
 
 try:
-    response = requests.get("http://x:"+femskacopw+"@"+femsip+":8084/rest/channel/_sum/(GridActivePower|ProductionActivePower|ConsumptionActivePower)").json()
+    response = requests.get("http://"+femsip+":8084/rest/channel/_sum/(GridActivePower|ProductionActivePower|ConsumptionActivePower)", auth=("x", femskacopw)).json()
 except:
     traceback.print_exc()
     exit(1)
@@ -84,7 +84,7 @@ for singleValue in response:
 leistung = grid + pv - haus
 
 ra = "^[-+]?[0-9]+\.?[0-9]*$"
-if re.search(ra, leistung) == None:
+if re.search(ra, str(leistung)) == None:
     leistung = "0"
 if Debug >= 1:
     DebugLog('Speicherleistung: ' + str(leistung))

--- a/modules/wr_fems/fems.py
+++ b/modules/wr_fems/fems.py
@@ -38,9 +38,9 @@ except:
     exit(1)
 
 regex = '^-?[0-9]+$'
-if re.search(regex, pvwatt) == None:
+if re.search(regex, str(pvwatt)) == None:
     pvwatt = "0"
-if re.search(regex, pvwh) != None:
+if re.search(regex, str(pvwh)) != None:
     if Debug >= 1:
         DebugLog('WR Energie: ' + str(pvwh))
     with open("/var/www/html/openWB/ramdisk/pvkwh", "w") as f:


### PR DESCRIPTION
It seem pyhton 3.5 "re.search" only takes strings and does not do implicit conversion.

Errors in `openwb.log` were:

```
TypeError: expected string or bytes-like object
Traceback (most recent call last):
  File "/var/www/html/openWB/modules/speicher_fems/fems.py", line 30, in write_ramdisk
    if re.search("^[-+]?[0-9]+\.?[0-9]*$", value) == None:
  File "/usr/lib/python3.5/re.py", line 173, in search
    return _compile(pattern, flags).search(string)
TypeError: expected string or bytes-like object
Traceback (most recent call last):
  File "/var/www/html/openWB/modules/wr_fems/fems.py", line 41, in <module>
    if re.search(regex, pvwatt) == None:
  File "/usr/lib/python3.5/re.py", line 173, in search
    return _compile(pattern, flags).search(string)
```