### PR TITLE
HTTP Module: Multi command CLI-Parser & URL validation

### DIFF
--- a/packages/helpermodules/cli/_run_using_positional_cli_args.py
+++ b/packages/helpermodules/cli/_run_using_positional_cli_args.py
@@ -1,13 +1,12 @@
 import argparse
 import inspect
-from typing import Callable, Union
+from typing import Callable, Union, Dict
 
 NoneType = type(None)
 
 
-def run_using_positional_cli_args(function: Callable):
+def _add_positional_parser_args(parser: argparse.ArgumentParser, function: Callable):
     arg_spec = inspect.getfullargspec(function)
-    parser = argparse.ArgumentParser()
     for argument_name in arg_spec.args:
         type = arg_spec.annotations[argument_name]
         if hasattr(type, "__origin__") and type.__origin__ is Union:
@@ -15,5 +14,20 @@ def run_using_positional_cli_args(function: Callable):
             parser.add_argument(argument_name, nargs='?', type=type_arg)
         else:
             parser.add_argument(argument_name, type=type)
+    # We are using the parameter RUN in uppercase to avoid collision with any actual arguments. At any rate there
+    # must not be any argument with the name RUN
+    parser.set_defaults(RUN=lambda args: function(*[getattr(args, argument_name) for argument_name in arg_spec.args]))
+
+
+def run_using_positional_cli_args(specification: Union[Callable, Dict[str, Callable]]):
+    parser = argparse.ArgumentParser()
+    if isinstance(specification, dict):
+        sub_parsers = parser.add_subparsers(dest="command")
+        sub_parsers.required = True
+        for command_name, function in specification.items():
+            _add_positional_parser_args(sub_parsers.add_parser(command_name), function)
+    else:
+        _add_positional_parser_args(parser, specification)
+
     args = parser.parse_args()
-    function(*[getattr(args, argument_name) for argument_name in arg_spec.args])
+    args.RUN(args)

--- a/packages/helpermodules/cli/_run_using_positional_cli_args_test.py
+++ b/packages/helpermodules/cli/_run_using_positional_cli_args_test.py
@@ -61,3 +61,18 @@ def test_run_using_cli_args_int_arg(monkeypatch, function_factory, argv, arg_par
 
     # evaluation
     mock.assert_called_once_with(arg_parsed)
+
+
+def test_run_using_cli_args_multi_command(monkeypatch):
+    # setup
+    monkeypatch.setattr(sys, "argv", ["dummy", "a", "42"])
+    mock_a = Mock()
+    mock_b = Mock()
+    commands = {"a": create_int_arg_function(mock_a), "b": create_str_arg_function(mock_b)}
+
+    # execution
+    run_using_positional_cli_args(commands)
+
+    # evaluation
+    mock_a.assert_called_once_with(42)
+    mock_b.assert_not_called()

--- a/packages/modules/http/device.py
+++ b/packages/modules/http/device.py
@@ -1,9 +1,11 @@
 #!/usr/bin/env python3
 import re
-import sys
-from typing import Dict, List, Union
+from typing import Dict, Union
+
+from urllib3.util import parse_url
 
 from helpermodules import log
+from helpermodules.cli import run_using_positional_cli_args
 from modules.common.abstract_device import AbstractDevice
 from modules.common.component_context import SingleComponentUpdateContext
 from modules.http import bat
@@ -68,65 +70,63 @@ class Device(AbstractDevice):
             )
 
 
-def read_legacy(argv: List[str]) -> None:
-    COMPONENT_TYPE_TO_MODULE = {
-        "bat": bat,
-        "counter": counter,
-        "inverter": inverter
-    }
-    component_type = argv[1]
-
-    device_config = get_default_config()
-    regex = re.search("(http[s]?)://([0-9.]+)", argv[2])
-    device_config["configuration"]["protocol"] = regex.group(1)
-    device_config["configuration"]["domain"] = regex.group(2)
-    dev = Device(device_config)
-    if component_type in COMPONENT_TYPE_TO_MODULE:
-        component_config = COMPONENT_TYPE_TO_MODULE[component_type].get_default_config()
-        if component_type == "bat":
-            component_config["configuration"] = {
-                "power_path": __extract_url_path(argv[2]),
-                "imported_path": __extract_url_path(argv[3]),
-                "exported_path": __extract_url_path(argv[4]),
-                "soc_path": __extract_url_path(argv[5]),
-            }
-            num = None
-        elif component_type == "counter":
-            component_config["configuration"] = {
-                "power_all_path": __extract_url_path(argv[2]),
-                "imported_path": __extract_url_path(argv[3]),
-                "exported_path": __extract_url_path(argv[4]),
-                "power_l1_path": __extract_url_path(argv[5]),
-                "power_l2_path": __extract_url_path(argv[6]),
-                "power_l3_path": __extract_url_path(argv[7]),
-            }
-            num = None
-        else:
-            component_config["configuration"] = {
-                "power_path": __extract_url_path(argv[2]),
-                "counter_path": __extract_url_path(argv[3]),
-            }
-            num = int(argv[4])
-    else:
-        raise Exception(
-            "illegal component type " + component_type + ". Allowed values: " +
-            ','.join(COMPONENT_TYPE_TO_MODULE.keys())
-        )
-    component_config["id"] = num
-    dev.add_component(component_config)
-
-    log.MainLogger().debug(
-        'Http Konfiguration: ' + str(device_config["configuration"]) + str(component_config["configuration"]))
-
-    dev.update()
-
-
 def __extract_url_path(arg):
     return re.search("^(?:https?://[^/]+)?(.*)", arg).group(1)
 
 
+def run_device_legacy(device_config: dict, component_config: dict):
+    device = Device(device_config)
+    device.add_component(component_config)
+    log.MainLogger().debug(
+        'Http Konfiguration: ' + str(device_config["configuration"]) + str(component_config["configuration"])
+    )
+    device.update()
+
+
+def create_legacy_device_config(url: str):
+    parsed_url = parse_url(url)
+    device_config = get_default_config()
+    device_config["configuration"]["protocol"] = parsed_url.scheme
+    device_config["configuration"]["domain"] = parsed_url.hostname
+    return device_config
+
+
+def read_legacy_bat(power_path: str, imported_path: str, exported_path: str, soc_path: str) -> None:
+    component_config = bat.get_default_config()
+    component_config["configuration"] = {
+        "power_path": __extract_url_path(power_path),
+        "imported_path": __extract_url_path(imported_path),
+        "exported_path": __extract_url_path(exported_path),
+        "soc_path": __extract_url_path(soc_path),
+    }
+    run_device_legacy(create_legacy_device_config(power_path), component_config)
+
+
+def read_legacy_counter(power_all_path: str, imported_path: str, exported_path: str, power_l1_path: str,
+                        power_l2_path: str, power_l3_path: str):
+    component_config = counter.get_default_config()
+    component_config["configuration"] = {
+        "power_all_path": __extract_url_path(power_all_path),
+        "imported_path": __extract_url_path(imported_path),
+        "exported_path": __extract_url_path(exported_path),
+        "power_l1_path": __extract_url_path(power_l1_path),
+        "power_l2_path": __extract_url_path(power_l2_path),
+        "power_l3_path": __extract_url_path(power_l3_path),
+    }
+    run_device_legacy(create_legacy_device_config(power_all_path), component_config)
+
+
+def read_legacy_inverter(power_path: str, counter_path: str, num: int):
+    component_config = inverter.get_default_config()
+    component_config["id"] = num
+    component_config["configuration"] = {
+        "power_path": __extract_url_path(power_path),
+        "counter_path": __extract_url_path(counter_path),
+    }
+    run_device_legacy(create_legacy_device_config(power_path), component_config)
+
+
 if __name__ == "__main__":
-    try:
-        read_legacy(sys.argv)
-    except Exception:
-        log.MainLogger().exception("Fehler im HTTP Skript")
+    run_using_positional_cli_args(
+        {"bat": read_legacy_bat, "counter": read_legacy_counter, "inverter": read_legacy_inverter}
+    )

--- a/packages/modules/http/device.py
+++ b/packages/modules/http/device.py
@@ -70,8 +70,23 @@ class Device(AbstractDevice):
             )
 
 
-def __extract_url_path(arg):
-    return re.search("^(?:https?://[^/]+)?(.*)", arg).group(1)
+def create_paths_dict(**kwargs):
+    regex = re.compile("^(https?://[^/]+)(.*)")
+    result = {}
+    host_scheme = None
+    for key, path in kwargs.items():
+        if path == "none":
+            result[key] = "none"
+        else:
+            match = regex.search(path)
+            if match is None:
+                raise Exception("Invalid URL <" + path + ">: Absolute HTTP or HTTPS URL required")
+            if host_scheme is None:
+                host_scheme = match.group(1)
+            elif host_scheme != match.group(1):
+                raise Exception("All URLs must have the same scheme and host. However URLs are: " + str(kwargs))
+            result[key] = match.group(2)
+    return result
 
 
 def run_device_legacy(device_config: dict, component_config: dict):
@@ -93,36 +108,36 @@ def create_legacy_device_config(url: str):
 
 def read_legacy_bat(power_path: str, imported_path: str, exported_path: str, soc_path: str) -> None:
     component_config = bat.get_default_config()
-    component_config["configuration"] = {
-        "power_path": __extract_url_path(power_path),
-        "imported_path": __extract_url_path(imported_path),
-        "exported_path": __extract_url_path(exported_path),
-        "soc_path": __extract_url_path(soc_path),
-    }
+    component_config["configuration"] = create_paths_dict(
+        power_path=power_path,
+        imported_path=imported_path,
+        exported_path=exported_path,
+        soc_path=soc_path,
+    )
     run_device_legacy(create_legacy_device_config(power_path), component_config)
 
 
 def read_legacy_counter(power_all_path: str, imported_path: str, exported_path: str, power_l1_path: str,
                         power_l2_path: str, power_l3_path: str):
     component_config = counter.get_default_config()
-    component_config["configuration"] = {
-        "power_all_path": __extract_url_path(power_all_path),
-        "imported_path": __extract_url_path(imported_path),
-        "exported_path": __extract_url_path(exported_path),
-        "power_l1_path": __extract_url_path(power_l1_path),
-        "power_l2_path": __extract_url_path(power_l2_path),
-        "power_l3_path": __extract_url_path(power_l3_path),
-    }
+    component_config["configuration"] = create_paths_dict(
+        power_all_path=power_all_path,
+        imported_path=imported_path,
+        exported_path=exported_path,
+        power_l1_path=power_l1_path,
+        power_l2_path=power_l2_path,
+        power_l3_path=power_l3_path,
+    )
     run_device_legacy(create_legacy_device_config(power_all_path), component_config)
 
 
 def read_legacy_inverter(power_path: str, counter_path: str, num: int):
     component_config = inverter.get_default_config()
     component_config["id"] = num
-    component_config["configuration"] = {
-        "power_path": __extract_url_path(power_path),
-        "counter_path": __extract_url_path(counter_path),
-    }
+    component_config["configuration"] = create_paths_dict(
+        power_path=power_path,
+        counter_path=counter_path,
+    )
     run_device_legacy(create_legacy_device_config(power_path), component_config)
 
 


### PR DESCRIPTION
Zwei Dinge:
1. Die Funktion `read_legacy` ist lang. Sehr lang. Ich finde die recht umständlich zu lesen und zu verstehen. Ich fände es schöner das ganze wäre unterteilt in kleine logische Funktionen mit passenden Parametern. Das habe ich in diesem PR gemacht. Dazu habe ich den CLI-Argument-Parser erweitert um die Funktionalität mehrere Kommandos zu unterstützen. Das hat nebenbei den auch hier wieder den netten Vorteil, dass man eine brauchbare Fehlermeldung bekommt, wenn mit den CLI-Argumenten was nicht stimmt.
2. Aktuell nimmt das Modul Protokoll+Domain von der ersten URL die ihm in die Hände gerät und von allen anderen URLs wird der Pfad einfach abgeschnitten, wohl in der Erwartung, dass das schon gleich sein wird. Wenn das mal abweichen sollte, dann kann die Fehlersuche schwierig werden, denn die Bedingung ist nicht sonderlich offensichtlich. Im zweiten Commit dieses PRs habe ich Code hinzugefügt, der validiert, dass die URLs alle das selbe Protokoll und die selbe Domain haben und wenn nicht eine hilfeiche Lognachricht rauswerfen.

Mit diesem PR wird #1830 überflüssig, der ist hier schon integriert. Löst also auch #1827