### PR TITLE
Anpassung Fronius mit S0 Zähler

### DIFF
--- a/modules/bezug_fronius_s0/main.sh
+++ b/modules/bezug_fronius_s0/main.sh
@@ -15,7 +15,7 @@ else
 	MYLOGFILE="${RAMDISKDIR}/evu.log"
 fi
 
-python3 ${OPENWBBASEDIR}/packages/modules/fronius/device.py "counter_s0" "${wrfroniusip}" "${froniuserzeugung}" "${wrfroniusisgen24}" "${froniusvar2}" "${froniusprimo}" "${froniusmeterlocation}" "${wrfronius2ip}" "${speichermodul}" >>${MYLOGFILE} 2>&1
+python3 ${OPENWBBASEDIR}/packages/modules/fronius/device.py "counter_s0" "${wrfroniusip}" "${froniuserzeugung}" "${wrfroniusisgen24}" "${froniusvar2}" "${froniusmeterlocation}" "${wrfronius2ip}" "${speichermodul}" >>${MYLOGFILE} 2>&1
 ret=$?
 
 openwbDebugLog ${DMOD} 2 "EVU RET: ${ret}"

--- a/modules/bezug_fronius_s0/main.sh
+++ b/modules/bezug_fronius_s0/main.sh
@@ -15,7 +15,7 @@ else
 	MYLOGFILE="${RAMDISKDIR}/evu.log"
 fi
 
-python3 ${OPENWBBASEDIR}/packages/modules/fronius/device.py "counter_s0" "${wrfroniusip}" "0" "0" "0" "${froniusprimo}" "0" "none" "" >>${MYLOGFILE} 2>&1
+python3 ${OPENWBBASEDIR}/packages/modules/fronius/device.py "counter_s0" "${wrfroniusip}" "${froniuserzeugung}" "${wrfroniusisgen24}" "${froniusvar2}" "${froniusprimo}" "${froniusmeterlocation}" "${wrfronius2ip}" "${speichermodul}" >>${MYLOGFILE} 2>&1
 ret=$?
 
 openwbDebugLog ${DMOD} 2 "EVU RET: ${ret}"

--- a/modules/bezug_fronius_sm/main.sh
+++ b/modules/bezug_fronius_sm/main.sh
@@ -21,7 +21,7 @@ if [[ -z "$debug" ]]; then
 	. $OPENWBBASEDIR/helperFunctions.sh
 fi
 
-python3 /var/www/html/openWB/packages/modules/fronius/device.py "counter_sm" "${wrfroniusip}" "${froniuserzeugung}" "0" "${froniusvar2}" "0" "0" "none" "" &>>$MYLOGFILE
+python3 /var/www/html/openWB/packages/modules/fronius/device.py "counter_sm" "${wrfroniusip}" "${froniuserzeugung}" "${wrfroniusisgen24}" "${froniusvar2}" "${froniusprimo}" "${froniusmeterlocation}" "${wrfronius2ip}" "${speichermodul}" &>>$MYLOGFILE
 ret=$?
 
 openwbDebugLog ${DMOD} 2 "RET: ${ret}"

--- a/modules/bezug_fronius_sm/main.sh
+++ b/modules/bezug_fronius_sm/main.sh
@@ -21,7 +21,7 @@ if [[ -z "$debug" ]]; then
 	. $OPENWBBASEDIR/helperFunctions.sh
 fi
 
-python3 /var/www/html/openWB/packages/modules/fronius/device.py "counter_sm" "${wrfroniusip}" "${froniuserzeugung}" "${wrfroniusisgen24}" "${froniusvar2}" "${froniusprimo}" "${froniusmeterlocation}" "${wrfronius2ip}" "${speichermodul}" &>>$MYLOGFILE
+python3 /var/www/html/openWB/packages/modules/fronius/device.py "counter_sm" "${wrfroniusip}" "${froniuserzeugung}" "${wrfroniusisgen24}" "${froniusvar2}" "${froniusmeterlocation}" "${wrfronius2ip}" "${speichermodul}" &>>$MYLOGFILE
 ret=$?
 
 openwbDebugLog ${DMOD} 2 "RET: ${ret}"

--- a/modules/speicher_fronius/main.sh
+++ b/modules/speicher_fronius/main.sh
@@ -18,7 +18,7 @@ fi
 
 openwbDebugLog ${DMOD} 2 "Speicher IP: ${wrfroniusip}"
 
-python3 /var/www/html/openWB/packages/modules/fronius/device.py "bat" "${wrfroniusip}" "${froniuserzeugung}" "${wrfroniusisgen24}" "0" "0" "0" "none" "" >>$MYLOGFILE 2>&1
+python3 /var/www/html/openWB/packages/modules/fronius/device.py "bat" "${wrfroniusip}" "${froniuserzeugung}" "${wrfroniusisgen24}" "0" "0" "none" "" >>$MYLOGFILE 2>&1
 ret=$?
 
 openwbDebugLog ${DMOD} 2 "RET: ${ret}"

--- a/modules/wr_fronius/main.sh
+++ b/modules/wr_fronius/main.sh
@@ -19,7 +19,7 @@ openwbDebugLog ${DMOD} 2 "WR IP: ${wrfroniusip}"
 openwbDebugLog ${DMOD} 2 "WR Gen 24: ${wrfroniusisgen24}"
 openwbDebugLog ${DMOD} 2 "WR IP2: ${wrfronius2ip}"
 
-python3 /var/www/html/openWB/packages/modules/fronius/device.py "inverter" "${wrfroniusip}" "0" "${wrfroniusisgen24}" "0" "0" "0" "${wrfronius2ip}" "${speichermodul}" "1" &>>$MYLOGFILE
+python3 /var/www/html/openWB/packages/modules/fronius/device.py "inverter" "${wrfroniusip}" "0" "${wrfroniusisgen24}" "0" "0" "${wrfronius2ip}" "${speichermodul}" "1" &>>$MYLOGFILE
 ret=$?
 
 openwbDebugLog ${DMOD} 2 "RET: ${ret}"

--- a/packages/modules/fronius/bat.py
+++ b/packages/modules/fronius/bat.py
@@ -15,7 +15,7 @@ def get_default_config() -> dict:
         "type": "bat",
         "configuration":
         {
-            "gen24": 0
+            "gen24": False
         }
     }
 
@@ -48,7 +48,7 @@ class FroniusBat:
             power = 0
 
         try:
-            if gen24 == 1:
+            if gen24:
                 soc = float(resp_json["Body"]["Data"][meter_id]["Controller"]["StateOfCharge_Relative"])
             else:
                 soc = float(resp_json["Body"]["Data"]["Inverters"]["1"]["SOC"])

--- a/packages/modules/fronius/bat.py
+++ b/packages/modules/fronius/bat.py
@@ -33,7 +33,7 @@ class FroniusBat:
     def update(self, bat: bool) -> None:
         log.MainLogger().debug("Komponente "+self.component_config["name"]+" auslesen.")
         gen24 = self.component_config["configuration"]["gen24"]
-        meter_id = self.device_config["meter_id"]
+        meter_id = str(self.device_config["meter_id"])
 
         response = requests.get(
             'http://' + self.device_config["ip_address"] + '/solar_api/v1/GetPowerFlowRealtimeData.fcgi',
@@ -49,9 +49,11 @@ class FroniusBat:
 
         try:
             if gen24:
-                soc = float(resp_json["Body"]["Data"][meter_id]["Controller"]["StateOfCharge_Relative"])
+                resp_json_id = dict(resp_json["Body"]["Data"])
+                soc = float(resp_json_id.get(meter_id)["Controller"]["StateOfCharge_Relative"])
             else:
-                soc = float(resp_json["Body"]["Data"]["Inverters"]["1"]["SOC"])
+                resp_json_id = dict(resp_json["Body"]["Data"]["Inverters"])
+                soc = float(resp_json_id.get(meter_id)["SOC"])
         except TypeError:
             # Wenn WR aus bzw. im Standby (keine Antwort), ersetze leeren Wert durch eine 0.
             soc = 0

--- a/packages/modules/fronius/counter_s0.py
+++ b/packages/modules/fronius/counter_s0.py
@@ -30,7 +30,6 @@ class FroniusS0Counter:
         self.component_info = ComponentInfo.from_component_config(component_config)
 
     def update(self, bat: bool) -> CounterState:
-        primo = self.component_config["configuration"]["primo"]
         log.MainLogger().debug("Komponente "+self.component_config["name"]+" auslesen.")
 
         response = requests.get(
@@ -51,7 +50,7 @@ class FroniusS0Counter:
         response = response.json()
         for location in response["Body"]["Data"]:
             if "EnergyReal_WAC_Minus_Absolute" in response["Body"]["Data"][location] and \
-            "EnergyReal_WAC_Plus_Absolute" in response["Body"]["Data"][location]:
+               "EnergyReal_WAC_Plus_Absolute" in response["Body"]["Data"][location]:
                 imported = float(response["Body"]["Data"][location]["EnergyReal_WAC_Minus_Absolute"])
                 exported = float(response["Body"]["Data"][location]["EnergyReal_WAC_Plus_Absolute"])
             else:

--- a/packages/modules/fronius/counter_sm.py
+++ b/packages/modules/fronius/counter_sm.py
@@ -18,7 +18,7 @@ def get_default_config() -> dict:
         "configuration":
         {
             "variant": 0,
-            "meter_location": MeterLocation.grid.value
+            "meter_location": MeterLocation.grid
         }
     }
 
@@ -81,7 +81,7 @@ class FroniusSmCounter:
         elif variant == 1:
             params = (
                 ('Scope', 'Device'),
-                ('DeviceID', meter_id),
+                ('DeviceId', meter_id),
                 ('DataCollection', 'MeterRealtimeData'),
             )
         else:
@@ -131,7 +131,7 @@ class FroniusSmCounter:
             params=(('Scope', 'System'),),
             timeout=5)
         response.raise_for_status()
-        response_json_id = response.json()["Body"]["Data"][meter_id]
+        response_json_id = dict(response.json()["Body"]["Data"]).get(meter_id)
         meter_location = self.component_config["configuration"]["meter_location"]
 
         power_all = response_json_id["SMARTMETER_POWERACTIVE_MEAN_SUM_F64"]

--- a/packages/modules/fronius/counter_sm.py
+++ b/packages/modules/fronius/counter_sm.py
@@ -125,7 +125,7 @@ class FroniusSmCounter:
         ), meter_location
 
     def __update_variant_2(self) -> Tuple[CounterState, bool]:
-        meter_id = self.device_config["meter_id"]
+        meter_id = str(self.device_config["meter_id"])
         response = requests.get(
             'http://' + self.device_config["ip_address"] + '/solar_api/v1/GetMeterRealtimeData.cgi',
             params=(('Scope', 'System'),),

--- a/packages/modules/fronius/counter_sm.py
+++ b/packages/modules/fronius/counter_sm.py
@@ -50,7 +50,7 @@ class FroniusSmCounter:
                 params=(('Scope', 'System'),),
                 timeout=5)
             response.raise_for_status()
-            counter_state.power_all = int(response.json()["Body"]["Data"]["Site"]["P_Grid"])
+            counter_state.power_all = float(response.json()["Body"]["Data"]["Site"]["P_Grid"])
             topic_str = "openWB/set/system/device/{}/component/{}/".format(
                 self.__device_id, self.component_config["id"]
             )

--- a/packages/modules/fronius/device.py
+++ b/packages/modules/fronius/device.py
@@ -107,7 +107,6 @@ def read_legacy(
         meter_id: int,
         gen24: int,
         variant: int,
-        primo: int,
         meter_location: int = meter.MeterLocation.grid.value,
         ip_address2: str = "none",
         bat_module: str = "none",
@@ -127,8 +126,6 @@ def read_legacy(
         component_config = COMPONENT_TYPE_TO_MODULE[component_type].get_default_config()
         if component_type == "bat":
             component_config["configuration"]["gen24"] = bool(gen24)
-        elif component_type == "counter_s0":
-            component_config["configuration"]["primo"] = bool(primo)
         elif component_type == "counter_sm":
             component_config["configuration"]["variant"] = variant
             component_config["configuration"]["meter_location"] = meter.MeterLocation(meter_location)

--- a/packages/modules/fronius/device.py
+++ b/packages/modules/fronius/device.py
@@ -105,10 +105,10 @@ def read_legacy(
         component_type: str,
         ip_address: str,
         meter_id: int,
-        gen24: bool,
+        gen24: int,
         variant: int,
-        primo: bool = False,
-        meter_location: str = meter.MeterLocation.grid,
+        primo: int,
+        meter_location: int = meter.MeterLocation.grid.value,
         ip_address2: str = "none",
         bat_module: str = "none",
         num: Optional[int] = None) -> None:
@@ -126,15 +126,15 @@ def read_legacy(
     if component_type in COMPONENT_TYPE_TO_MODULE:
         component_config = COMPONENT_TYPE_TO_MODULE[component_type].get_default_config()
         if component_type == "bat":
-            device_config["configuration"]["gen24"] = gen24
+            component_config["configuration"]["gen24"] = bool(gen24)
         elif component_type == "counter_s0":
-            component_config["primo"] = primo
+            component_config["configuration"]["primo"] = bool(primo)
         elif component_type == "counter_sm":
-            component_config["variant"] = variant
-            component_config["meter_location"] = meter_location
+            component_config["configuration"]["variant"] = variant
+            component_config["configuration"]["meter_location"] = meter.MeterLocation(meter_location)
         elif component_type == "inverter":
             component_config["ip_address2"] = ip_address2
-            device_config["configuration"]["gen24"] = gen24
+            component_config["configuration"]["gen24"] = bool(gen24)
             if bat_module == "speicher_fronius":
                 dev.bat_configured = True
     else:

--- a/packages/modules/fronius/inverter.py
+++ b/packages/modules/fronius/inverter.py
@@ -62,8 +62,8 @@ class FroniusInverter:
         if gen24:
             _, counter = self.__sim_count.sim_count(power, topic=topic, data=self.__simulation, prefix="pv")
         else:
-            counter = int(response.json()["Body"]["Data"]["Site"]["E_Total"])
-            daily_yield = int(response.json()["Body"]["Data"]["Site"]["E_Day"])
+            counter = float(response.json()["Body"]["Data"]["Site"]["E_Total"])
+            daily_yield = float(response.json()["Body"]["Data"]["Site"]["E_Day"])
             counter, counter_start, counter_offset = self.__calculate_offset(counter, daily_yield)
             counter = counter + counter2
             if counter > 0 and self.component_config["configuration"]["ip_address2"] == "none":
@@ -90,12 +90,12 @@ class FroniusInverter:
                                     params=params, timeout=3)
             response.raise_for_status()
             try:
-                power2 = int(response.json()["Body"]["Data"]["Site"]["P_PV"])
+                power2 = float(response.json()["Body"]["Data"]["Site"]["P_PV"])
             except TypeError:
                 # Ohne PV Produktion liefert der WR 'null', ersetze durch Zahl 0
                 power2 = 0
             if not self.component_config["configuration"]["gen24"]:
-                counter2 = int(response.json()["Body"]["Data"]["Site"]["E_Total"])
+                counter2 = float(response.json()["Body"]["Data"]["Site"]["E_Total"])
         else:
             power2 = 0
         return power2, counter2
@@ -105,13 +105,13 @@ class FroniusInverter:
         if ramdisk:
             try:
                 with open("/var/www/html/openWB/ramdisk/pvkwh_offset", "r") as f:
-                    counter_offset = int(f.read())
+                    counter_offset = float(f.read())
             except FileNotFoundError as e:
                 log.MainLogger().exception(str(e))
                 counter_offset = 0
             try:
                 with open("/var/www/html/openWB/ramdisk/pvkwh_start", "r") as f:
-                    counter_start = int(f.read())
+                    counter_start = float(f.read())
             except FileNotFoundError as e:
                 log.MainLogger().exception(str(e))
                 counter_start = counter - daily_yield

--- a/packages/modules/fronius/inverter.py
+++ b/packages/modules/fronius/inverter.py
@@ -21,7 +21,7 @@ def get_default_config() -> dict:
         "configuration":
         {
             "ip_address2": "none",
-            "gen24": 0
+            "gen24": False
         }
     }
 
@@ -59,15 +59,15 @@ class FroniusInverter:
         power1 = power
         power *= -1
         topic = "openWB/set/system/device/" + str(self.__device_id)+"/component/" + str(self.component_config["id"])+"/"
-        if gen24 == 0:
+        if gen24:
+            _, counter = self.__sim_count.sim_count(power, topic=topic, data=self.__simulation, prefix="pv")
+        else:
             counter = int(response.json()["Body"]["Data"]["Site"]["E_Total"])
             daily_yield = int(response.json()["Body"]["Data"]["Site"]["E_Day"])
             counter, counter_start, counter_offset = self.__calculate_offset(counter, daily_yield)
             counter = counter + counter2
             if counter > 0 and self.component_config["configuration"]["ip_address2"] == "none":
                 counter = self.__add_and_save_offset(daily_yield, counter, counter_start, counter_offset)
-        else:
-            _, counter = self.__sim_count.sim_count(power, topic=topic, data=self.__simulation, prefix="pv")
 
         if bat is True:
             _, counter = self.__sim_count.sim_count(power, topic=topic, data=self.__simulation, prefix="pv")
@@ -94,7 +94,7 @@ class FroniusInverter:
             except TypeError:
                 # Ohne PV Produktion liefert der WR 'null', ersetze durch Zahl 0
                 power2 = 0
-            if self.component_config["configuration"]["gen24"] == 0:
+            if not self.component_config["configuration"]["gen24"]:
                 counter2 = int(response.json()["Body"]["Data"]["Site"]["E_Total"])
         else:
             power2 = 0

--- a/packages/modules/fronius/inverter.py
+++ b/packages/modules/fronius/inverter.py
@@ -151,7 +151,7 @@ class FroniusInverter:
                 with open("/var/www/html/openWB/ramdisk/pvkwh_start", "w") as f:
                     f.write(str(counter))
                 with open("/var/www/html/openWB/ramdisk/pvkwh", "r") as ff:
-                    counter_old = int(ff.read())
+                    counter_old = float(ff.read())
             else:
                 topic = "openWB/set/system/device/" + str(self.__device_id)+"/component/" + \
                     str(self.component_config["id"])+"/pvkwh_start"

--- a/runs/updateConfig.sh
+++ b/runs/updateConfig.sh
@@ -1097,9 +1097,6 @@ updateConfig(){
 	if ! grep -Fq "froniuserzeugung=" $ConfigFile; then
 		echo "froniuserzeugung=0" >> $ConfigFile
 	fi
-	if ! grep -Fq "froniusprimo=" $ConfigFile; then
-		echo "froniusprimo=0" >> $ConfigFile
-	fi
 	if ! grep -Fq "froniusvar2=" $ConfigFile; then
 		echo "froniusvar2=0" >> $ConfigFile
 	fi

--- a/web/settings/modulconfigevu.php
+++ b/web/settings/modulconfigevu.php
@@ -707,19 +707,6 @@
 								</div>
 								<hr>
 								<div class="form-row mb-1">
-									<label class="col-md-4 col-form-label">Kompatibilitätsmodus für die Primo Reihe</label>
-									<div class="col">
-										<div class="btn-group btn-group-toggle btn-block" data-toggle="buttons">
-											<label class="btn btn-outline-info<?php if($froniusprimoold == 0) echo " active" ?>">
-												<input type="radio" name="froniusprimo" id="froniusprimoOff" value="0"<?php if($froniusprimoold == 0) echo " checked=\"checked\"" ?>>Aus
-											</label>
-											<label class="btn btn-outline-info<?php if($froniusprimoold == 1) echo " active" ?>">
-												<input type="radio" name="froniusprimo" id="froniusprimoOn" value="1"<?php if($froniusprimoold == 1) echo " checked=\"checked\"" ?>>An
-											</label>
-										</div>
-									</div>
-								</div>
-								<div class="form-row mb-1">
 									<label class="col-md-4 col-form-label">Kompatibilitätsmodus für Gen24 / neuere Symo</label>
 									<div class="col">
 										<div class="btn-group btn-group-toggle btn-block" data-toggle="buttons">


### PR DESCRIPTION
Nach der Umstellung auf die neue Paketstruktur für Fronius WR wurden im Forum Probleme gemeldet (https://openwb.de/forum/viewtopic.php?f=9&t=4489).

Dieser Pull Request enthält folgende Anpassungen:
- S0-Zählermodul liefert korrekte Daten
- Die absoluten Erzeugungswerte werden für S0-Zähler simuliert. Es wird die SimCount-Klasse benutzt, das ersetzt #1707.
- Der Kompatibilitätsmodus für die Primo Reihe wird als Standardmodus benutzt. Das ist etwas provokativ, aber im Forum habe ich keine Meldungen gefunden, wo der andere Modus jemals Daten geliefert hätte. Weiterhin ist der dahinterliegende Aufruf der Fronius SolarAPI so nicht korrekt. Die benutze Funktion 'GetPowerFlowRealtimeData' enthält den erfragten Parameter 'PowerReal_P_Sum' einfach nicht. Wenn die Rückmeldungen meine These bekräftigen, würde ich vorschlagen, die Konfiguration des Moduls auch entsprechend aufzuräumen.
- Beim Aufruf des neuen Fronius-Paktes werden alle Konfigurationsparameter übergeben und entsprechend den Variablen zugewiesen.