### PR TITLE
fix huawei: modbus_id must be an int

### DIFF
--- a/packages/modules/huawei/device.py
+++ b/packages/modules/huawei/device.py
@@ -1,9 +1,10 @@
 #!/usr/bin/env python3
-import sys
 import time
-from typing import Dict, List, Union
+from typing import Dict, Union
 
 from helpermodules import log
+from helpermodules.cli import run_using_positional_cli_args
+from helpermodules.log import setup_logging_stdout
 from modules.common import modbus
 from modules.common.abstract_device import AbstractDevice
 from modules.common.component_context import SingleComponentUpdateContext
@@ -73,14 +74,12 @@ class Device(AbstractDevice):
             )
 
 
-def read_legacy(argv: List[str]) -> None:
+def read_legacy(ip_address: str, modbus_id: int) -> None:
     COMPONENT_TYPE_TO_MODULE = {
         "bat": bat,
         "counter": counter,
         "inverter": inverter
     }
-    ip_address = argv[1]
-    modbus_id = argv[2]
 
     device_config = get_default_config()
     device_config["configuration"]["ip_address"] = ip_address
@@ -108,7 +107,5 @@ def read_legacy(argv: List[str]) -> None:
 
 
 if __name__ == "__main__":
-    try:
-        read_legacy(sys.argv)
-    except Exception:
-        log.MainLogger().exception("Fehler im Huawei Skript")
+    setup_logging_stdout()
+    run_using_positional_cli_args(read_legacy)


### PR DESCRIPTION
Im Forum [wird berichtet](https://openwb.de/forum/viewtopic.php?p=53077#p53077), dass Huawei kaputt ist. Dem Stacktrace nach zu urteilen und einem Vergleich aus altem und neuen Code liegt es daran, dass die modbus_id nicht als `int` sondern als `str` vorliegt. Wenn das alles ist, dann würde dieser PR das Problem beheben. Allerdings soweit genau null getestet.