### PR TITLE
Add test for SMA Energy Meter

### DIFF
--- a/modules/bezug_smashm/main.sh
+++ b/modules/bezug_smashm/main.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
 
-timeout 3 python3 /var/www/html/openWB/modules/bezug_smashm/sma-em-measurement.py $smashmbezugid
+timeout 3 python3 /var/www/html/openWB/modules/bezug_smashm/sma_em_measurement.py $smashmbezugid
 wattbezug=$(</var/www/html/openWB/ramdisk/wattbezug)
 echo $wattbezug

--- a/modules/bezug_smashm/sma_em_measurement.py
+++ b/modules/bezug_smashm/sma_em_measurement.py
@@ -29,10 +29,11 @@
 """
 
 import signal
-# import smaem
 import socket
 import struct
 import sys
+from pathlib import Path
+from typing import Optional
 
 from speedwiredecoder import decode_speedwire
 
@@ -44,9 +45,7 @@ def abortprogram(signal,frame):
     sys.exit(0)
 
 def writeToFile(filename, content):
-    """Write content to file"""
-    with open(filename, 'w') as f:
-        f.write(str(content))
+    Path(filename).write_text(str(content))
 
 # abort-signal
 signal.signal(signal.SIGINT, abortprogram)
@@ -55,12 +54,11 @@ signal.signal(signal.SIGINT, abortprogram)
 #read configuration
 #parser = ConfigParser()
 #default values
-smaserials = sys.argv[1] if len(sys.argv) > 1 else None
 ipbind = '0.0.0.0'
 MCAST_GRP = '239.12.255.254'
 MCAST_PORT = 9522
 
-basepath = '/var/www/html/openWB/ramdisk/'
+basepath = str(Path(__file__).parents[2] / "ramdisk") + "/"
 #                filename:  channel
 mappingdict      = { 'evuhz':   'frequency' }
 phasemappingdict = { 'bezuga%i': { 'from': 'i%i', 'sign': True },
@@ -75,23 +73,27 @@ phasemappingdict = { 'bezuga%i': { 'from': 'i%i', 'sign': True },
 #except:
 #    print('Cannot find config /etc/smaemd/config... using defaults')
 
-sock = socket.socket(socket.AF_INET, socket.SOCK_DGRAM, socket.IPPROTO_UDP)
-sock.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)
-sock.bind(('', MCAST_PORT))
-try:
-    mreq = struct.pack("4s4s", socket.inet_aton(MCAST_GRP), socket.inet_aton(ipbind))
-    sock.setsockopt(socket.IPPROTO_IP, socket.IP_ADD_MEMBERSHIP, mreq)
-except BaseException:
-    print('could not connect to mulicast group or bind to given interface')
-    sys.exit(1)
-# processing received messages
-while True:
-    emparts = {}
-    sock_data = sock.recv(608)
+
+def run(smaserials: Optional[str] = None):
+    sock = socket.socket(socket.AF_INET, socket.SOCK_DGRAM, socket.IPPROTO_UDP)
+    sock.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)
+    sock.bind(('', MCAST_PORT))
+    try:
+        mreq = struct.pack("4s4s", socket.inet_aton(MCAST_GRP), socket.inet_aton(ipbind))
+        sock.setsockopt(socket.IPPROTO_IP, socket.IP_ADD_MEMBERSHIP, mreq)
+    except BaseException:
+        print('could not connect to mulicast group or bind to given interface')
+        sys.exit(1)
+    # processing received messages
+    while not process_datagram(sock.recv(608), smaserials):
+        pass
+
+
+def process_datagram(datagram: bytes, smaserials: Optional[str] = None):
     #Paket ignorieren, wenn es nicht dem SMA-"energy meter protocol" mit protocol id = 0x6069 entspricht
-    if sock_data[16:18] != b'\x60\x69':
-        continue
-    emparts=decode_speedwire(sock_data)
+    if datagram[16:18] != b'\x60\x69':
+        return
+    emparts=decode_speedwire(datagram)
     # Output...
     # don't know what P,Q and S means:
     # http://en.wikipedia.org/wiki/AC_power or http://de.wikipedia.org/wiki/Scheinleistung
@@ -100,7 +102,7 @@ while True:
     positive = [ 1,1,1,1 ]
     if smaserials is None or smaserials == 'none' or str(emparts['serial']) == smaserials:
         # Special treatment for positive / negative power
-        
+
         try:
             watt=int(emparts['pconsume'])
             if watt < 5:
@@ -137,4 +139,8 @@ while True:
                     writeToFile(basepath + filename, emparts[key])
         except:
             pass
-        sys.exit(0)
+        return True
+
+
+if __name__ == '__main__':
+    run(sys.argv[1] if len(sys.argv) > 1 else None)

--- a/modules/bezug_smashm/sma_em_measurement.py
+++ b/modules/bezug_smashm/sma_em_measurement.py
@@ -29,11 +29,13 @@
 """
 
 import signal
-import sys
-#import smaem
+# import smaem
 import socket
 import struct
+import sys
+
 from speedwiredecoder import decode_speedwire
+
 
 # clean exit
 def abortprogram(signal,frame):

--- a/modules/bezug_smashm/sma_em_measurement_test.py
+++ b/modules/bezug_smashm/sma_em_measurement_test.py
@@ -1,0 +1,51 @@
+import base64
+
+import pytest
+
+import sma_em_measurement as sma
+from test_utils.mock_ramdisk import MockRamdisk
+
+# This sample was collected from an SMA Energy Meter with Firmware 2.0.18.R on 2021-12-22:
+SAMPLE_SMA_ENERGY_EM = """
+U01BAAAEAqAAAAABAkQAEGBpAV1xVXzY4imVNQABBAAAAAAAAAEIAAAAAAZJYH0AAAIEAAAB03YAA
+ggAAAAASKlcgTAAAwQAAAAOpgADCAAAAAABs7fAAAAEBAAAAAAAAAQIAAAAAAHA7tMwAAkEAAAAAA
+AACQgAAAAABtNNHmAACgQAAAHTsgAKCAAAAABIyAd/4AANBAAAAAPoABUEAAAAAAAAFQgAAAAAAcc
+tgCAAFgQAAACfQgAWCAAAAAAYndxeAAAXBAAAAAaQABcIAAAAAAB1R9JwABgEAAAAAAAAGAgAAAAA
+AMHoL4AAHQQAAAAAAAAdCAAAAAACC2mY8AAeBAAAAJ9gAB4IAAAAABinDvUAAB8EAAAAQwgAIAQAA
+AOjZgAhBAAAAAPnACkEAAAAAAAAKQgAAAAAAiAQN/AAKgQAAACfQgAqCAAAAAAYhLpHcAArBAAAAA
+cIACsIAAAAAAFF1ESgACwEAAAAAAAALAgAAAAAADY1tcAAMQQAAAAAAAAxCAAAAAACUKu34AAyBAA
+AAJ9+ADIIAAAAABibCGxQADMEAAAAQswANAQAAAOmwgA1BAAAAAPnAD0EAAAAAAAAPQgAAAAAAqNm
+AhAAPgQAAACU8gA+CAAAAAAXyAkY4AA/BAAAAAEOAD8IAAAAAAB26GxwAEAEAAAAAAAAQAgAAAAAA
+Ucd26AARQQAAAAAAABFCAAAAAADCmzGsABGBAAAAJTyAEYIAAAAABfUThagAEcEAAAAPpQASAQAAA
+OkkgBJBAAAAAPokAAAAAIAElIAAAAA
+"""
+
+
+@pytest.fixture
+def mock_ramdisk(monkeypatch):
+    return MockRamdisk(monkeypatch)
+
+
+def test_process_datagram_energy_meter(mock_ramdisk):
+    # setup
+    data = base64.b64decode(SAMPLE_SMA_ENERGY_EM)
+
+    # execution
+    sma.process_datagram(data)
+
+    # evaluation
+    assert mock_ramdisk.files["wattbezug"] == "-11967"
+    assert mock_ramdisk.files["einspeisungkwh"] == "86688627.0"
+    assert mock_ramdisk.files["bezugkwh"] == "7500240.0"
+    assert mock_ramdisk.files["bezugw1"] == "-4077"
+    assert mock_ramdisk.files["bezugw2"] == "-4077"
+    assert mock_ramdisk.files["bezugw3"] == "-3813"
+    assert mock_ramdisk.files["bezuga1"] == "-17.16"
+    assert mock_ramdisk.files["bezuga2"] == "-17.1"
+    assert mock_ramdisk.files["bezuga3"] == "-16.02"
+    assert mock_ramdisk.files["evuv1"] == "238.438"
+    assert mock_ramdisk.files["evuv2"] == "239.298"
+    assert mock_ramdisk.files["evuv3"] == "238.738"
+    assert mock_ramdisk.files["evupf1"] == "0.999"
+    assert mock_ramdisk.files["evupf2"] == "0.999"
+    assert mock_ramdisk.files["evupf3"] == "1.0"


### PR DESCRIPTION
Mit diesem PR füge ich einen Unittest für den SMA Energy Meter hinzu. Genau genommen einen Test der prüft ob das Datagram korrekt dekodiert wird.

Das Ziel von dem PR ist es die Datei so wenig wie möglich anzufassen (weil sie funktioniert). Allerdings hat sich laut [diesem Thread im Forum](https://openwb.de/forum/viewtopic.php?f=9&t=4215) etwas geändert und der Test soll dabei helfen sicherzustellen, dass potentielle Fixes kompatibel sind mit dem SMA EM, der aktuell funktioniert.

Um Testdaten zu erzeugen habe ich folgendes Script geschrieben:
```python
import base64
import socket
import struct

ipbind = '0.0.0.0'
MCAST_GRP = '239.12.255.254'
MCAST_PORT = 9522


sock = socket.socket(socket.AF_INET, socket.SOCK_DGRAM, socket.IPPROTO_UDP)
sock.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)
sock.bind(('', MCAST_PORT))
mreq = struct.pack("4s4s", socket.inet_aton(MCAST_GRP), socket.inet_aton(ipbind))
sock.setsockopt(socket.IPPROTO_IP, socket.IP_ADD_MEMBERSHIP, mreq)


def parse(packet: bytes):
    packet_pos = 0
    while packet_pos < len(packet):
        channel, key, type, tarif = struct.unpack(">BBBB", packet[packet_pos : packet_pos + 4])
        print(f"received: ({channel},{key},{type},{tarif})")
        packet_pos += 4 + type


def chunkstring(string, length):
    return (string[0+i:length+i] for i in range(0, len(string), length))


while True:
    buffer = sock.recv(1024)
    if buffer[0:4] == b"SMA\0":
        print("-----")
        for s in chunkstring(base64.b64encode(buffer).decode('utf-8'), 77):
            print(s)
        print(".....")
```
Die ausgegebenen Daten (ein Base64-encodiertes Datagram) habe ich dann in den Unittest kodiert. Paralell dazu habe ich versucht möglichst gleichzeitig einen Export der Momentanwerte in meinem SMA Data Manager M zu ziehen. Dabei habe ich folgende Werte erhalten:

| Gruppe        | Name                                                         | Wert               | Übersetzter Wert | Einheit | Kanal                                   |
|---------------|--------------------------------------------------------------|--------------------|-------------------|---------|-----------------------------------------|
| Netzanschluss | Ausgangsstrom Netzeinspeisung Phase L1 am Netzanschlusspunkt | 17.46              | 17,460            | A       | Measurement.Metering.PCCMs.PlntA.phsA   |
| Netzanschluss | Ausgangsstrom Netzeinspeisung Phase L2 am Netzanschlusspunkt | 17.34              | 17,340            | A       | Measurement.Metering.PCCMs.PlntA.phsB   |
| Netzanschluss | Ausgangsstrom Netzeinspeisung Phase L3 am Netzanschlusspunkt | 16.32              | 16,320            | A       | Measurement.Metering.PCCMs.PlntA.phsC   |
| Netzanschluss | Leistung Netzbezug                                           | 0                  | 0                 | W       | Measurement.Metering.PCCMs.PlntCsmpW    |
| Netzanschluss | Energiebezug am Netzanschlusspunkt                           | 7197342            | 7.197,34          | kWh     | Measurement.Metering.PCCMs.PlntCsmpWh   |
| Netzanschluss | Verschiebungsfaktor am Netzanschlusspunkt                    | 1                  | 1,00              |         | Measurement.Metering.PCCMs.PlntPF       |
| Netzanschluss | Netzspannung Phase L1 am Netzanschlusspunkt                  | 238.49800000000002 | 238,498           | V       | Measurement.Metering.PCCMs.PlntPhV.phsA |
| Netzanschluss | Netzspannung Phase L2 am Netzanschlusspunkt                  | 239.35500000000002 | 239,355           | V       | Measurement.Metering.PCCMs.PlntPhV.phsB |
| Netzanschluss | Netzspannung Phase L3 am Netzanschlusspunkt                  | 238.67000000000002 | 238,67            | V       | Measurement.Metering.PCCMs.PlntPhV.phsC |
| Netzanschluss | Anlagenblindleistung am Netzanschlusspunkt                   | 57                 | 57                | var     | Measurement.Metering.PCCMs.PlntVAr      |
| Netzanschluss | Blindleistung Netzeinspeisung Phase L1 am Netzanschlusspunkt | -21                | -21               | var     | Measurement.Metering.PCCMs.PlntVAr.phsA |
| Netzanschluss | Blindleistung Netzeinspeisung Phase L2 am Netzanschlusspunkt | -39                | -39               | var     | Measurement.Metering.PCCMs.PlntVAr.phsB |
| Netzanschluss | Blindleistung Netzeinspeisung Phase L3 am Netzanschlusspunkt | 117                | 117               | var     | Measurement.Metering.PCCMs.PlntVAr.phsC |
| Netzanschluss | Leistung Netzeinspeisung                                     | 12177              | 12,18             | kW      | Measurement.Metering.PCCMs.PlntW        |
| Netzanschluss | Leistung Netzeinspeisung Phase L1 am Netzanschlusspunkt      | 4152               | 4.152             | W       | Measurement.Metering.PCCMs.PlntW.phsA   |
| Netzanschluss | Leistung Netzeinspeisung Phase L2 am Netzanschlusspunkt      | 4143               | 4.143             | W       | Measurement.Metering.PCCMs.PlntW.phsB   |
| Netzanschluss | Leistung Netzeinspeisung Phase L3 am Netzanschlusspunkt      | 3879               | 3.879             | W       | Measurement.Metering.PCCMs.PlntW.phsC   |
| Netzanschluss | Eingespeiste Energie am Netzanschlusspunkt                   | 78572460           | 78,572            | MWh     | Measurement.Metering.PCCMs.PlntWh       |

Die Werte erscheinen mir alle plausibel, bis auf "Eingespeiste Energie am Netzanschlusspunkt" und "Energiebezug am Netzanschlusspunkt". Allerdings stimmen die Werte, die in dem Test rauskommen mit den Werten im ennexOS-Portal überein, daher denke ich ist das eher irgend eine Fehlinterpretation von mir in der Tabelle oben und die Werte sind eigentlich korrekt.