### PR TITLE
fix: directories for old-style SoC-model might still exist...

### DIFF
--- a/loadvars.sh
+++ b/loadvars.sh
@@ -2,8 +2,9 @@
 
 run_soc_module() {
 	module_dir="modules/$1"
-	if [ -d "$module_dir" ];
+	if [ -f "$module_dir/main.sh" ]
 	then
+		openwbDebugLog "MAIN" 2 "Calling SoC-Module <$module_dir/main.sh>"
 		"$module_dir/main.sh" &
 	elif [[ "$module_dir" =~ ^(.*)((s)([1-9])|(lp)([2-9]))$ ]]; then
 		# Historically if each SoC-Module applied to a single charge point, only. Thus if multiple charge points were
@@ -18,6 +19,7 @@ run_soc_module() {
 		module_dir_lp1=${BASH_REMATCH[1]}
 		if [ -d "$module_dir_lp1" ];
 		then
+			openwbDebugLog "MAIN" 2 "Calling SoC-Module <$module_dir_lp1/main.sh>"
 			"$module_dir_lp1/main.sh" "$charge_point_num" &
 		else
 			openwbDebugLog "MAIN" 0 "Neither <$module_dir> nor <$module_dir_lp1> exist!"


### PR DESCRIPTION
...even without main.sh due to old (config) files created by those modules a long time ago

also add more logging

--

Siehe [Forum](https://openwb.de/forum/viewtopic.php?p=53342#p53342).

Kurzfassung: Manche Module haben von irgendwann mal noch irgendwelche (temporären Konfigurations)-Dateien in ihrem Ordner für den LP2 liegen. Diese Dateien werden zwar nicht mehr gebraucht, aber sie sorgen dafür, dass das Verzeichnis nicht von Git gelöscht wird und daher denkt der Code aus meinem PR #1818 dann, dass das SoC-Modul noch ein Modul nach altem Format ist und versucht die main.sh aufzurufen, die aber garnicht mehr existiert.

Dieser PR fixt das.

Außerdem kommen noch 2 weitere Logausgaben hinzu um bei Problemen das debugging zu erleichtern.