### PR TITLE
Ramdisk structure as Python-Code

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,7 +4,7 @@ web/logging/data/
 *.log
 *.pyc
 *.bak
-ramdisk/
+/ramdisk/
 .DS_Store
 .ftp*
 web/settings/.htaccess

--- a/modules/bezug_discovergy/discovergy_test.py
+++ b/modules/bezug_discovergy/discovergy_test.py
@@ -1,0 +1,56 @@
+import json
+from unittest.mock import Mock
+
+import pytest
+
+import discovergy
+from test_utils.mock_ramdisk import MockRamdisk
+
+SAMPLE_JSON = """{
+    "time":1622132613773,
+    "values":{
+        "energyOut":25545649812000,
+        "energy2":12593551340000,
+        "energy1":2210138000,
+        "voltage1":233400,
+        "voltage2":234600,
+        "voltage3":200000,
+        "energyOut1":0,
+        "energyOut2":0,
+        "power":1234567,
+        "power1":1167000,
+        "power2":2650980,
+        "power3":-230000,
+        "energy":12595761479000
+    }
+}"""
+
+
+@pytest.fixture(scope='function')
+def mock_ramdisk(monkeypatch):
+    return MockRamdisk(monkeypatch)
+
+
+def test_update(mock_ramdisk: MockRamdisk, monkeypatch):
+    # setup
+    mock_get_last_reading = Mock(return_value=json.loads(SAMPLE_JSON))
+    monkeypatch.setattr(discovergy, 'get_last_reading', mock_get_last_reading)
+
+    # exeuction
+    discovergy.update("someUser", "somePassword", "someMeterId")
+
+    # evaluation
+    mock_get_last_reading.assert_called_once_with("someUser", "somePassword", "someMeterId")
+    assert mock_ramdisk["bezuga1"] == "5.0"
+    assert mock_ramdisk["bezuga2"] == "11.3"
+    assert mock_ramdisk["bezuga3"] == "-1.15"
+    assert mock_ramdisk["bezugkwh"] == "1259576.1479"
+    assert mock_ramdisk["bezugw1"] == "1167"
+    assert mock_ramdisk["bezugw2"] == "2650"
+    assert mock_ramdisk["bezugw3"] == "-230"
+    assert mock_ramdisk["einspeisungkwh"] == "2554564.9812"
+    assert mock_ramdisk["evuv1"] == "233.4"
+    assert mock_ramdisk["evuv2"] == "234.6"
+    assert mock_ramdisk["evuv3"] == "200.0"
+    assert mock_ramdisk["wattbezug"] == "1234"
+

--- a/modules/bezug_discovergy/main.sh
+++ b/modules/bezug_discovergy/main.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
+OPENWBBASEDIR=$(cd `dirname $0`/../../ && pwd)
 
-sudo python3 /var/www/html/openWB/modules/bezug_discovergy/discovergy.py $discovergyuser $discovergypass $discovergyevuid
-wattbezug=$(</var/www/html/openWB/ramdisk/wattbezug)
-echo $wattbezug
+python3 /var/www/html/openWB/modules/bezug_discovergy/discovergy.py "$discovergyuser" "$discovergypass" "$discovergyevuid" &>> "$OPENWBBASEDIR/ramdisk/openWB.log"
+cat /var/www/html/openWB/ramdisk/wattbezug

--- a/packages/modules/common/store/__init__.py
+++ b/packages/modules/common/store/__init__.py
@@ -3,5 +3,5 @@ from modules.common.store._battery import get_bat_value_store
 from modules.common.store._car import get_car_value_store
 from modules.common.store._counter import get_counter_value_store
 from modules.common.store._inverter import get_inverter_value_store
-from modules.common.store._ramdisk import ramdisk_write, ramdisk_read, ramdisk_read_float, ramdisk_read_int, \
+from modules.common.store.ramdisk.io import ramdisk_write, ramdisk_read, ramdisk_read_float, ramdisk_read_int, \
     RAMDISK_PATH

--- a/packages/modules/common/store/_battery.py
+++ b/packages/modules/common/store/_battery.py
@@ -1,8 +1,8 @@
 from helpermodules import log, compatibility
 from modules.common.component_state import BatState
 from modules.common.store import ValueStore
+from modules.common.store.ramdisk import files
 from modules.common.store._broker import pub_to_broker
-from modules.common.store._ramdisk import ramdisk_write
 from modules.common.store._util import process_error
 
 
@@ -12,10 +12,10 @@ class BatteryValueStoreRamdisk(ValueStore[BatState]):
 
     def set(self, bat_state: BatState):
         try:
-            ramdisk_write("speicherleistung", bat_state.power, 0)
-            ramdisk_write("speichersoc", bat_state.soc, 0)
-            ramdisk_write("speicherikwh", bat_state.imported, 2)
-            ramdisk_write("speicherekwh", bat_state.exported, 2)
+            files.battery.power.write(bat_state.power)
+            files.battery.soc.write(bat_state.soc)
+            files.battery.energy_imported.write(bat_state.imported)
+            files.battery.energy_exported.write(bat_state.exported)
             log.MainLogger().info('BAT Watt: ' + str(bat_state.power))
             log.MainLogger().info('BAT Einspeisung: ' + str(bat_state.exported))
             log.MainLogger().info('BAT Bezug: ' + str(bat_state.imported))

--- a/packages/modules/common/store/_car.py
+++ b/packages/modules/common/store/_car.py
@@ -2,15 +2,15 @@ from helpermodules import compatibility
 from modules.common.component_state import CarState
 from modules.common.store import ValueStore
 from modules.common.store._broker import pub_to_broker
-from modules.common.store._ramdisk import ramdisk_write
+from modules.common.store.ramdisk import files
 
 
 class CarValueStoreRamdisk(ValueStore[CarState]):
     def __init__(self, charge_point: int):
-        self.filename = "soc" if charge_point == 1 else "soc1"
+        self.file = files.charge_points[charge_point - 1].soc
 
     def set(self, state: CarState) -> None:
-        ramdisk_write(self.filename, state.soc, 0)
+        self.file.write(state.soc)
 
 
 class CarValueStoreBroker(ValueStore[CarState]):

--- a/packages/modules/common/store/ramdisk/files.py
+++ b/packages/modules/common/store/ramdisk/files.py
@@ -1,0 +1,231 @@
+from builtins import property
+from typing import Generic, TypeVar, Callable, Sequence, List, Iterable, Union
+
+from modules.common.store.ramdisk.io import ramdisk_write, ramdisk_read
+
+_T = TypeVar("_T")
+
+
+class _Coder(Generic[_T]):
+    def __init__(self, decoder: Callable[[str], _T], encoder: Callable[[_T], str] = str):
+        self.encoder = encoder
+        self.decoder = decoder
+
+
+def _encode_int(value: Union[int, float]):
+    return str(int(value))
+
+
+_int_coder = _Coder(int, _encode_int)
+_float_coder = _Coder(float)
+_bool_coder = _Coder(lambda value: value == "1", lambda value: "1" if value else "0")
+
+
+class _RamdiskFile(Generic[_T]):
+    def __init__(self, filename: str, coder: _Coder[_T]):
+        self.filename = filename
+        self.coder = coder
+
+    def read(self) -> _T:
+        return self.coder.decoder(ramdisk_read(self.filename))
+
+    def write(self, value: _T):
+        ramdisk_write(self.filename, self.coder.encoder(value))
+
+    def get_filename(self):
+        return self.filename
+
+
+class _RamdiskIndexFile(Generic[_T]):
+    def __init__(self, filename_formatter: Callable[[int], str], coder: _Coder[_T]):
+        self.filename_formatter = filename_formatter
+        self.coder = coder
+
+    @staticmethod
+    def for_prefix(prefix: str, coder: _Coder[_T]):
+        return _RamdiskIndexFile(lambda index: prefix + str(index + 1), coder)
+
+    def __getitem__(self, index: int) -> _RamdiskFile[_T]:
+        return _RamdiskFile(self.filename_formatter(index), self.coder)
+
+    def read(self, range: Sequence) -> List[_T]:
+        return [self[index].read() for index in range]
+
+    def write(self, values: Iterable[_T]):
+        for index, value in enumerate(values):
+            self[index].write(value)
+
+
+def _build_filename_charge_point_phase(prefix: str, charge_point_index: int):
+    def result(phase_index: int):
+        if charge_point_index == 0:
+            return prefix + str(phase_index + 1)
+        if charge_point_index <= 2:
+            return "{}s{}{}".format(prefix, charge_point_index, phase_index + 1)
+        return "{}{}lp{}".format(prefix, phase_index + 1, charge_point_index + 1)
+
+    return result
+
+
+def _build_filename_charge_point(prefix: str, charge_point_index: int, s_limit=2):
+    if charge_point_index == 0:
+        return prefix
+    if charge_point_index <= s_limit:
+        return "{}s{}".format(prefix, charge_point_index)
+    return "{}lp{}".format(prefix, charge_point_index + 1)
+
+
+class _ChargePoint:
+    def __init__(self, charge_point_index: int):
+        self.charge_point_index = charge_point_index
+
+    @property
+    def is_charging(self):
+        return self.__create_ramdisk_file("chargestat", _bool_coder, s_limit=1)
+
+    @property
+    def voltages(self):
+        return self.__create_ramdisk_phase_file("llv", _float_coder)
+
+    @property
+    def currents(self):
+        return self.__create_ramdisk_phase_file("lla", _float_coder)
+
+    @property
+    def current_target(self):
+        return self.__create_ramdisk_file("llsoll", _int_coder)
+
+    @property
+    def energy(self):
+        """Total energy charged in Wh"""
+        return self.__create_ramdisk_file("llkwh", _float_coder)
+
+    @property
+    def is_plugged(self):
+        filename = "plugstat"
+        if self.charge_point_index == 1:
+            filename += "s1"
+        elif self.charge_point_index > 1:
+            filename += "lp" + str(self.charge_point_index + 1)
+        return _RamdiskFile(filename, _bool_coder)
+
+    @property
+    def power(self):
+        return self.__create_ramdisk_file("llaktuell", _float_coder)
+
+    @property
+    def frequency(self):
+        return self.__create_ramdisk_file("llhz", _float_coder)
+
+    @property
+    def power_factors(self):
+        return self.__create_ramdisk_phase_file("llpf", _float_coder)
+
+    @property
+    def soc(self):
+        return _RamdiskFile("soc" if self.charge_point_index == 0 else "soc" + str(self.charge_point_index), _int_coder)
+
+    def __create_ramdisk_file(self, prefix: str, coder: _Coder, s_limit=2):
+        return _RamdiskFile(_build_filename_charge_point(prefix, self.charge_point_index, s_limit), coder)
+
+    def __create_ramdisk_phase_file(self, prefix: str, coder: _Coder):
+        return _RamdiskIndexFile(_build_filename_charge_point_phase(prefix, self.charge_point_index), coder)
+
+
+class _PV:
+    def __init__(self, index: int):
+        self.prefix = "pv" if index == 0 else "pv" + str(index + 1)
+
+    @property
+    def currents(self):
+        return _RamdiskIndexFile.for_prefix(self.prefix + "a", _float_coder)
+
+    @property
+    def power(self):
+        return _RamdiskFile(self.prefix + "watt", _int_coder)
+
+    @property
+    def energy(self):
+        """Total energy produced in Wh"""
+        return _RamdiskFile(self.prefix + "kwh", _float_coder)
+
+    @property
+    def energy_k(self):
+        """Total energy produced in kWh"""
+        return _RamdiskFile(self.prefix + "kwhk", _float_coder)
+
+
+class _Battery:
+    @property
+    def power(self):
+        return _RamdiskFile("speicherleistung", _int_coder)
+
+    @property
+    def soc(self):
+        """battery state of charge. 0=empty, 100=full"""
+        return _RamdiskFile("speichersoc", _int_coder)
+
+    @property
+    def energy_imported(self):
+        """total energy imported in Wh"""
+        return _RamdiskFile("speicherikwh", _float_coder)
+
+    @property
+    def energy_exported(self):
+        """total energy exported in Wh"""
+        return _RamdiskFile("speicherekwh", _float_coder)
+
+
+class _Counter:
+    @property
+    def voltages(self):
+        return _RamdiskIndexFile.for_prefix("evuv", _float_coder)
+
+    @property
+    def currents(self):
+        return _RamdiskIndexFile.for_prefix("bezuga", _float_coder)
+
+    @property
+    def powers_import(self):
+        return _RamdiskIndexFile.for_prefix("bezugw", _int_coder)
+
+    @property
+    def power_factors(self):
+        return _RamdiskIndexFile.for_prefix("evupf", _float_coder)
+
+    @property
+    def energy_import(self):
+        """Total energy imported in Wh"""
+        return _RamdiskFile("bezugkwh", _float_coder)
+
+    @property
+    def energy_export(self):
+        """Total energy exported in Wh"""
+        return _RamdiskFile("einspeisungkwh", _float_coder)
+
+    @property
+    def power_import(self):
+        return _RamdiskFile("wattbezug", _int_coder)
+
+    @property
+    def frequency(self):
+        return _RamdiskFile("evuhz", _float_coder)
+
+
+class _RootIndex(Generic[_T]):
+    def __init__(self, factory: Callable[[int], _T]):
+        self.factory = factory
+
+    def __getitem__(self, item):
+        return self.factory(item)
+
+
+class _ChargePoints:
+    def __getitem__(self, charge_point_index: int):
+        return _ChargePoint(charge_point_index)
+
+
+charge_points = _RootIndex(_ChargePoint)
+pv = _RootIndex(_PV)
+battery = _Battery()
+evu = _Counter()

--- a/packages/modules/common/store/ramdisk/files_test.py
+++ b/packages/modules/common/store/ramdisk/files_test.py
@@ -1,0 +1,130 @@
+from modules.common.store.ramdisk import files
+
+
+def test_get_file_path():
+    # Battery
+    # -------
+    assert files.battery.energy_exported.filename == "speicherekwh"
+    assert files.battery.energy_imported.filename == "speicherikwh"
+    assert files.battery.power.filename == "speicherleistung"
+    assert files.battery.soc.filename == "speichersoc"
+
+    # Charge points
+    # -------------
+    assert files.charge_points[0].current_target.filename == "llsoll"
+    assert files.charge_points[1].current_target.filename == "llsolls1"
+    assert files.charge_points[2].current_target.filename == "llsolls2"
+    assert files.charge_points[3].current_target.filename == "llsolllp4"
+    assert files.charge_points[4].current_target.filename == "llsolllp5"
+
+    assert files.charge_points[0].currents[0].filename == "lla1"
+    assert files.charge_points[0].currents[1].filename == "lla2"
+    assert files.charge_points[0].currents[2].filename == "lla3"
+    assert files.charge_points[1].currents[0].filename == "llas11"
+    assert files.charge_points[1].currents[1].filename == "llas12"
+    assert files.charge_points[1].currents[2].filename == "llas13"
+    assert files.charge_points[2].currents[0].filename == "llas21"
+    assert files.charge_points[2].currents[1].filename == "llas22"
+    assert files.charge_points[2].currents[2].filename == "llas23"
+    assert files.charge_points[3].currents[0].filename == "lla1lp4"
+    assert files.charge_points[3].currents[1].filename == "lla2lp4"
+    assert files.charge_points[3].currents[2].filename == "lla3lp4"
+    assert files.charge_points[4].currents[0].filename == "lla1lp5"
+    assert files.charge_points[4].currents[1].filename == "lla2lp5"
+    assert files.charge_points[4].currents[2].filename == "lla3lp5"
+
+    assert files.charge_points[0].energy.filename == "llkwh"
+    assert files.charge_points[1].energy.filename == "llkwhs1"
+    assert files.charge_points[2].energy.filename == "llkwhs2"
+    assert files.charge_points[3].energy.filename == "llkwhlp4"
+    assert files.charge_points[4].energy.filename == "llkwhlp5"
+
+    assert files.charge_points[0].frequency.filename == "llhz"
+    assert files.charge_points[1].frequency.filename == "llhzs1"
+    assert files.charge_points[2].frequency.filename == "llhzs2"
+
+    assert files.charge_points[0].is_charging.filename == "chargestat"
+    assert files.charge_points[1].is_charging.filename == "chargestats1"
+    assert files.charge_points[2].is_charging.filename == "chargestatlp3"
+    assert files.charge_points[3].is_charging.filename == "chargestatlp4"
+    assert files.charge_points[4].is_charging.filename == "chargestatlp5"
+
+    assert files.charge_points[0].is_plugged.filename == "plugstat"
+    assert files.charge_points[1].is_plugged.filename == "plugstats1"
+    assert files.charge_points[2].is_plugged.filename == "plugstatlp3"
+    assert files.charge_points[3].is_plugged.filename == "plugstatlp4"
+    assert files.charge_points[4].is_plugged.filename == "plugstatlp5"
+
+    assert files.charge_points[0].power.filename == "llaktuell"
+    assert files.charge_points[1].power.filename == "llaktuells1"
+    assert files.charge_points[2].power.filename == "llaktuells2"
+    assert files.charge_points[3].power.filename == "llaktuelllp4"
+    assert files.charge_points[4].power.filename == "llaktuelllp5"
+
+    assert files.charge_points[0].power_factors[0].filename == "llpf1"
+    assert files.charge_points[0].power_factors[1].filename == "llpf2"
+    assert files.charge_points[0].power_factors[2].filename == "llpf3"
+    assert files.charge_points[1].power_factors[0].filename == "llpfs11"
+    assert files.charge_points[1].power_factors[1].filename == "llpfs12"
+    assert files.charge_points[1].power_factors[2].filename == "llpfs13"
+    assert files.charge_points[2].power_factors[0].filename == "llpfs21"
+    assert files.charge_points[2].power_factors[1].filename == "llpfs22"
+    assert files.charge_points[2].power_factors[2].filename == "llpfs23"
+
+    assert files.charge_points[0].soc.filename == "soc"
+    assert files.charge_points[1].soc.filename == "soc1"
+
+    assert files.charge_points[0].voltages[0].filename == "llv1"
+    assert files.charge_points[0].voltages[1].filename == "llv2"
+    assert files.charge_points[0].voltages[2].filename == "llv3"
+    assert files.charge_points[1].voltages[0].filename == "llvs11"
+    assert files.charge_points[1].voltages[1].filename == "llvs12"
+    assert files.charge_points[1].voltages[2].filename == "llvs13"
+    assert files.charge_points[2].voltages[0].filename == "llvs21"
+    assert files.charge_points[2].voltages[1].filename == "llvs22"
+    assert files.charge_points[2].voltages[2].filename == "llvs23"
+    assert files.charge_points[3].voltages[0].filename == "llv1lp4"
+    assert files.charge_points[3].voltages[1].filename == "llv2lp4"
+    assert files.charge_points[3].voltages[2].filename == "llv3lp4"
+    assert files.charge_points[4].voltages[0].filename == "llv1lp5"
+    assert files.charge_points[4].voltages[1].filename == "llv2lp5"
+    assert files.charge_points[4].voltages[2].filename == "llv3lp5"
+
+    # EVU
+    # ---
+    assert files.evu.currents[0].filename == "bezuga1"
+    assert files.evu.currents[1].filename == "bezuga2"
+    assert files.evu.currents[2].filename == "bezuga3"
+
+    assert files.evu.energy_export.filename == "einspeisungkwh"
+    assert files.evu.energy_import.filename == "bezugkwh"
+    assert files.evu.frequency.filename == "evuhz"
+
+    assert files.evu.power_factors[0].filename == "evupf1"
+    assert files.evu.power_factors[1].filename == "evupf2"
+    assert files.evu.power_factors[2].filename == "evupf3"
+
+    assert files.evu.power_import.filename == "wattbezug"
+
+    assert files.evu.powers_import[0].filename == "bezugw1"
+    assert files.evu.powers_import[1].filename == "bezugw2"
+    assert files.evu.powers_import[2].filename == "bezugw3"
+
+    assert files.evu.voltages[0].filename == "evuv1"
+    assert files.evu.voltages[1].filename == "evuv2"
+    assert files.evu.voltages[2].filename == "evuv3"
+
+    # PV
+    # --
+    assert files.pv[0].currents[0].filename == "pva1"
+    assert files.pv[0].currents[1].filename == "pva2"
+    assert files.pv[0].currents[2].filename == "pva3"
+    assert files.pv[1].currents[0].filename == "pv2a1"
+    assert files.pv[1].currents[1].filename == "pv2a2"
+    assert files.pv[1].currents[2].filename == "pv2a3"
+
+    assert files.pv[0].energy.filename == "pvkwh"
+    assert files.pv[1].energy.filename == "pv2kwh"
+
+    assert files.pv[0].power.filename == "pvwatt"
+    assert files.pv[1].power.filename == "pv2watt"

--- a/packages/modules/common/store/ramdisk/io.py
+++ b/packages/modules/common/store/ramdisk/io.py
@@ -3,7 +3,7 @@ from typing import Iterable, Optional, TypeVar, Callable
 
 from modules.common.store._util import get_rounding_function_by_digits, process_error
 
-RAMDISK_PATH = Path(__file__).resolve().parents[4] / "ramdisk"
+RAMDISK_PATH = Path(__file__).resolve().parents[5] / "ramdisk"
 
 T = TypeVar('T')
 
@@ -26,7 +26,9 @@ def ramdisk_write(file: str, value, digits: Optional[int] = None) -> None:
 
 
 def ramdisk_read(file: str) -> str:
-    return (RAMDISK_PATH / file).read_text()
+    # Using `strip`, because oftentimes values are written from bash like `echo value > file` which adds a newline at
+    # the end of file
+    return (RAMDISK_PATH / file).read_text().strip()
 
 
 def ramdisk_read_mapping(file: str, mapper: Callable[[str], T], error_message: str) -> T:


### PR DESCRIPTION
Welche Dateien gibt es in der Ramdisk? Wie heißen die jetzt? Ob der LP1 eingesteckt ist steht in der Datei `plugstat`, ob LP2 eingesteckt ist in der `plugstats1` und ob LP3 eingesteckt ist in der `plugstatlp3`. Wo ist das System?

Muss in die Datei nun ein `int` oder ein `float`? Nimmt man ein `float` bei `wattbezug` zeigt das System garnichts mehr an. Nimmt man einen `int` bei der EVU-Stromstärke geht die Genauigkeit dramatisch den Bach runter.

Schön wäre es, wenn das ganze ordentlich dokumentiert wäre. Und zwar am liebsten im Code. So dass jeder verwendet, die Regeln durchgesetzt werden, die IDE einem direkt per Code-Completion vor die Auswahl stellt was geht und was nicht. Und das man nicht über die unterschiedlichen Muster der Dateinamen überhaupt nachdenken muss.

Dieser PR setzt genau das um:
![code_completion](https://user-images.githubusercontent.com/1841729/145728953-5fac722b-4ccd-4dd8-80c3-66a0b4a85bff.png)
Um bei dem Beispiel oben zu bleiben: `files.charge_points[0].is_plugged.read()` liest ob der Ladepunkt 1 eingesteckt ist. `files.charge_points[1].is_plugged.read()` macht das gleiche für den LP2. Und `files.charge_points[2].currents.write([1, 2, 3])` schreibt, dass die Ladeleistung am LP3 auf den Phasen L1, L2 und L3 = 1A, 2A und 3A beträgt. Das vereinfacht die Arbeit mit der Ramdisk ungemein.

Verwendet wird das neue System direkt von den `ValueStore`s. Außerdem habe ich auch das Discovergy-Bezugsmodul und das SoC-Modul Manuell+Berechnung angepasst.

Nebenbei habe ich bemerkt, dass das bisherige Discovergy-Modul garnicht vollständig funktioniert. BEVOR ich den Code umgestellt habe, habe ich mir angesehen was auf der Statusseite bei mir (mit dem Discovergy-Modul) angezeigt wird:
![kl_discovergy_broken](https://user-images.githubusercontent.com/1841729/145727827-0c5c88da-4bad-47b2-81d0-318d668f4795.png)


Das wichtigste (die Gesamtleistung) ist da. Aber die Werte für die einzelnen Phasen fehlen. Das habe ich nun im Zuge von diesem PR auch gleich gefixt. Jetzt sieht es so aus:
![kl_discovergy_fixed](https://user-images.githubusercontent.com/1841729/145727834-12a0c289-f5aa-493a-b0e3-84ac38387f76.png)

