### PR TITLE
fix: component id must be a number, not string

### DIFF
--- a/packages/modules/json/device.py
+++ b/packages/modules/json/device.py
@@ -106,7 +106,7 @@ def read_legacy(argv: List[str]) -> None:
             "jq_power": argv[3],
             "jq_counter": argv[4]
         }
-        num = argv[5]
+        num = int(argv[5])
 
     component_config["id"] = num
     dev.add_component(component_config)


### PR DESCRIPTION
[Aus dem Forum](https://openwb.de/forum/viewtopic.php?p=52626#p52626):

> Das neue JSON Modul für PV funktioniert nicht mehr 
> ```
> 2021-12-16 13:44:53: PID: 3929: root: Json Wechselrichter: FaultState FaultStateLevel.ERROR, FaultStr Unbekannte PV-Nummer 1, Traceback:
> Traceback (most recent call last):
>   File "/var/www/html/openWB/packages/modules/json/device.py", line 65, in update
>     self._components[component].update(response)
>   File "/var/www/html/openWB/packages/modules/json/inverter.py", line 58, in update
>     self.__store.set(inverter_state)
>   File "/var/www/html/openWB/packages/modules/common/store/_inverter.py", line 27, in set
>     raise FaultState.from_exception(e)
>   File "/var/www/html/openWB/packages/modules/common/store/_inverter.py", line 20, in set
>     raise FaultState.error("Unbekannte PV-Nummer " + str(self.num))
> modules.common.fault_state.FaultState: ('Unbekannte PV-Nummer 1', <FaultStateLevel.ERROR: 2>)
> ```

Der Fehler ist offensichtlich.

Getestet ob das Modul noch weitere Fehler hat habe ich nicht.