### PR TITLE
Fronius WR keine Daten bei Zähler im Verbrauchszweig

### DIFF
--- a/packages/modules/fronius/inverter.py
+++ b/packages/modules/fronius/inverter.py
@@ -106,12 +106,17 @@ class FroniusInverter:
             try:
                 with open("/var/www/html/openWB/ramdisk/pvkwh_offset", "r") as f:
                     counter_offset = int(f.read())
+            except FileNotFoundError as e:
+                log.MainLogger().exception(str(e))
+                counter_offset = 0
+            try:
                 with open("/var/www/html/openWB/ramdisk/pvkwh_start", "r") as f:
                     counter_start = int(f.read())
             except FileNotFoundError as e:
                 log.MainLogger().exception(str(e))
-            counter_offset = 0
-            counter_start = None
+                counter_start = counter - daily_yield
+                with open("/var/www/html/openWB/ramdisk/pvkwh_start", "w") as f:
+                    f.write(str(counter_start))
         else:
             topic = "openWB/system/device/" + str(self.__device_id)+"/component/" + \
                 str(self.component_config["id"])+"/counter_offset"

--- a/packages/modules/fronius/inverter.py
+++ b/packages/modules/fronius/inverter.py
@@ -151,7 +151,7 @@ class FroniusInverter:
                 with open("/var/www/html/openWB/ramdisk/pvkwh_start", "w") as f:
                     f.write(str(counter))
                 with open("/var/www/html/openWB/ramdisk/pvkwh", "r") as ff:
-                    counter_old = ff.read()
+                    counter_old = int(ff.read())
             else:
                 topic = "openWB/set/system/device/" + str(self.__device_id)+"/component/" + \
                     str(self.component_config["id"])+"/pvkwh_start"

--- a/packages/modules/fronius/meter.py
+++ b/packages/modules/fronius/meter.py
@@ -1,0 +1,6 @@
+#!/usr/bin/env python3
+from enum import Enum
+
+class MeterLocation(Enum):
+    grid = 0
+    load = 1

--- a/packages/modules/fronius/meter.py
+++ b/packages/modules/fronius/meter.py
@@ -1,6 +1,7 @@
 #!/usr/bin/env python3
 from enum import Enum
 
+
 class MeterLocation(Enum):
     grid = 0
     load = 1


### PR DESCRIPTION
Nach der Umstellung auf die Fronius Pakete werden keine Daten des WR mehr in der Übersicht angezeigt.
Siehe https://openwb.de/forum/viewtopic.php?p=52700#p52700 und https://openwb.de/forum/viewtopic.php?p=53087#p53087.

Angepasst werden:
- Position des Zählers im Verbrauchszweig
- Bessere Fehlerbehandlung bei der Berechnung der PV-Erzeugung