### PR TITLE
Inverter Value Store verwenden

### DIFF
--- a/modules/wr_kostalpiko/kostal_piko_var1.py
+++ b/modules/wr_kostalpiko/kostal_piko_var1.py
@@ -4,7 +4,9 @@ from datetime import datetime, timezone
 import os
 import requests
 import sys
-import traceback
+
+from modules.common.component_state import InverterState
+from modules.common.store import get_inverter_value_store
 
 Debug = int(os.environ.get('debug'))
 myPid = str(os.getpid())
@@ -23,11 +25,6 @@ if Debug >= 2:
     DebugLog('Wechselrichter Kostal Piko Var 1 Speicher: ' + speichermodul)
     DebugLog('Wechselrichter Kostal Piko Var 1 IP: ' + wrkostalpikoip)
 
-if num == 1:
-    file_ext = ""
-elif num == 2:
-    file_ext = "2"
-
 # Auslesen eines Kostal Piko WR über die integrierte API des WR. Rückgabewert ist die aktuelle Wattleistung.
 if speichermodul != "none":
     params = (('dxsEntries', ['33556736', '251658753)']),)
@@ -37,28 +34,14 @@ else:
     pvwatttmp = requests.get('http://'+wrkostalpikoip+'/api/dxs.json', params=params, timeout=5).json()
 
 # aktuelle Ausgangsleistung am WR [W]
-try:
-    pvwatt = int(pvwatttmp["dxsEntries"][0]["value"])
-except:
-    traceback.print_exc()
-    exit(1)
+pvwatt = int(pvwatttmp["dxsEntries"][0]["value"])
+
 if pvwatt > 5:
     pvwatt = pvwatt*-1
 
-# zur weiteren verwendung im webinterface
 if Debug >= 1:
     DebugLog('WR Leistung: ' + str(pvwatt))
-with open("/var/www/html/openWB/ramdisk/pv"+file_ext+"watt", "w") as f:
-    f.write(str(pvwatt))
 # Gesamtzählerstand am WR [kWh]
 pvkwh = int(pvwatttmp['dxsEntries'][1]['value'])
-with open("/var/www/html/openWB/ramdisk/pv"+file_ext+"kwhk", "w") as f:
-    f.write(str(pvkwh))
 
-pvkwh = pvkwh*1000
-# zur weiteren verwendung im webinterface
-with open("/var/www/html/openWB/ramdisk/pv"+file_ext+"kwh", "w") as f:
-    f.write(str(pvkwh))
-
-
-exit(0)
+get_inverter_value_store(num).set(InverterState(counter=pvkwh*1000, power=pvwatt))

--- a/modules/wr_powerwall/powerwall.py
+++ b/modules/wr_powerwall/powerwall.py
@@ -4,10 +4,12 @@ from datetime import datetime, timezone
 import os
 import json
 import requests
-import re
 import sys
 import time
 import traceback
+
+from modules.common.component_state import InverterState
+from modules.common.store import get_inverter_value_store
 
 Debug = int(os.environ.get('debug'))
 myPid = str(os.getpid())
@@ -81,17 +83,13 @@ if speicherpwloginneeded == 1:
 
 answer = requests.get("https://"+speicherpwip+"/api/meters/aggregates", cookies=cookie, verify=False, timeout=5).json()
 pvwatt=int(answer["solar"]["instant_power"])
+pvkwh=answer["solar"]["energy_exported"]
+
 if pvwatt > 5:
-	pvwatt=pvwatt*-1
+    pvwatt=pvwatt*-1
 if Debug >= 1:
     DebugLog('WR Leistung: ' + str(pvwatt))
-with open("/var/www/html/openWB/ramdisk/pvwatt", "w") as f:
-    f.write(str(pvwatt))
-
-pvkwh=answer["solar"]["energy_exported"]
-if Debug >= 1:
     DebugLog('WR Energie: ' + str(pvkwh))
-with open("/var/www/html/openWB/ramdisk/pvkwh", "w") as f:
-    f.write(str(pvkwh))
 
-exit(0)
+
+get_inverter_value_store(1).set(InverterState(counter=pvkwh, power=pvwatt))

--- a/modules/wr_smartme/smartme.py
+++ b/modules/wr_smartme/smartme.py
@@ -1,10 +1,12 @@
 #!/usr/bin/env python3
-from datetime import datetime, timezone
 import os
-import re
-import requests
 import sys
-import traceback
+from datetime import datetime, timezone
+
+import requests
+
+from modules.common.component_state import InverterState
+from modules.common.store import get_inverter_value_store
 
 Debug = int(os.environ.get('debug'))
 myPid = str(os.getpid())
@@ -26,45 +28,17 @@ if Debug >= 2:
 # Daten einlesen
 response = requests.get(wr_smartme_url, auth=(wr_smartme_user, wr_smartme_pass), timeout=10).json()
 # Aktuelle Leistung (kW --> W)
-try:
-    wattwr = response["ActivePower"]
-    wattwr = round(wattwr * 1000, 3)
-    wattwr = int(wattwr)
-except:
-    traceback.print_exc()
-    exit(1)
+wattwr = response["ActivePower"]
+wattwr = round(wattwr * 1000, 3)
+wattwr = int(wattwr)
 
 # Zählerstand Export (kWh --> Wh)
-try:
-    pvkwh = response["CounterReadingExport"]
-    pvkwh = round(pvkwh * 1000, 3)
-except:
-    traceback.print_exc()
-    exit(1)
-# Zur Reduzierung der Datenmenge kann die folgende Zeile eingefügt werden.
-# pvkwh=$(echo "$pvkwh / 1" | bc)
-
-# Prüfen ob Werte gültig
-regex = '^[-+]?[0-9]+\.?[0-9]*$'
-if re.search(regex, wattwr) == None:
-    with open("/var/www/html/openWB/ramdisk/pvwatt", "r") as f:
-        wattwr = f.read()
-if re.search(regex, pvkwh) == None:
-    with open("/var/www/html/openWB/ramdisk/pvkwh", "r") as f:
-        pvkwh = f.read()
+pvkwh = response["CounterReadingExport"]
+pvkwh = round(pvkwh * 1000, 3)
 
 
-# Ausgabe
 if Debug >= 1:
     DebugLog('WR Leistung: ' + str(wattwr))
-with open("/var/www/html/openWB/ramdisk/pvwatt", "w") as f:
-    f.write(str(wattwr))
-if Debug >= 1:
     DebugLog('WR Energie: ' + str(pvkwh))
-with open("/var/www/html/openWB/ramdisk/pvkwh", "w") as f:
-    f.write(str(pvkwh))
-pvkwhk = round(pvkwh / 1000, 3)
-with open("/var/www/html/openWB/ramdisk/pvkwhk", "w") as f:
-    f.write(str(pvkwhk))
 
-exit(0)
+get_inverter_value_store(1).set(InverterState(counter=pvkwh, power=wattwr))

--- a/modules/wr_solarlog/solarlog.py
+++ b/modules/wr_solarlog/solarlog.py
@@ -5,7 +5,9 @@ import os
 import json
 import requests
 import sys
-import traceback
+
+from modules.common.component_state import InverterState
+from modules.common.store import get_inverter_value_store
 
 Debug = int(os.environ.get('debug'))
 myPid = str(os.getpid())
@@ -23,27 +25,14 @@ if Debug >= 2:
 data = {"801": {"170": None}}
 data = json.dumps(data)
 response = requests.post("http://"+bezug_solarlog_ip+'/getjp', data=data, timeout=5).json()
-try:
-    pvwatt = response["801"]["170"]["101"]
-except:
-    traceback.print_exc()
-    exit(1)
-try:
-    pvkwh = response["801"]["170"]["109"]
-except:
-    traceback.print_exc()
-    exit(1)
+pvwatt = response["801"]["170"]["101"]
+pvkwh = response["801"]["170"]["109"]
 
 if pvwatt > 5:
     pvwatt = pvwatt*-1
 
 if Debug >= 1:
     DebugLog('WR Leistung: ' + str(pvwatt))
-with open("/var/www/html/openWB/ramdisk/pvwatt", "w") as f:
-    f.write(str(pvwatt))
-if Debug >= 1:
     DebugLog('WR Energie: ' + str(pvkwh))
-with open("/var/www/html/openWB/ramdisk/pvkwh", "w") as f:
-    f.write(str(pvkwh))
 
-exit(0)
+get_inverter_value_store(1).set(InverterState(counter=pvkwh, power=pvwatt))

--- a/modules/wr_tripower9000/tripower.py
+++ b/modules/wr_tripower9000/tripower.py
@@ -8,6 +8,9 @@ import struct
 import traceback
 from pymodbus.client.sync import ModbusTcpClient
 
+from modules.common.component_state import InverterState
+from modules.common.store import get_inverter_value_store
+
 Debug = int(os.environ.get('debug'))
 myPid = str(os.getpid())
 
@@ -87,15 +90,6 @@ else:
     power = power * -1
     if Debug >= 1:
         DebugLog('WR Leistung: ' + str(power))
-    f = open('/var/www/html/openWB/ramdisk/pvwatt', 'w')
-    f.write(str(power))
-    f.close()
-
-    if Debug >= 1:
         DebugLog('WR Energie: ' + str(counter))
-    f = open('/var/www/html/openWB/ramdisk/pvkwh', 'w')
-    f.write(str(counter))
-    f.close()
 
-
-exit(0)
+    get_inverter_value_store(1).set(InverterState(counter=counter, power=power))


### PR DESCRIPTION
Nochmal so ein kleiner Schritt in Richtung schönerer Code, der sich leichter später zu oWB2 migrieren lässt.

Außerdem ist Smartme so wie es war nicht lauffähig, das habe ich noch gefixt.

Tripower dürfte so meines Erachtens auch nicht funktionieren, da hier noch `str.decode` aufgerufen wird (siehe auch [mein Kommentar hier](https://github.com/snaptec/openWB/pull/1578/files#r768052045).

Mir ist auch aufgefallen, dass sunways/sunwaves etwas völlig anderes tun als das alte Script. Ich gehe davon aus, dass die nicht funktionieren. Ich habe schonmal angefangen das neu zu implementieren, aber mir ist das Konstrukt suspekt: Ich finde im Internet keine Hinweise auf "sunwaves". "sunwayes" dagegen gibt es wirklich. Bis auf zwei Parameter, die möglicherweise Optional sind, sind die Skripte auch gleich. Das hinterlässt bei mir große Fragezeichen. Für das Archiv aber mal Quelltext wie ich das Bashscript übersetzt hätte:
```python
#!/usr/bin/env python3
import logging

import requests
from requests.auth import HTTPDigestAuth

from helpermodules.cli import run_using_positional_cli_args
from helpermodules.log import setup_logging_stdout
from modules.common.component_state import InverterState
from modules.common.store import get_inverter_value_store

log = logging.getLogger("Sunwaves")


def update(address: str, password: str):
    response = requests.get(
        "http://" + address + "/data/ajax.txt?CAN=1", auth=HTTPDigestAuth("customer", password)
    )
    response.raise_for_status()
    log.debug("API Response: %s", response.text)
    values = response.text.split(';')
    get_inverter_value_store(1).set(InverterState(counter=float(values[16]), power=int(values[1])))


if __name__ == '__main__':
    setup_logging_stdout()
    run_using_positional_cli_args(update)
```