### PR TITLE
automatically detect SoC-Modules that support multiple charge points

### DIFF
--- a/modules/soc_evnotifys1/main.sh
+++ b/modules/soc_evnotifys1/main.sh
@@ -1,8 +1,0 @@
-#!/bin/bash
-
-OPENWBBASEDIR=$(cd `dirname $0`/../../ && pwd)
-
-# for backward compatibility only
-# functionality is in soc_evnotify
-$OPENWBBASEDIR/modules/soc_evnotify/main.sh 2
-exit 0

--- a/modules/soc_manuallp2/main.sh
+++ b/modules/soc_manuallp2/main.sh
@@ -1,8 +1,0 @@
-#!/bin/bash
-
-OPENWBBASEDIR=$(cd `dirname $0`/../../ && pwd)
-
-# for backward compatibility only
-# functionality is in soc_manual
-$OPENWBBASEDIR/modules/soc_manual/main.sh 2
-exit 0


### PR DESCRIPTION
Zwei Dinge gehe ich hier an. Die Hauptmotivation ist, dass es unschön ist, dass es jede Menge SoC-Module doppelt gibt. Das bläht das "modules"-Verzeichnis unnötig auf und sorgt für doppelten Code. In Vergangenheit hat das offensichtlich immer wieder dazu verleitet für die Unterstützung von einem 2. Ladepunkt einfach das Script vom ersten Ladepunkt zu kopieren und dann nur ein paar Pfade anzupassen. Bei den geschickteren Modulen gibt es im Verzeichnis für den LP2 ein Script welches mit Parameter auf das Script vom LP1 umleitet. Dennoch ist das wieder ein unnötiger weiterer Prozessstart und unnötig kompliziert zu verstehen.

Dieser PR ist ein erster Schritt dazu das zu ändern. Die niemand Lust auf einen Monster-PR hat in der alle Module sich plötzlich ändern muss das ganze aber rückwärtskompatibel sein und muss für die bestehenden Module ohne Anpassung weiter funktionieren. Meine Lösung dafür ist den Aufruf für LP1 grundsätzlich unangetastet zu lassen und beim Aufruf für LP2 sich nur anders zu verhalten, wenn die dafür passende `main.sh` fehlt. Nur wenn beides der Fall ist (LP2 UND keine passende main.sh) wird das neue Verfahren angewandt und die `main.sh` vom Modul für den LP1 mit einem Parameter der den Ladepunkt angibt aufgerufen.

Im Einsatz ist das ganze im Rahmen dieses PRs für EVNotify und Manuell+Berechnung.

~~Die zweite Änderung betrifft wie die Module aufgerufen werden. Während ich die Änderung umgesetzt habe ist mir aufgefallen, dass der Aufruf bisher so war:~~
```bash
modules/$socmodul/main.sh &
soc=$(</var/www/html/openWB/ramdisk/soc)
```
~~Durch das `&` wird das Modul als paraleller Prozess aufgerufen, der im Hintergrund läuft. Direkt danach wird auf die SoC-Datei zugegriffen, in die das SoC-Modul reinschreibt. Das führt zu einer Race-Condition. Wenn gleichzeitig geschrieben und gelesen wird, dann passiert am Ende irgendwas, aber nicht unbedingt das, was man sich gewünscht hat. Jetzt liegt die Datei auf einer schnellen Ramdisk und die Datei ist sehr klein, dadurch ist die Wahrscheinlichkeit, dass etwas schief geht gering, aber es ist möglich. Ein weiterer Punkt ist, dass das Script den Eindruck vermittelt, dass es gerne den SoC laden möchte, denn das SoC-Modul gerade geschrieben hat. Das wird in den allermeisten Fällen nicht klappen, denn das SoC-Modul ist noch nicht durch. Dass der SoC noch vom vorherigen Durchlauf kam wird zwar wahrscheinlich meistens nicht auffallen, unschön ist es trotzdem. Daher habe ich das `&` entfernt und stattdessen ein `timeout 5` hinzugefügt, damit die oWB nicht blockiert, falls mal ein SoC-Modul klemmt.~~

Ich habe die Änderung mit der Paralellisierung nochmal wieder rausgenommen. Die Python-Scripte haben ein Startup-Time des Todes. Das ist wohl doch ganz sinnvoll etwas zu paralellisieren, sonst hält das den ganzen Betrieb auf. Zwar ist es schon auch ein Gedanke daran was zu machen, aber da das Thema doch größer ist als initial gedacht besser seperat.