### PR TITLE
refactor SolarEdge battery module to use 2.0 style libraries

### DIFF
--- a/modules/speicher_solaredge/main.sh
+++ b/modules/speicher_solaredge/main.sh
@@ -2,5 +2,6 @@
 if [[ $solaredgespeicherip == $solaredgepvip ]]  ; then
 	echo "value read at pv modul" > /dev/null
 else
-	python /var/www/html/openWB/modules/speicher_solaredge/solaredge.py $solaredgespeicherip $solaredgezweiterspeicher
+	OPENWBBASEDIR=$(cd `dirname $0`/../../ && pwd)
+	python3 "$OPENWBBASEDIR/modules/speicher_solaredge/solaredge.py" "$solaredgespeicherip" "$solaredgezweiterspeicher" >> "${OPENWBBASEDIR}/ramdisk/openWB.log" 2>&1
 fi


### PR DESCRIPTION
Nachdem ich es schon mit dem WR-Modul von SolarEdge (#1685) und dem EVU-Modul (#1857) getan habe kenne ich mich jetzt mit SolarEdge aus und kann auch gerade noch das Batteriemodul nachziehen, als ein erster Schritt in Richtung 2.0-Modul.

So ganz viel kann eigentlich nicht schief gehen, da der Code doch recht einfach ist und ein erheblicher Teil einfach vom WR-Modul copy&paste ist, dennoch ist die Änderung so ungetestet, weil ich mangels Batterie keine Möglichkeit dazu habe.