### PR TITLE
E3DC Bezugsmodul auf  V2 Syntax umgestellt

### DIFF
--- a/modules/bezug_e3dc/e3dc.py
+++ b/modules/bezug_e3dc/e3dc.py
@@ -22,8 +22,7 @@ def update(ipaddress: str):
     currents = [0]*3
     voltages = [230]*3
     for i in range(0, 3):
-        if powers[i] > 0:
-            currents[i]=powers[i]/voltages[i]
+        currents[i]=powers[i]/voltages[i]
     get_counter_value_store(1).set(CounterState(
         power_all=power_all,
         powers=powers,

--- a/modules/bezug_e3dc/e3dc.py
+++ b/modules/bezug_e3dc/e3dc.py
@@ -16,9 +16,9 @@ def update(ipaddress: str):
     log.debug("Beginning update")
     client = ModbusClient(ipaddress, port=502)
 #40074 EVU Punkt negativ -> Einspeisung in Watt
-    power_all = client.read_holding_registers(40073, ModbusDataType.INT_32,wordorder=Endian.Little, unit=1)
+    power_all = client.read_holding_registers(40073, ModbusDataType.INT_32, wordorder=Endian.Little, unit=1)
 #40130 Phasenleistung in Watt
-    powers = [val for val in client.read_holding_registers(40129, [ModbusDataType.INT_16] * 3,unit=1)]
+    powers = client.read_holding_registers(40129, [ModbusDataType.INT_16] * 3, unit=1)
     currents = [0]*3
     voltages = [230]*3
     for i in range(0, 3):

--- a/modules/bezug_e3dc/e3dc.py
+++ b/modules/bezug_e3dc/e3dc.py
@@ -19,18 +19,11 @@ def update(ipaddress: str):
     power_all = client.read_holding_registers(40073, ModbusDataType.INT_32, wordorder=Endian.Little, unit=1)
 #40130 Phasenleistung in Watt
     powers = client.read_holding_registers(40129, [ModbusDataType.INT_16] * 3, unit=1)
-    currents = [0]*3
-    voltages = [230]*3
-    for i in range(0, 3):
-        currents[i]=powers[i]/voltages[i]
     get_counter_value_store(1).set(CounterState(
-        power_all=power_all,
-        powers=powers,
-        voltages=voltages,
-        currents=currents
+        power=power_all,
+        powers=powers
     ))
     log.debug("Update completed successfully")
-
 if __name__ == '__main__':
     setup_logging_stdout()
     run_using_positional_cli_args(update)

--- a/modules/bezug_e3dc/e3dc.py
+++ b/modules/bezug_e3dc/e3dc.py
@@ -1,90 +1,37 @@
 #!/usr/bin/python
-import sys
-# import os
-# import time
-# import getopt
-# import socket
-# import ConfigParser
-import struct
-# import binascii
-from pymodbus.client.sync import ModbusTcpClient
+from pymodbus.constants import Endian
+import logging
+import math
+from typing import List
 
-ipaddress = str(sys.argv[1])
+from helpermodules.cli import run_using_positional_cli_args
+from helpermodules.log import setup_logging_stdout
+from modules.common.component_state import CounterState
+from modules.common.modbus import ModbusClient, ModbusDataType
+from modules.common.store import get_counter_value_store
 
-client = ModbusTcpClient(ipaddress, port=502)
+log = logging.getLogger("E3DC EVU")
 
-# evu punkt
-resp= client.read_holding_registers(40073,2,unit=1)
-value1 = resp.registers[0]
-value2 = resp.registers[1]
-all = format(value2, '04x') + format(value1, '04x')
-final = int(struct.unpack('>i', all.decode('hex'))[0])
-f = open('/var/www/html/openWB/ramdisk/wattbezug', 'w')
-f.write(str(final))
-f.close()
+def update(ipaddress: str):
+    log.debug("Beginning update")
+    client = ModbusClient(ipaddress, port=502)
+#40074 EVU Punkt negativ -> Einspeisung in Watt
+    power_all = client.read_holding_registers(40073, ModbusDataType.INT_32,wordorder=Endian.Little, unit=1)
+#40130 Phasenleistung in Watt
+    powers = [val for val in client.read_holding_registers(40129, [ModbusDataType.INT_16] * 3,unit=1)]
+    currents = [0]*3
+    voltages = [230]*3
+    for i in range(0, 3):
+        if powers[i] > 0:
+            currents[i]=powers[i]/voltages[i]
+    get_counter_value_store(1).set(CounterState(
+        power_all=power_all,
+        powers=powers,
+        voltages=voltages,
+        currents=currents
+    ))
+    log.debug("Update completed successfully")
 
-volt=230
-resp= client.read_holding_registers(40128,4,unit=1)
-
-# print >>f1,(resp.registers)
-
-value1 = resp.registers[0]
-all = format(value1, '04x')
-finale0 = int(struct.unpack('>h', all.decode('hex'))[0]) 
-value1 = resp.registers[1]
-all = format(value1, '04x')
-finale1 = int(struct.unpack('>h', all.decode('hex'))[0]) 
-value1 = resp.registers[2]
-all = format(value1, '04x')
-finale2 = int(struct.unpack('>h', all.decode('hex'))[0]) 
-value1 = resp.registers[3]
-all = format(value1, '04x')
-finale3 = int(struct.unpack('>h', all.decode('hex'))[0]) 
-
-if finale0 == 1:
-    # f1 = open('/var/www/html/openWB/ramdisk/logtest2', 'a')
-    # print >>f1,('e3dc zaehler %1d l1 %6d l2 %6d  l3 %6d Watt' % (finale0,finale1,finale2,finale3))
-    if finale1 > 0:
-        finala1=finale1/volt
-    else:
-        finala1 = 0
-    if finale2 > 0:
-        finala2=finale2/volt
-    else:
-        finala2 = 0
-    if finale3 > 0:
-        finala3=finale3/volt
-    else:
-        finala3 = 0
-    # print >>f1,('e3dc zaehler %1d l1 %6d l2 %6d  l3 %6d Amp' %  (finale0,finala1,finala2,finala3))
-    # volt
-    f = open('/var/www/html/openWB/ramdisk/evuv1', 'w')
-    f.write(str(volt))
-    f.close()
-    f = open('/var/www/html/openWB/ramdisk/evuv2', 'w')
-    f.write(str(volt))
-    f.close()
-    f = open('/var/www/html/openWB/ramdisk/evuv3', 'w')
-    f.write(str(volt))
-    f.close()
-    # watt pro phase  
-    f = open('/var/www/html/openWB/ramdisk/bezugw1', 'w')
-    f.write(str(finale1))
-    f.close()
-    f = open('/var/www/html/openWB/ramdisk/bezugw2', 'w')
-    f.write(str(finale2))
-    f.close()
-    f = open('/var/www/html/openWB/ramdisk/bezugw3', 'w')
-    f.write(str(finale3))
-    f.close()
-    # amp pro phase
-    f = open('/var/www/html/openWB/ramdisk/bezuga1', 'w')
-    f.write(str(finala1))
-    f.close()
-    f = open('/var/www/html/openWB/ramdisk/bezuga2', 'w')
-    f.write(str(finala2))
-    f.close()
-    f = open('/var/www/html/openWB/ramdisk/bezuga3', 'w')
-    f.write(str(finala3))
-    f.close()
-    # f1.close()
+if __name__ == '__main__':
+    setup_logging_stdout()
+    run_using_positional_cli_args(update)

--- a/modules/bezug_e3dc/main.sh
+++ b/modules/bezug_e3dc/main.sh
@@ -1,5 +1,4 @@
 #!/bin/bash
-
-sudo python /var/www/html/openWB/modules/bezug_e3dc/e3dc.py $e3dcip
-wattbezug=$(</var/www/html/openWB/ramdisk/wattbezug)
-echo $wattbezug
+OPENWBBASEDIR=$(cd `dirname $0`/../../ && pwd)
+python3 "$OPENWBBASEDIR/modules/bezug_e3dc/e3dc.py" "$e3dcip"  >> "$OPENWBBASEDIR/ramdisk/openWB.log" 2>&1
+cat "$OPENWBBASEDIR/ramdisk/wattbezug"


### PR DESCRIPTION
Das bestehende E3DC Bezugsmodul wurde auf V2 Syntax  umgestellt. Wie bisher wird 230 Volt angenommen und Ampere berechnet. Die Berechnung findet nur statt, wenn ein EVU Bezug vorliegt. 
Der Typ vom Leistungsmesser 6 (Modbusadresse 40129 -1) wird nicht mehr abgefragt (da immer 1). Modul ist mit meinem E3DC getestet