### PR TITLE
Fix extremely incorrect values for carlo gavazzi caused by incorrect word order

### DIFF
--- a/packages/modules/carlo_gavazzi/counter.py
+++ b/packages/modules/carlo_gavazzi/counter.py
@@ -1,4 +1,6 @@
 #!/usr/bin/env python3
+from pymodbus.constants import Endian
+
 from helpermodules import log
 from modules.common import modbus
 from modules.common import simcount
@@ -35,12 +37,12 @@ class CarloGavazziCounter:
             "Komponente "+self.component_config["name"]+" auslesen.")
 
         voltages = [val / 10 for val in self.__tcp_client.read_input_registers(
-            0x00, [ModbusDataType.INT_32] * 3, unit=unit)]
+            0x00, [ModbusDataType.INT_32] * 3, wordorder=Endian.Little, unit=unit)]
         powers = [val / 10 for val in self.__tcp_client.read_input_registers(
-            0x12, [ModbusDataType.INT_32] * 3, unit=unit)]
+            0x12, [ModbusDataType.INT_32] * 3, wordorder=Endian.Little, unit=unit)]
         power_all = sum(powers)
         currents = [abs(val / 1000) for val in self.__tcp_client.read_input_registers(
-            0x0C, [ModbusDataType.INT_32] * 3, unit=unit)]
+            0x0C, [ModbusDataType.INT_32] * 3, wordorder=Endian.Little, unit=unit)]
         frequency = self.__tcp_client.read_input_registers(0x33, ModbusDataType.INT_16, unit=unit) / 10
         if frequency > 100:
             frequency = frequency / 10


### PR DESCRIPTION
Ich bin im Forum über [diesen Thread](https://openwb.de/forum/viewtopic.php?f=9&t=4499) gestolpert und habe den alten Code und den neuen Code verglichen. Aufgefallen ist mir, dass der alte Code Little-Endian-Word-order verwendet hat:
```python
all = format(resp.registers[1], '04x') + format(resp.registers[0], '04x')
```
Da der Codeausschnitt nicht sonderlich intuitiv ist: An der Stelle werden zwei aufeinanderfolgende Register Hex-encoded und dann die Hexwerte aneinander gefügt und später wird das Hex wieder geparst. Ein sehr komplizierter Weg, aber einer der funktioniert.

Wichtig dabei ist zu sehen, dass zuerst Register [1] und danach Register [0] genommen wird. Das entspricht der Little-Endian-Wordorder.

Wenn ich das so richtig interpretiert habe müsste der PR das Problem fixen. Ich habe allerdings genau Null Testmöglichkeit, also bitte gut hinterfragen und am schönsten wäre es, wenn das jemand testen würde.

Nebenbei ist mir noch was aufgefallen, was ich in diesem PR nicht behandele: Die Ströme werden aktuell so abgefragt:
```python
currents = [abs(val / 1000) for val in self.__tcp_client.read_input_registers(
            0x0C, [ModbusDataType.INT_32] * 3, wordorder=Endian.Little, unit=unit)]
```
Was macht das `abs` dort? Ich habe das mit dem alten Script gegengeprüft und auch das alte Script hat das genau so gemacht. Insofern ist das keine Änderung. Aber es wundert mich, dass der Wert immer positiv sein soll. Ich würde vermuten, dass die Werte für Lastmanagement rangezogen werden und das würde bedeuten, dass das Lastmanagement anspringt, wenn gerade viel eingespeist wird, obwohl dann garkein Grund dazu besteht (im Gegenteil, es wäre viel Reserve vorhanden).