### PR TITLE
delete files obsolete thanks to #1818

### DIFF
--- a/modules/soc_audilp2/main.sh
+++ b/modules/soc_audilp2/main.sh
@@ -1,8 +1,0 @@
-#!/bin/bash
-
-OPENWBBASEDIR=$(cd `dirname $0`/../../ && pwd)
-
-# for backward compatibility only
-# functionality is in soc_audi
-$OPENWBBASEDIR/modules/soc_audi/main.sh 2
-exit 0

--- a/modules/soc_carnetlp2/main.sh
+++ b/modules/soc_carnetlp2/main.sh
@@ -1,8 +1,0 @@
-#!/bin/bash
-
-OPENWBBASEDIR=$(cd `dirname $0`/../../ && pwd)
-
-# for backward compatibility only
-# functionality is in soc_carnet
-$OPENWBBASEDIR/modules/soc_carnet/main.sh 2
-exit 0

--- a/modules/soc_eqlp2/main.sh
+++ b/modules/soc_eqlp2/main.sh
@@ -1,8 +1,0 @@
-#!/bin/bash
-
-OPENWBBASEDIR=$(cd `dirname $0`/../../ && pwd)
-
-# for backward compatibility only
-# functionality is in soc_eq
-$OPENWBBASEDIR/modules/soc_eq/main.sh 2
-exit 0

--- a/modules/soc_evcclp2/main.sh
+++ b/modules/soc_evcclp2/main.sh
@@ -1,8 +1,0 @@
-#!/bin/bash
-
-OPENWBBASEDIR=$(cd `dirname $0`/../../ && pwd)
-
-# for backward compatibility only
-# functionality is in soc_evcc
-$OPENWBBASEDIR/modules/soc_evcc/main.sh 2
-exit 0

--- a/modules/soc_i3s1/main.sh
+++ b/modules/soc_i3s1/main.sh
@@ -1,8 +1,0 @@
-#!/bin/bash
-
-OPENWBBASEDIR=$(cd `dirname $0`/../../ && pwd)
-
-# for backward compatibility only
-# functionality is in soc_i3
-$OPENWBBASEDIR/modules/soc_i3/main.sh 2
-exit 0

--- a/modules/soc_idlp2/main.sh
+++ b/modules/soc_idlp2/main.sh
@@ -1,8 +1,0 @@
-#!/bin/bash
-
-OPENWBBASEDIR=$(cd `dirname $0`/../../ && pwd)
-
-# for backward compatibility only
-# functionality is in soc_id
-$OPENWBBASEDIR/modules/soc_id/main.sh 2
-exit 0

--- a/modules/soc_kialp2/main.sh
+++ b/modules/soc_kialp2/main.sh
@@ -1,8 +1,0 @@
-#!/bin/bash
-
-OPENWBBASEDIR=$(cd `dirname $0`/../../ && pwd)
-
-# for backward compatibility only
-# functionality is in soc_kia
-$OPENWBBASEDIR/modules/soc_kia/main.sh 2
-exit 0

--- a/modules/soc_leafs1/main.sh
+++ b/modules/soc_leafs1/main.sh
@@ -1,8 +1,0 @@
-#!/bin/bash
-
-OPENWBBASEDIR=$(cd `dirname $0`/../../ && pwd)
-
-# for backward compatibility only
-# functionality is in soc_leaf
-$OPENWBBASEDIR/modules/soc_leaf/main.sh 2
-exit 0

--- a/modules/soc_myopellp2/main.sh
+++ b/modules/soc_myopellp2/main.sh
@@ -1,8 +1,0 @@
-#!/bin/bash
-
-OPENWBBASEDIR=$(cd `dirname $0`/../../ && pwd)
-
-# for backward compatibility only
-# functionality is in soc_myopel
-$OPENWBBASEDIR/modules/soc_myopel/main.sh 2
-exit 0

--- a/modules/soc_mypeugeotlp2/main.sh
+++ b/modules/soc_mypeugeotlp2/main.sh
@@ -1,8 +1,0 @@
-#!/bin/bash
-
-OPENWBBASEDIR=$(cd `dirname $0`/../../ && pwd)
-
-# for backward compatibility only
-# functionality is in soc_mypeugeot
-$OPENWBBASEDIR/modules/soc_mypeugeot/main.sh 2
-exit 0

--- a/modules/soc_myrenaultlp2/main.sh
+++ b/modules/soc_myrenaultlp2/main.sh
@@ -1,8 +1,0 @@
-#!/bin/bash
-
-OPENWBBASEDIR=$(cd `dirname $0`/../../ && pwd)
-
-# for backward compatibility only
-# functionality is in soc_myrenault
-$OPENWBBASEDIR/modules/soc_myrenault/main.sh 2
-exit 0

--- a/modules/soc_psalp2/main.sh
+++ b/modules/soc_psalp2/main.sh
@@ -1,8 +1,0 @@
-#!/bin/bash
-
-OPENWBBASEDIR=$(cd `dirname $0`/../../ && pwd)
-
-# for backward compatibility only
-# functionality is in soc_psa
-$OPENWBBASEDIR/modules/soc_psa/main.sh 2
-exit 0

--- a/modules/soc_teslalp2/main.sh
+++ b/modules/soc_teslalp2/main.sh
@@ -1,8 +1,0 @@
-#!/bin/bash
-
-OPENWBBASEDIR=$(cd `dirname $0`/../../ && pwd)
-
-# for backward compatibility only
-# functionality is in soc_tesla
-$OPENWBBASEDIR/modules/soc_tesla/main.sh 2
-exit 0

--- a/modules/soc_tronitylp2/main.sh
+++ b/modules/soc_tronitylp2/main.sh
@@ -1,8 +1,0 @@
-#!/bin/bash
-
-OPENWBBASEDIR=$(cd `dirname $0`/../../ && pwd)
-
-# for backward compatibility only
-# functionality is in soc_tronity
-$OPENWBBASEDIR/modules/soc_tronity/main.sh 2
-exit 0

--- a/modules/soc_vaglp2/main.sh
+++ b/modules/soc_vaglp2/main.sh
@@ -1,8 +1,0 @@
-#!/bin/bash
-
-OPENWBBASEDIR=$(cd `dirname $0`/../../ && pwd)
-
-# for backward compatibility only
-# functionality is in soc_vag
-$OPENWBBASEDIR/modules/soc_vag/main.sh 2
-exit 0

--- a/modules/soc_volvolp2/main.sh
+++ b/modules/soc_volvolp2/main.sh
@@ -1,8 +1,0 @@
-#!/bin/bash
-
-OPENWBBASEDIR=$(cd `dirname $0`/../../ && pwd)
-
-# for backward compatibility only
-# functionality is in soc_volvo
-$OPENWBBASEDIR/modules/soc_volvo/main.sh 2
-exit 0

--- a/modules/soc_zeronglp2/main.sh
+++ b/modules/soc_zeronglp2/main.sh
@@ -1,8 +1,0 @@
-#!/bin/bash
-
-OPENWBBASEDIR=$(cd `dirname $0`/../../ && pwd)
-
-# for backward compatibility only
-# functionality is in soc_zerong
-$OPENWBBASEDIR/modules/soc_zerong/main.sh 2
-exit 0

--- a/modules/soc_zoelp2/main.sh
+++ b/modules/soc_zoelp2/main.sh
@@ -1,8 +1,0 @@
-#!/bin/bash
-
-OPENWBBASEDIR=$(cd `dirname $0`/../../ && pwd)
-
-# for backward compatibility only
-# functionality is in soc_zoe
-$OPENWBBASEDIR/modules/soc_zoe/main.sh 2
-exit 0


### PR DESCRIPTION
Seit #1818 werden SoC-Module, die mehrere LPs unterstützen für den LP2 automatisch mit einem Parameter "2" aufgerufen. Die "Weiterleitungsskripte" werden nicht mehr gebraucht und werden von diesem PR entfernt.