### PR TITLE
use legacy run server for json module and refactor read_legacy call

### DIFF
--- a/modules/bezug_json/main.sh
+++ b/modules/bezug_json/main.sh
@@ -20,7 +20,7 @@ openwbDebugLog ${DMOD} 2 "Filter Watt : ${bezugjsonwatt}"
 openwbDebugLog ${DMOD} 2 "Filter Bezug: ${bezugjsonkwh}"
 openwbDebugLog ${DMOD} 2 "Filter Einsp: ${einspeisungjsonkwh}"
 
-python3 $OPENWBBASEDIR/packages/modules/json/device.py "counter" "${bezugjsonurl}" "${bezugjsonwatt}" "${bezugjsonkwh}" "${einspeisungjsonkwh}" >>$MYLOGFILE 2>&1
+bash "$OPENWBBASEDIR/packages/legacy_run.sh" "modules.json.device" "counter" "${bezugjsonurl}" "${bezugjsonwatt}" "${bezugjsonkwh}" "${einspeisungjsonkwh}" >>$MYLOGFILE 2>&1
 ret=$?
 
 openwbDebugLog ${DMOD} 2 "RET: ${ret}"

--- a/modules/speicher_json/main.sh
+++ b/modules/speicher_json/main.sh
@@ -21,7 +21,7 @@ openwbDebugLog ${DMOD} 2 "Speicher URL: ${battjsonurl}"
 openwbDebugLog ${DMOD} 2 "Speicher Watt: ${battjsonwatt}"
 openwbDebugLog ${DMOD} 2 "Speicher SoC: ${battjsonsoc}"
 
-python3 $OPENWBBASEDIR/packages/modules/json/device.py "bat" "${battjsonurl}" "${battjsonwatt}" "${battjsonsoc}" >>$MYLOGFILE 2>&1
+bash "$OPENWBBASEDIR/packages/legacy_run.sh" "modules.json.device" "bat" "${battjsonurl}" "${battjsonwatt}" "${battjsonsoc}" >>$MYLOGFILE 2>&1
 ret=$?
 
 openwbDebugLog ${DMOD} 2 "RET: ${ret}"

--- a/modules/wr2_json/main.sh
+++ b/modules/wr2_json/main.sh
@@ -23,7 +23,7 @@ openwbDebugLog ${DMOD} 2 "PV URL : ${wr2jsonurl}"
 openwbDebugLog ${DMOD} 2 "PV Watt: ${wr2jsonwatt}"
 openwbDebugLog ${DMOD} 2 "PV kWh : ${wr2jsonkwh}"
 
-python3 $OPENWBBASEDIR/packages/modules/json/device.py "inverter" "${wr2jsonurl}" "${wr2jsonwatt}" "${wr2jsonkwh}" "2" >>$MYLOGFILE 2>&1
+bash "$OPENWBBASEDIR/packages/legacy_run.sh" "modules.json.device" "inverter" "${wr2jsonurl}" "${wr2jsonwatt}" "${wr2jsonkwh}" "2" >>$MYLOGFILE 2>&1
 ret=$?
 
 openwbDebugLog ${DMOD} 2 "RET: ${ret}"

--- a/modules/wr_json/main.sh
+++ b/modules/wr_json/main.sh
@@ -23,7 +23,7 @@ openwbDebugLog ${DMOD} 2 "PV URL : ${wrjsonurl}"
 openwbDebugLog ${DMOD} 2 "PV Watt: ${wrjsonwatt}"
 openwbDebugLog ${DMOD} 2 "PV kWh : ${wrjsonkwh}"
 
-python3 $OPENWBBASEDIR/packages/modules/json/device.py "inverter" "${wrjsonurl}" "${wrjsonwatt}" "${wrjsonkwh}" "1" >>$MYLOGFILE 2>&1
+bash "$OPENWBBASEDIR/packages/legacy_run.sh" "modules.json.device" "inverter" "${wrjsonurl}" "${wrjsonwatt}" "${wrjsonkwh}" "1" >>$MYLOGFILE 2>&1
 ret=$?
 
 openwbDebugLog ${DMOD} 2 "RET: ${ret}"

--- a/packages/modules/json/device.py
+++ b/packages/modules/json/device.py
@@ -1,8 +1,8 @@
 #!/usr/bin/env python3
-import sys
-from typing import Dict, List, Union
+from typing import Dict, List, Union, Optional
 
 from helpermodules import log
+from helpermodules.cli import run_using_positional_cli_args
 from modules.common import req
 from modules.common.abstract_device import AbstractDevice
 from modules.common.component_context import SingleComponentUpdateContext
@@ -66,54 +66,46 @@ class Device(AbstractDevice):
             )
 
 
-def read_legacy(argv: List[str]) -> None:
-    COMPONENT_TYPE_TO_MODULE = {
-        "bat": bat,
-        "counter": counter,
-        "inverter": inverter
-    }
-    component_type = argv[1]
-
+def read_legacy(ip_address: str, component_config: dict, id: Optional[int] = None, **kwargs):
+    component_config["id"] = id
+    component_config["configuration"].update(kwargs)
     device_config = get_default_config()
-    device_config["configuration"]["ip_address"] = argv[2]
+    device_config["configuration"]["ip_address"] = ip_address
     dev = Device(device_config)
-    if component_type in COMPONENT_TYPE_TO_MODULE:
-        component_config = COMPONENT_TYPE_TO_MODULE[component_type].get_default_config()
-    else:
-        raise Exception(
-            "illegal component type " + component_type + ". Allowed values: " +
-            ','.join(COMPONENT_TYPE_TO_MODULE.keys())
-        )
-    if component_type == "bat":
-        component_config["configuration"] = {
-            "jq_power": argv[3],
-            "jq_soc": argv[4]
-        }
-        num = None
-    elif component_type == "counter":
-        component_config["configuration"] = {
-            "jq_power": argv[3],
-            "jq_imported": argv[4],
-            "jq_exported": argv[5]
-        }
-        num = None
-    else:
-        component_config["configuration"] = {
-            "jq_power": argv[3],
-            "jq_counter": argv[4]
-        }
-        num = int(argv[5])
-
-    component_config["id"] = num
     dev.add_component(component_config)
-
-    log.MainLogger().debug('Json Konfiguration: ' + str(component_config["configuration"]))
-
     dev.update()
 
 
-if __name__ == "__main__":
-    try:
-        read_legacy(sys.argv)
-    except Exception:
-        log.MainLogger().exception("Fehler im Json Skript")
+def read_legacy_bat(ip_address: str, jq_power: str, jq_soc: str):
+    read_legacy(
+        ip_address,
+        bat.get_default_config(),
+        jq_power=jq_power,
+        jq_soc=jq_soc,
+    )
+
+
+def read_legacy_counter(ip_address: str, jq_power: str, jq_imported: str, jq_exported: str):
+    read_legacy(
+        ip_address,
+        counter.get_default_config(),
+        jq_power=jq_power,
+        jq_imported=jq_imported,
+        jq_exported=jq_exported,
+    )
+
+
+def read_legacy_inverter(ip_address: str, jq_power: str, jq_counter: str, id: int):
+    read_legacy(
+        ip_address,
+        inverter.get_default_config(),
+        id,
+        jq_power=jq_power,
+        jq_counter=jq_counter,
+    )
+
+
+def main(argv: List[str]):
+    run_using_positional_cli_args(
+        {"bat": read_legacy_bat, "counter": read_legacy_counter, "inverter": read_legacy_inverter}, argv
+    )


### PR DESCRIPTION
Refactoring für eine bessere Performance vom json-Modul: Legacy run-Server nutzen (siehe #1837, #1838)

Außerdem habe ich die read_legacy-Funktion von JSON für bessere Lesbarkeit überarbeitet. Ist aber noch ungetestet.