### PR TITLE
Send git details via MQTT

### DIFF
--- a/runs/atreboot.sh
+++ b/runs/atreboot.sh
@@ -227,10 +227,10 @@ echo "timezone..."
 sudo cp /usr/share/zoneinfo/Europe/Berlin /etc/localtime
 
 
-if [ ! -f /home/pi/ssl_patched ]; then 
-	sudo apt-get update 
-	sudo apt-get -qq install -y openssl libcurl3 curl libgcrypt20 libgnutls30 libssl1.1 libcurl3-gnutls libssl1.0.2 php7.0-cli php7.0-gd php7.0-opcache php7.0 php7.0-common php7.0-json php7.0-readline php7.0-xml php7.0-curl libapache2-mod-php7.0 
-	touch /home/pi/ssl_patched 
+if [ ! -f /home/pi/ssl_patched ]; then
+	sudo apt-get update
+	sudo apt-get -qq install -y openssl libcurl3 curl libgcrypt20 libgnutls30 libssl1.1 libcurl3-gnutls libssl1.0.2 php7.0-cli php7.0-gd php7.0-opcache php7.0 php7.0-common php7.0-json php7.0-readline php7.0-xml php7.0-curl libapache2-mod-php7.0
+	touch /home/pi/ssl_patched
 fi
 
 
@@ -367,6 +367,10 @@ curl -s https://raw.githubusercontent.com/snaptec/openWB/stable/web/version > /v
 
 # update our local version
 sudo git -C /var/www/html/openWB show --pretty='format:%ci [%h]' | head -n1 > /var/www/html/openWB/web/lastcommit
+# and record the current commit details
+commitId=`git -C /var/www/html/openWB log --format="%h" -n 1`
+echo $commitId > /var/www/html/openWB/ramdisk/currentCommitHash
+echo `git -C /var/www/html/openWB branch -a --contains $commitId | perl -nle 'm|.*origin/(.+).*|; print $1' | uniq | xargs` > /var/www/html/openWB/ramdisk/currentCommitBranches
 
 # update broker
 echo "update broker..."

--- a/runs/cron5min.sh
+++ b/runs/cron5min.sh
@@ -385,6 +385,11 @@ if (( $pingcheckactive == 1 )); then
 	$OPENWBBASEDIR/runs/pingcheck.sh &
 fi
 
+# record the current commit details
+commitId=`git -C /var/www/html/openWB log --format="%h" -n 1`
+echo "$commitId" > $RAMDISKDIR/currentCommitHash
+echo `git -C /var/www/html/openWB branch -a --contains $commitId | perl -nle 'm|.*origin/(.+).*|; print $1' | uniq | xargs` > $RAMDISKDIR/currentCommitBranches
+
 # EVSE Check
 openwbDebugLog "MAIN" 1 "starting evsecheck"
 $OPENWBBASEDIR/runs/evsecheck

--- a/runs/pubmqtt.sh
+++ b/runs/pubmqtt.sh
@@ -236,6 +236,8 @@ mqttvar["lp/5/TimeRemaining"]=restzeitlp5
 mqttvar["lp/6/TimeRemaining"]=restzeitlp6
 mqttvar["lp/7/TimeRemaining"]=restzeitlp7
 mqttvar["lp/8/TimeRemaining"]=restzeitlp8
+mqttvar["system/CommitHash"]=currentCommitHash
+mqttvar["system/CommitBranches"]=currentCommitBranches
 
 if [[ "$standardSocketInstalled" == "1" ]]; then
 	mqttvar["config/get/slave/SocketActivated"]=socketActivated


### PR DESCRIPTION
I'd really like to see the git details also via MQTT.

This PR adds topics  
* `openWB/system/CommitHash`
* `openWB/system/CommitBranches`

In contrast to the display info of Web-UI (which takes the 'train' from `openwb.conf` file) this implementation takes all info from Git only. It first determines the last commit hash and then queries the **list of branches** that this hash can be found on. So watch out: Branch info might be a list!

The querying of the details runs on `atreboot.sh` and, just to be sure and safe, also in `cron5min.sh`.