### PR TITLE
fix issue #1833 - wr_http: fix use http module from packages and convert pv-num to int

### DIFF
--- a/modules/wr_http/main.sh
+++ b/modules/wr_http/main.sh
@@ -16,7 +16,7 @@ else
 fi
 
 
-python3 ${OPENWBBASEDIR}/packages/modules/openwb/device.py "inverter" "${wr_http_w_url}" "${wr_http_kwh_url}" "1">>${MYLOGFILE} 2>&1
+python3 ${OPENWBBASEDIR}/packages/modules/http/device.py "inverter" "${wr_http_w_url}" "${wr_http_kwh_url}" "1">>${MYLOGFILE} 2>&1
 
 pvwatt=$(<${RAMDISKDIR}/pvwatt)
 echo $pvwatt

--- a/packages/modules/http/device.py
+++ b/packages/modules/http/device.py
@@ -106,7 +106,7 @@ def read_legacy(argv: List[str]) -> None:
                 "power_path": __extract_url_path(argv[2]),
                 "counter_path": __extract_url_path(argv[3]),
             }
-            num = argv[4]
+            num = int(argv[4])
     else:
         raise Exception(
             "illegal component type " + component_type + ". Allowed values: " +


### PR DESCRIPTION
Problem ist mit issue #1833 beschrieben - http pv/wr modul funktioniert seit umstellung auf "packages" nicht mehr.
Mit diesen Änderungen geht es wieder - getestet auf meiner openWB mit HTTP PV Modul
