### PR TITLE
Fronius: handle WR2 ip-address as configuration

### DIFF
--- a/packages/modules/fronius/device.py
+++ b/packages/modules/fronius/device.py
@@ -130,7 +130,7 @@ def read_legacy(
             component_config["configuration"]["variant"] = variant
             component_config["configuration"]["meter_location"] = meter.MeterLocation(meter_location)
         elif component_type == "inverter":
-            component_config["ip_address2"] = ip_address2
+            component_config["configuration"]["ip_address2"] = ip_address2
             component_config["configuration"]["gen24"] = bool(gen24)
             if bat_module == "speicher_fronius":
                 dev.bat_configured = True


### PR DESCRIPTION
Fix:
Die Konfiguration der IP-Adresse für einen 2. Fronius WR wurde in die Hauptdaten der WR-Komponente übernommen. Dadurch blieb die eigentlich Konfiguration weiterhin nicht konfiguriert.

Mit dieser Änderung wird die IP-Adresse an die richtige Stelle der Komponentenkonfiguration geschrieben.
