### PR TITLE
Bei Autoladen abschalten Korrektur

### DIFF
--- a/runs/smarthomehandler.py
+++ b/runs/smarthomehandler.py
@@ -1175,7 +1175,7 @@ def conditions(nummer):
                 logDebug(LOGLEVELDEBUG,"(" + str(nummer) + ") " + str(name) + " Soll nicht eingeschaltet werden bei Ladung, pruefe " + str( testcharge) )
                 if chargestatus == 1:
                     logDebug(LOGLEVELDEBUG,"(" + str(nummer) + ") " + str(name) + " Ladung läuft, wird nicht eingeschaltet")
-                return
+                    return
     # Auto ladung ende
     # Art vom ueberschussberechnung pruefen
     ueberschussberechnung = 0


### PR DESCRIPTION
Falsche Einrückung führt dazu das die Geräte mit Autoladen ausschalten nicht richtig funktionieren.
Siehe auch
https://openwb.de/forum/viewtopic.php?p=53321#p53321