### PR TITLE
PV Gesamt-Anlagendaten (automatische Nachführung für Monatsertrag und … Jahresertrag) / angepasst allerneuste Nightly

### DIFF
--- a/loadvars.sh
+++ b/loadvars.sh
@@ -1189,7 +1189,15 @@ loadvars(){
 		pvallwh=$(echo "$pvkwh + $pv2kwh" |bc)
 		echo $pvallwh > /var/www/html/openWB/ramdisk/pvallwh
 	fi
-
+	# monthly / yearly fuer status rechnen (csv aus cronnight und laufend)
+	pvdaily=$(</var/www/html/openWB/ramdisk/daily_pvkwhk)
+	pvyearlycsv=$(</var/www/html/openWB/ramdisk/yearly_pvkwhk_csv)
+	pvmonthlycsv=$(</var/www/html/openWB/ramdisk/monthly_pvkwhk_csv)
+	pvyearly=$(echo "$pvdaily + $pvyearlycsv" |bc)
+	pvmonthly=$(echo "$pvdaily + $pvmonthlycsv" |bc)
+	echo $pvyearly > /var/www/html/openWB/ramdisk/yearly_pvkwhk
+	echo $pvmonthly > /var/www/html/openWB/ramdisk/monthly_pvkwhk
+	# rechnen ende
 	if [[ $speichermodul == "speicher_e3dc" ]] || [[ $speichermodul == "speicher_tesvoltsma" ]] || [[ $speichermodul == "speicher_solarwatt" ]] || [[ $speichermodul == "speicher_rct" ]]|| [[ $speichermodul == "speicher_lgessv1" ]] || [[ $speichermodul == "speicher_bydhv" ]] || [[ $speichermodul == "speicher_kostalplenticore" ]] || [[ $speichermodul == "speicher_powerwall" ]] || [[ $speichermodul == "speicher_sbs25" ]] || [[ $speichermodul == "speicher_solaredge" ]] || [[ $speichermodul == "speicher_sonneneco" ]] || [[ $speichermodul == "speicher_varta" ]] ; then
 		ra='^-?[0-9]+$'
 		watt2=$(</var/www/html/openWB/ramdisk/speicherleistung)

--- a/runs/initRamdisk.sh
+++ b/runs/initRamdisk.sh
@@ -245,6 +245,7 @@ initRamdisk(){
 	echo 0 > $RamdiskPath/daily_pvkwhk1
 	echo 0 > $RamdiskPath/daily_pvkwhk2
 	echo 0 > $RamdiskPath/monthly_pvkwhk
+	echo 0 > $RamdiskPath/monthly_pvkwhk_csv	
 	echo 0 > $RamdiskPath/monthly_pvkwhk1
 	echo 0 > $RamdiskPath/monthly_pvkwhk2
 	echo 0 > $RamdiskPath/nurpv70dynstatus
@@ -268,6 +269,7 @@ initRamdisk(){
 	echo 0 > $RamdiskPath/pvwatt1
 	echo 0 > $RamdiskPath/pvwatt2
 	echo 0 > $RamdiskPath/yearly_pvkwhk
+	echo 0 > $RamdiskPath/yearly_pvkwhk_csv
 	echo 0 > $RamdiskPath/yearly_pvkwhk1
 	echo 0 > $RamdiskPath/yearly_pvkwhk2
 


### PR DESCRIPTION
Neu werden in der Statusseite die Felder Monatsertrag und Jahresertrag (unter PV Gesamt-Anlagendaten) von openWB gerechnet (wie schon vorher das Feld Tagesertrag). Der Jahresertrag und der Monatsertrag wird im Cronnighlty basierend auf den csv Files errechnet und während dem Tag laufend mit dem Tagesertrag ergänzt.
Angepasst an allerneuste neuste Nightly
Bitte noch Feedback ob die Lösung für alle WR (so ist es jetzt umgesetzt) dienen soll, oder ob es mit zusätzlichen If auf einzelne  WR eingeschränkte werden soll.
Siehe Kommentar von hhhoefling im original pull reqeust
https://github.com/snaptec/openWB/pull/1798