### PR TITLE
fix endianness for SolarEdge battery values

### DIFF
--- a/packages/modules/common/modbus.py
+++ b/packages/modules/common/modbus.py
@@ -62,7 +62,8 @@ class ModbusClient:
     def __read_registers(self, read_register_method: Callable,
                          address: int,
                          types: Union[Iterable[ModbusDataType], ModbusDataType],
-                         big_endian: bool = True,
+                         byteorder: Endian = Endian.Big,
+                         wordorder: Endian = Endian.Big,
                          **kwargs):
         try:
             multi_request = isinstance(types, Iterable)
@@ -78,8 +79,7 @@ class ModbusClient:
                 address, number_of_addresses, **kwargs)
             if response.isError():
                 raise FaultState.error(__name__+" "+str(response))
-            decoder = BinaryPayloadDecoder.fromRegisters(
-                response.registers, Endian.Big if big_endian else Endian.Little)
+            decoder = BinaryPayloadDecoder.fromRegisters(response.registers, byteorder, wordorder)
             result = [getattr(decoder, t.decoding_method)() for t in types]
             return result if multi_request else result[0]
         except pymodbus.exceptions.ConnectionException as e:
@@ -96,27 +96,38 @@ class ModbusClient:
                                    str(e)) from e
 
     @overload
-    def read_holding_registers(self, address: int, types: Iterable[ModbusDataType], **kwargs) -> List[Number]:
+    def read_holding_registers(self, address: int, types: Iterable[ModbusDataType], byteorder: Endian = Endian.Big,
+                               wordorder: Endian = Endian.Big, **kwargs) -> List[Number]:
         pass
 
     @overload
-    def read_holding_registers(self, address: int, types: ModbusDataType, **kwargs) -> Number:
+    def read_holding_registers(self, address: int, types: ModbusDataType, byteorder: Endian = Endian.Big,
+                               wordorder: Endian = Endian.Big, **kwargs) -> Number:
         pass
 
     def read_holding_registers(self, address: int,
                                types: Union[Iterable[ModbusDataType], ModbusDataType],
+                               byteorder: Endian = Endian.Big,
+                               wordorder: Endian = Endian.Big,
                                **kwargs):
-        return self.__read_registers(self.delegate.read_holding_registers, address, types, **kwargs)
+        return self.__read_registers(
+            self.delegate.read_holding_registers, address, types, byteorder, wordorder, **kwargs
+        )
 
     @overload
-    def read_input_registers(self, address: int, types: Iterable[ModbusDataType], **kwargs) -> List[Number]:
+    def read_input_registers(self, address: int, types: Iterable[ModbusDataType], byteorder: Endian = Endian.Big,
+                             wordorder: Endian = Endian.Big,
+                             **kwargs) -> List[Number]:
         pass
 
     @overload
-    def read_input_registers(self, address: int, types: ModbusDataType, **kwargs) -> Number:
+    def read_input_registers(self, address: int, types: ModbusDataType, byteorder: Endian = Endian.Big,
+                             wordorder: Endian = Endian.Big, **kwargs) -> Number:
         pass
 
     def read_input_registers(self, address: int,
                              types: Union[Iterable[ModbusDataType], ModbusDataType],
+                             byteorder: Endian = Endian.Big,
+                             wordorder: Endian = Endian.Big,
                              **kwargs):
-        return self.__read_registers(self.delegate.read_input_registers, address, types, **kwargs)
+        return self.__read_registers(self.delegate.read_input_registers, address, types, byteorder, wordorder, **kwargs)


### PR DESCRIPTION
Scheint so als würde mein tolles neues SolarEdge-Modul (#1685) nicht richtig funktionieren, wenn eine Batterie angeschlossen ist. Nach nochmaligem genauen Studium des alten Codes glaube ich, dass es an der wordorder liegt, die bei Floats plötzlich Little Endian ist.

Wenn das so stimmt, dann würde dieser PR das Problem beheben. Im Forum habe ich einen betroffenen noch um einen Test gebeten, der noch aussteht: https://openwb.de/forum/viewtopic.php?p=52594#p52594

Außerdem habe ich ein paar Logausgaben hinzugefügt.