### PR TITLE
Improve soc_i3 error handling

### DIFF
--- a/modules/soc_i3/index.php
+++ b/modules/soc_i3/index.php
@@ -40,10 +40,17 @@ class Battery_API {
 
 	function cache_remote_token( $token_data ) {
 		$cuser = $this->auth["username"];
-		$content = json_decode( @file_get_contents(
+		if (file_exists($this->token_file))
+		{
+			$content = json_decode( @file_get_contents(
 				$this->token_file
-			)
-		);
+			));
+		}
+		else
+		{
+			$content = (object)array();
+		}
+
 		$content->$cuser = $token_data;
 		file_put_contents(
 			$this->token_file,
@@ -52,34 +59,48 @@ class Battery_API {
 	}
 
 
-
 	function get_cached_token() {
-		$cuser = $this->auth["username"];
-		$json_content = json_decode(
-			@file_get_contents(
-				$this->token_file
-			)
-		);
 
-		//echo json_encode($json_content);
-		if(!empty($json_content->token)) {
-			unset($json_content["token"]);
+		try
+		{
+			$cuser = $this->auth["username"];
+			$json_content = json_decode(
+				@file_get_contents(
+					$this->token_file
+				)
+			);
+
+			//echo json_encode($json_content);
+			if(!empty($json_content->token)) {
+				unset($json_content["token"]);
+			}
+			if(!empty($json_content->expires)) {
+				unset($json_content["expires"]);
+			}
+
+			//echo json_encode($json_content);
+			file_put_contents(
+				$this->token_file,
+				json_encode( $json_content )
+			);
+
+			return json_decode(
+				@file_get_contents(
+					$this->token_file
+				)
+			)->$cuser;
 		}
-		if(!empty($json_content->expires)) {
-			unset($json_content["expires"]);
+		catch(Exception $e)
+		{
+			// Something must be really defective in this file but we don't know what exactly.
+			// So we delete the file and have it re-created from scratch (because we return null).
+			if (file_exists($this->token_file))
+			{
+				unlink ($this->token_file);
+			}
+
+			return NULL;
 		}
-
-		//echo json_encode($json_content);
-		file_put_contents(
-			$this->token_file,
-			json_encode( $json_content )
-		);
-
-		return json_decode(
-			@file_get_contents(
-				$this->token_file
-			)
-		)->$cuser;
 	}
 
 
@@ -175,6 +196,9 @@ class Battery_API {
 		$response_1 = curl_multi_getcontent( $ch_1 );
 		$response_2 = curl_multi_getcontent( $ch_2 );
 
+		//echo "Response 1: '" . $response_1 . "'\n";
+		//echo "Response 2: '" . $response_2 . "'\n";
+
 		// Decode response
 		$json = (object)array_merge(
 			json_decode( $response_1, true )['attributesMap'],
@@ -205,7 +229,9 @@ class Battery_API {
 		$chargingLevel = intval( $attributes->chargingLevelHv );
 		$chargingActive = intval( $attributes->charging_status === 'CHARGINGACTIVE' );
 		$chargingError = intval( $attributes->charging_status === 'CHARGINGERROR' );
-		$chargingTimeRemaining = intval( $attributes->remaining_charging_time_minutes );
+
+		// following property seems only present in BMW API if the EV is actually charging
+		$chargingTimeRemaining = isset($attributes->remaining_charging_time_minutes) ? intval( $attributes->remaining_charging_time_minutes ) : 0;
 		//$chargingTimeRemaining = ( $chargingTimeRemaining ? ( date( 'H:i', mktime( 0, $chargingTimeRemaining ) ) ) : '0:00' );
 
 		$stateOfCharge = number_format( round( $attributes->soc, 2 ), 2, ',', '.');

--- a/modules/soc_i3/main.sh
+++ b/modules/soc_i3/main.sh
@@ -15,7 +15,7 @@ fi
 
 socDebug=$debug
 # for developement only
-socDebug=1
+#socDebug=1
 
 case $CHARGEPOINT in
 	2)


### PR DESCRIPTION
There seem to be cases of corrupt token file causing
```
thrown in /var/www/html/openWB/modules/soc_i3/index.php on line 66
#3 {main}
#2 /var/www/html/openWB/modules/soc_i3/index.php(260): Battery_API->__construct('1', 'meinBenutzername', 'meinPasswort', 'WBY8meineVIN')
#1 /var/www/html/openWB/modules/soc_i3/index.php(27): Battery_API->get_token()
#0 /var/www/html/openWB/modules/soc_i3/index.php(88): Battery_API->get_cached_token()
Stack trace:
PHP Fatal error: Uncaught Error: Cannot use object of type stdClass as array in /var/www/html/openWB/modules/soc_i3/index.php:66
thrown in /var/www/html/openWB/modules/soc_i3/index.php on line 66
#3 {main}
```

Though I cannot reproduce this case I've tested with various corruptions in file and missing file.

Adresses https://openwb.de/forum/viewtopic.php?p=52873#p52873