### PR TITLE
fix SMA: add missing redirect for log output

### DIFF
--- a/modules/wr_tripower9000/main.sh
+++ b/modules/wr_tripower9000/main.sh
@@ -1,4 +1,5 @@
 #!/bin/bash
+OPENWBBASEDIR=$(cd `dirname $0`/../../ && pwd)
 
-python3 /var/www/html/openWB/modules/wr_tripower9000/tripower.py "${wrsmawebbox}" "${tri9000ip}" "${wrsma2ip}" "${wrsma3ip}" "${wrsma4ip}"
+python3 /var/www/html/openWB/modules/wr_tripower9000/tripower.py "${wrsmawebbox}" "${tri9000ip}" "${wrsma2ip}" "${wrsma3ip}" "${wrsma4ip}" >> "$OPENWBBASEDIR/ramdisk/openWB.log" 2>&1
 cat /var/www/html/openWB/ramdisk/pvwatt


### PR DESCRIPTION
Wenn man logging aktiviert hat funktioniert das SMA-Modul nicht.

Kein Wunder: Der Output-Redirect für das Log fehlt. Ausgabe soll aber nur die Leistung sein und nicht das ganze log.