### PR TITLE
Bei Autoladen reduzieren / abschalten überarbeitet

### DIFF
--- a/runs/mqttsub.py
+++ b/runs/mqttsub.py
@@ -185,7 +185,7 @@ def on_message(client, userdata, msg):
                     client.publish("openWB/config/get/SmartHome/Devices/"+str(devicenumb)+"/device_einschaltschwelle", msg.payload.decode("utf-8"), qos=0, retain=True)
             if (( "openWB/config/set/SmartHome/Device" in msg.topic) and ("device_deactivateWhileEvCharging" in msg.topic)):
                 devicenumb=re.sub(r'\D', '', msg.topic)
-                if ( 1 <= int(devicenumb) <= numberOfSupportedDevices and 0 <= int(msg.payload) <= 1):
+                if ( 1 <= int(devicenumb) <= numberOfSupportedDevices and 0 <= int(msg.payload) <= 2):
                     writetoconfig(shconfigfile,'smarthomedevices','device_deactivateWhileEvCharging_'+str(devicenumb), msg.payload.decode("utf-8"))
                     client.publish("openWB/config/get/SmartHome/Devices/"+str(devicenumb)+"/device_deactivateWhileEvCharging", msg.payload.decode("utf-8"), qos=0, retain=True)
             if (( "openWB/config/set/SmartHome/Device" in msg.topic) and ("device_ausschaltschwelle" in msg.topic)):

--- a/runs/smarthomehandler.py
+++ b/runs/smarthomehandler.py
@@ -653,7 +653,7 @@ def getdevicevalues():
                 deactivatewhileevcharging = int(config.get('smarthomedevices', 'device_deactivatewhileevcharging_'+str(i)))
             except:
                 deactivatewhileevcharging = 0
-            if deactivatewhileevcharging == 1:
+            if deactivatewhileevcharging > 0:
             # nach startup alle aktiven devices mit Autoladen aus als other fuehren
                 DeviceCounters.update( {str(i) + "mantime" : time.time()})
         DeviceConfiguredOld[i-1] = DeviceConfigured[i-1]
@@ -673,7 +673,7 @@ def getdevicevalues():
             mineinschaltdauer = int(config.get('smarthomedevices', 'device_mineinschaltdauer_'+str(numberOfDevices))) * 60
         except:
             mineinschaltdauer = 0
-        if deactivatewhileevcharging == 1:
+        if deactivatewhileevcharging > 0:
             if str(numberOfDevices)+"eintime" in DeviceCounters:
                 timestart = int(time.time()) - int(DeviceCounters[str(numberOfDevices)+"eintime"])
                 if ( mineinschaltdauer < timestart):
@@ -1139,38 +1139,43 @@ def conditions(nummer):
             logDebug(LOGLEVELDEBUG,"(" + str(nummer) + ")" + str(name) + " Maximale Einschaltdauer erreicht bereits abgeschaltet")
         return
     # Auto ladung
-    if deactivatewhileevcharging == 1:
+    if deactivatewhileevcharging > 0:
         if ( DeviceValues[str(nummer)+"relais"] == 1 ):
-            logDebug(LOGLEVELDEBUG,"(" + str(nummer) + ") " + str(name) + " Soll reduziert werden bei Ladung, pruefe " + str( testcharge))
+            logDebug(LOGLEVELDEBUG,"(" + str(nummer) + ") " + str(name) + " Soll reduziert/abgeschaltet werden bei Ladung, pruefe " + str( testcharge))
             if chargestatus == 1:
                 logDebug(LOGLEVELDEBUG,"(" + str(nummer) + ") " + str(name) + " Ladung läuft, pruefe Mindestlaufzeit")
                 if str(nummer)+"eintime" in DeviceCounters:
                     timestart = int(time.time()) - int(DeviceCounters[str(nummer)+"eintime"])
                     if ( mineinschaltdauer < timestart):
-                        logDebug(LOGLEVELINFO,"(" + str(nummer) + ") " + str(name)  + " Mindesteinschaltdauer erreicht, setze Ausschaltschwelle auf 0")
-                        #turndevicerelais(nummer, 0,0,1)
-                        #return
-                        ausverz = 0
-                        if (ausschwelle < 0):
-                            ausschwelle = 0
+                        if deactivatewhileevcharging == 2:
+                            logDebug(LOGLEVELINFO,"(" + str(nummer) + ") " + str(name)  + " Mindesteinschaltdauer erreicht, schalte aus")
+                            turndevicerelais(nummer, 0,0,1)
+                            return
+                        else:
+                            logDebug(LOGLEVELINFO,"(" + str(nummer) + ") " + str(name)  + " Mindesteinschaltdauer erreicht, setze Ausschaltschwelle auf 0")
+                            ausverz = 0
+                            if (ausschwelle < 0):
+                                ausschwelle = 0
                     else:
                         logDebug(LOGLEVELINFO,"(" + str(nummer) + ") " + str(name)  + " Mindesteinschaltdauer nicht erreicht, " + str(mineinschaltdauer) + " > " + str(timestart))
                 else:
-                    logDebug(LOGLEVELINFO,"(" + str(nummer) + ") " + str(name)+ " Mindesteinschaltdauer nicht bekannt,setze Ausschaltschwelle auf 0")
-                    #turndevicerelais(nummer, 0,0,1)
-                    #return
-                    ausverz = 0
-                    if (ausschwelle < 0):
-                        ausschwelle = 0
+                    if deactivatewhileevcharging == 2:
+                        logDebug(LOGLEVELINFO,"(" + str(nummer) + ") " + str(name)+ " Mindesteinschaltdauer nicht bekannt,schalte aus")
+                        turndevicerelais(nummer, 0,0,1)
+                        return
+                    else:
+                        logDebug(LOGLEVELINFO,"(" + str(nummer) + ") " + str(name)+ " Mindesteinschaltdauer nicht bekannt,setze Ausschaltschwelle auf 0")
+                        ausverz = 0
+                        if (ausschwelle < 0):
+                            ausschwelle = 0
             else:
                 logDebug(LOGLEVELDEBUG,"(" + str(nummer) + ") " + str(name) + " Ladung läuft nicht, pruefe weiter")
-        #else:
-            #logDebug(LOGLEVELDEBUG,"(" + str(nummer) + ") " + str(name) + " Soll nicht eingeschaltet werden bei Ladung, pruefe " + str( testcharge) )
-            #if chargestatus == 1:
-                #logDebug(LOGLEVELDEBUG,"(" + str(nummer) + ") " + str(name) + " Ladung läuft, wird nicht eingeschaltet")
-                #return
-            #else:
-                #logDebug(LOGLEVELDEBUG,"(" + str(nummer) + ") " + str(name) + " Ladung läuft nicht, pruefe weiter")
+        else:
+            if deactivatewhileevcharging == 2:
+                logDebug(LOGLEVELDEBUG,"(" + str(nummer) + ") " + str(name) + " Soll nicht eingeschaltet werden bei Ladung, pruefe " + str( testcharge) )
+                if chargestatus == 1:
+                    logDebug(LOGLEVELDEBUG,"(" + str(nummer) + ") " + str(name) + " Ladung läuft, wird nicht eingeschaltet")
+                return
     # Auto ladung ende
     # Art vom ueberschussberechnung pruefen
     ueberschussberechnung = 0

--- a/web/settings/smarthomeconfig.php
+++ b/web/settings/smarthomeconfig.php
@@ -382,17 +382,24 @@ $numDevices = 9;
 									<hr class="border-secondary">
 									<div class="form-group">
 										<div class="form-row mb-1">
-											<label class="col-md-4 col-form-label">Bei Autoladen reduzieren</label>
+											<label class="col-md-4 col-form-label">Bei Autoladen...</label>
 											<div class="col">
 												<div class="btn-group btn-group-toggle btn-block" id="device_deactivateWhileEvChargingDevices<?php echo $devicenum; ?>" name="device_deactivateWhileEvCharging" data-toggle="buttons" data-default="0" value="0" data-topicprefix="openWB/config/get/SmartHome/" data-topicsubgroup="Devices/<?php echo $devicenum; ?>/">
 													<label class="btn btn-outline-info">
-														<input type="radio" name="device_deactivateWhileEvChargingDevices<?php echo $devicenum; ?>" id="device_deactivateWhileEvCharging<?php echo $devicenum; ?>0" data-option="0" value="0" checked="checked">Nein
+														<input type="radio" name="device_deactivateWhileEvChargingDevices<?php echo $devicenum; ?>" id="device_deactivateWhileEvCharging<?php echo $devicenum; ?>0" data-option="0" value="0" checked="checked">nichts tun
 													</label>
 													<label class="btn btn-outline-info">
-														<input type="radio" name="device_deactivateWhileEvChargingDevices<?php echo $devicenum; ?>" id="device_deactivateWhileEvCharging<?php echo $devicenum; ?>1" data-option="1" value="1">Ja
+														<input type="radio" name="device_deactivateWhileEvChargingDevices<?php echo $devicenum; ?>" id="device_deactivateWhileEvCharging<?php echo $devicenum; ?>1" data-option="1" value="1">Ausschaltschwelle anpassen
+													</label>
+												 	<label class="btn btn-outline-info">
+														<input type="radio" name="device_deactivateWhileEvChargingDevices<?php echo $devicenum; ?>" id="device_deactivateWhileEvCharging<?php echo $devicenum; ?>2" data-option="2" value="2">ausschalten/nicht einschalten
 													</label>
 												</div>
-												<span class="form-text small">Diese Option sorgt dafür, dass die aktuelle Leistungsaufnahme von diesem Gerät in den die Pv Überschussberechnung miteinbezogen wird. Wenn dann ein Auto geladen wird (> 1000 Watt Leistungsaufnahme), wird die Ausschaltschwelle (sofern eine Bezugsschwelle definiert ist) auf 0 gesetzt. Ebenso wird die Ausschaltverzögerung auf 0 gesetzt. Dadurch werden diese Geräte als erstes abgeschaltet, wenn das Auto lädt und der Überschuss nicht ausreicht.</span>
+												<span class="form-text small">Diese Option (bei Auschaltschwelle anpassen oder auschalten/nicht einschalten) sorgt dafür, dass die aktuelle Leistungsaufnahme von diesem Gerät in den die Pv Überschussberechnung miteinbezogen wird. Wenn dann ein Auto geladen wird (> 1000 Watt Leistungsaufnahme),<br>
+												wird bei Ausschaltschwelle anpassen: Die Ausschaltverzögerung auf 0 gesetzt und die Ausschaltschwelle (sofern eine Bezugsschwelle definiert ist) auf 0 gesetzt. Dadurch werden diese Geräte als erstes abgeschaltet, wenn das Auto lädt und der Überschuss nicht ausreicht.
+												<br>
+												wird bei ausschalten/nicht einschalten: Das Gerät abgeschaltet.		Dann steht die aktuelle Leistungsaufnahme sofort für die Autoladung zur Verfügung.										
+												</span>
 											</div>
 										</div>
 									</div>


### PR DESCRIPTION
Im smarthomehandler wurde die Option  bei Autoladen... erweitert.
Neu gibt es drei Möglichkeiten:
a) nichts tun
b) Ausschaltschwelle anpassen
c) ausschalten / nicht einschalten
c ist die neue Möglichkeit a und b ist wie heute.

Diese Option (bei Auschaltschwelle anpassen oder auschalten/nicht einschalten) sorgt dafür, dass die aktuelle Leistungsaufnahme von diesem Gerät in den die Pv Überschussberechnung miteinbezogen wird. Wenn dann ein Auto geladen wird (> 1000 Watt Leistungsaufnahme),
wird bei Ausschaltschwelle anpassen: Die Ausschaltverzögerung auf 0 gesetzt und die Ausschaltschwelle (sofern eine Bezugsschwelle definiert ist) auf 0 gesetzt. Dadurch werden diese Geräte als erstes abgeschaltet, wenn das Auto lädt und der Überschuss nicht ausreicht.
wird bei ausschalten/nicht einschalten: Das Gerät abgeschaltet. Dann steht die aktuelle Leistungsaufnahme sofort für die Autoladung zur Verfügung.

Die Beschreibung im Gui wurde angepasst und erweitert.

Siehe auch hier:
https://openwb.de/forum/viewtopic.php?f=11&t=4055&start=70