### PR TITLE
chmod the git commit detail files of atreboot

### DIFF
--- a/runs/atreboot.sh
+++ b/runs/atreboot.sh
@@ -371,6 +371,8 @@ sudo git -C /var/www/html/openWB show --pretty='format:%ci [%h]' | head -n1 > /v
 commitId=`git -C /var/www/html/openWB log --format="%h" -n 1`
 echo $commitId > /var/www/html/openWB/ramdisk/currentCommitHash
 echo `git -C /var/www/html/openWB branch -a --contains $commitId | perl -nle 'm|.*origin/(.+).*|; print $1' | uniq | xargs` > /var/www/html/openWB/ramdisk/currentCommitBranches
+sudo chmod 777 /var/www/html/openWB/ramdisk/currentCommitHash
+sudo chmod 777 /var/www/html/openWB/ramdisk/currentCommitBranches
 
 # update broker
 echo "update broker..."


### PR DESCRIPTION
As the cron job runs as normal user `pi` it causes

```
/var/www/html/openWB/runs/cron5min.sh: Zeile 390: /var/www/html/openWB/ramdisk/currentCommitHash: Keine Berechtigung
/var/www/html/openWB/runs/cron5min.sh: Zeile 391: /var/www/html/openWB/ramdisk/currentCommitBranches: Keine Berechtigung
```

Added chmod 777, similar to other files, in atreboot.sh so the files
can be updated by cron job as regular user.