### PR TITLE
simulation data in module get-topic

### DIFF
--- a/packages/modules/alpha_ess/bat.py
+++ b/packages/modules/alpha_ess/bat.py
@@ -50,8 +50,7 @@ class AlphaEssBat:
         soc_reg = self.__tcp_client.read_holding_registers(0x0102, ModbusDataType.INT_16, unit=sdmid)
         soc = int(soc_reg * 0.1)
 
-        topic_str = "openWB/set/system/device/" + str(
-            self.__device_id)+"/component/"+str(self.component_config["id"])+"/"
+        topic_str = "openWB/bat/" + str(self.component_config["id"]) + "/get/"
         imported, exported = self.__sim_count.sim_count(
             power, topic=topic_str, data=self.__simulation, prefix="speicher"
         )

--- a/packages/modules/alpha_ess/inverter.py
+++ b/packages/modules/alpha_ess/inverter.py
@@ -38,11 +38,8 @@ class AlphaEssInverter:
             self.component_config["configuration"]["version"])
         power = self.__get_power(85, reg_p)
 
-        topic_str = "openWB/set/system/device/" + \
-            str(self.__device_id)+"/component/" + \
-            str(self.component_config["id"])+"/"
-        _, counter = self.__sim_count.sim_count(
-            power, topic=topic_str, data=self.__simulation, prefix="pv")
+        topic_str = "openWB/pv/" + str(self.component_config["id"]) + "/get/"
+        _, counter = self.__sim_count.sim_count(power, topic=topic_str, data=self.__simulation, prefix="pv")
         inverter_state = InverterState(
             power=power,
             counter=counter,

--- a/packages/modules/carlo_gavazzi/counter.py
+++ b/packages/modules/carlo_gavazzi/counter.py
@@ -47,7 +47,7 @@ class CarloGavazziCounter:
         if frequency > 100:
             frequency = frequency / 10
 
-        topic_str = "openWB/set/system/device/{}/component/{}/".format(self.__device_id, self.component_config["id"])
+        topic_str = "openWB/counter/" + str(self.component_config["id"]) + "/get/"
         imported, exported = self.__sim_count.sim_count(
             power_all,
             topic=topic_str,

--- a/packages/modules/fronius/bat.py
+++ b/packages/modules/fronius/bat.py
@@ -53,8 +53,7 @@ class FroniusBat:
             # Wenn WR aus bzw. im Standby (keine Antwort), ersetze leeren Wert durch eine 0.
             soc = 0
 
-        topic_str = "openWB/set/system/device/" + str(
-            self.__device_id)+"/component/"+str(self.component_config["id"])+"/"
+        topic_str = "openWB/bat/" + str(self.component_config["id"]) + "/get/"
         imported, exported = self.__sim_count.sim_count(
             power, topic=topic_str, data=self.__simulation, prefix="speicher"
         )

--- a/packages/modules/fronius/counter_s0.py
+++ b/packages/modules/fronius/counter_s0.py
@@ -49,9 +49,7 @@ class FroniusS0Counter:
             imported = float(response_json_id["EnergyReal_WAC_Minus_Absolute"])
             exported = float(response_json_id["EnergyReal_WAC_Plus_Absolute"])
         else:
-            topic_str = "openWB/set/system/device/{}/component/{}/".format(
-                self.__device_id, self.component_config["id"]
-            )
+            topic_str = "openWB/counter/" + str(self.component_config["id"]) + "/get/"
             imported, exported = self.__sim_count.sim_count(
                 power_all,
                 topic=topic_str,

--- a/packages/modules/fronius/counter_sm.py
+++ b/packages/modules/fronius/counter_sm.py
@@ -53,9 +53,7 @@ class FroniusSmCounter:
                 params=(('Scope', 'System'),),
                 timeout=5)
             counter_state.power_all = float(response.json()["Body"]["Data"]["Site"]["P_Grid"])
-            topic_str = "openWB/set/system/device/{}/component/{}/".format(
-                self.__device_id, self.component_config["id"]
-            )
+            topic_str = "openWB/counter/" + str(self.component_config["id"]) + "/get/"
             # Beim Energiebezug ist nicht klar, welcher Anteil aus dem Netz bezogen wurde, und was aus
             # dem Wechselrichter kam.
             # Beim Energieexport ist nicht klar, wie hoch der Eigenverbrauch während der Produktion war.

--- a/packages/modules/fronius/inverter.py
+++ b/packages/modules/fronius/inverter.py
@@ -59,7 +59,7 @@ class FroniusInverter:
         power += power2
         power1 = power
         power *= -1
-        topic = "openWB/set/system/device/" + str(self.__device_id)+"/component/" + str(self.component_config["id"])+"/"
+        topic = "openWB/pv/" + str(self.component_config["id"]) + "/get/"
         if gen24:
             _, counter = self.__sim_count.sim_count(power, topic=topic, data=self.__simulation, prefix="pv")
         else:

--- a/packages/modules/huawei/bat.py
+++ b/packages/modules/huawei/bat.py
@@ -38,8 +38,7 @@ class HuaweiBat:
         time.sleep(0.1)
         soc = self.__tcp_client.read_holding_registers(37760, ModbusDataType.INT_16, unit=self.__modbus_id) / 10
 
-        topic_str = "openWB/set/system/device/" + str(
-            self.__device_id)+"/component/"+str(self.component_config["id"])+"/"
+        topic_str = "openWB/bat/" + str(self.component_config["id"]) + "/get/"
         imported, exported = self.__sim_count.sim_count(
             power, topic=topic_str, data=self.__simulation, prefix="speicher"
         )

--- a/packages/modules/huawei/counter.py
+++ b/packages/modules/huawei/counter.py
@@ -39,9 +39,7 @@ class HuaweiCounter:
         currents = [val / -100 for val in self.__tcp_client.read_holding_registers(
             37107, [ModbusDataType.INT_32] * 3, unit=self.__modbus_id)]
 
-        topic_str = "openWB/set/system/device/{}/component/{}/".format(
-            self.__device_id, self.component_config["id"]
-        )
+        topic_str = "openWB/counter/" + str(self.component_config["id"]) + "/get/"
         imported, exported = self.__sim_count.sim_count(
             power_all,
             topic=topic_str,

--- a/packages/modules/huawei/inverter.py
+++ b/packages/modules/huawei/inverter.py
@@ -36,11 +36,8 @@ class HuaweiInverter:
         time.sleep(0.1)
         power = self.__tcp_client.read_holding_registers(32064, ModbusDataType.INT_32, unit=self.__modbus_id) * -1
 
-        topic_str = "openWB/set/system/device/" + \
-            str(self.__device_id)+"/component/" + \
-            str(self.component_config["id"])+"/"
-        _, counter = self.__sim_count.sim_count(
-            power, topic=topic_str, data=self.__simulation, prefix="pv")
+        topic_str = "openWB/pv/" + str(self.component_config["id"]) + "/get/"
+        _, counter = self.__sim_count.sim_count(power, topic=topic_str, data=self.__simulation, prefix="pv")
         inverter_state = InverterState(
             power=power,
             counter=counter

--- a/packages/modules/janitza/counter.py
+++ b/packages/modules/janitza/counter.py
@@ -32,9 +32,7 @@ class JanitzaCounter:
 
         power_all = self.__tcp_client.read_holding_registers(19026, ModbusDataType.FLOAT_32, unit=1)
 
-        topic_str = "openWB/set/system/device/{}/component/{}/".format(
-            self.__device_id, self.component_config["id"]
-        )
+        topic_str = "openWB/counter/" + str(self.component_config["id"]) + "/get/"
         imported, exported = self.__sim_count.sim_count(
             power_all,
             topic=topic_str,

--- a/packages/modules/json/bat.py
+++ b/packages/modules/json/bat.py
@@ -40,8 +40,7 @@ class JsonBat:
         else:
             soc = 0
 
-        topic_str = "openWB/set/system/device/" + str(
-            self.__device_id)+"/component/"+str(self.component_config["id"])+"/"
+        topic_str = "openWB/bat/" + str(self.component_config["id"]) + "/get/"
         imported, exported = self.__sim_count.sim_count(
             power, topic=topic_str, data=self.__simulation, prefix="speicher"
         )

--- a/packages/modules/json/counter.py
+++ b/packages/modules/json/counter.py
@@ -37,9 +37,7 @@ class JsonCounter:
 
         power_all = jq.compile(config["jq_power"]).input(response).first()
         if config["jq_imported"] == "" or config["jq_exported"] == "":
-            topic_str = "openWB/set/system/device/{}/component/{}/".format(
-                self.__device_id, self.component_config["id"]
-            )
+            topic_str = "openWB/counter/" + str(self.component_config["id"]) + "/get/"
             imported, exported = self.__sim_count.sim_count(
                 power_all,
                 topic=topic_str,

--- a/packages/modules/json/inverter.py
+++ b/packages/modules/json/inverter.py
@@ -38,11 +38,8 @@ class JsonInverter:
         if power >= 0:
             power = power * -1
         if config["jq_counter"] == "":
-            topic_str = "openWB/set/system/device/" + \
-                str(self.__device_id)+"/component/" + \
-                str(self.component_config["id"])+"/"
-            _, counter = self.__sim_count.sim_count(
-                power, topic=topic_str, data=self.simulation, prefix="pv")
+            topic_str = "openWB/pv/" + str(self.component_config["id"]) + "/get/"
+            _, counter = self.__sim_count.sim_count(power, topic=topic_str, data=self.simulation, prefix="pv")
             inverter_state = InverterState(
                 power=power,
                 counter=counter,

--- a/packages/modules/openwb_flex/counter.py
+++ b/packages/modules/openwb_flex/counter.py
@@ -60,9 +60,7 @@ class EvuKitFlex:
         else:
             if version == 1:
                 power_all = sum(power_per_phase)
-            topic_str = "openWB/set/system/device/{}/component/{}/".format(
-                self.__device_id, self.component_config["id"]
-            )
+            topic_str = "openWB/counter/" + str(self.component_config["id"]) + "/get/"
             imported, exported = self.__sim_count.sim_count(
                 power_all,
                 topic=topic_str,

--- a/packages/modules/powerdog/counter.py
+++ b/packages/modules/powerdog/counter.py
@@ -35,9 +35,7 @@ class PowerdogCounter:
         return home_consumption
 
     def set_counter_state(self, power_all: float) -> None:
-        topic_str = "openWB/set/system/device/{}/component/{}/".format(
-            self.__device_id, self.component_config["id"]
-        )
+        topic_str = "openWB/counter/" + str(self.component_config["id"]) + "/get/"
         imported, exported = self.__sim_count.sim_count(
             power_all,
             topic=topic_str,

--- a/packages/modules/powerdog/inverter.py
+++ b/packages/modules/powerdog/inverter.py
@@ -33,8 +33,7 @@ class PowerdogInverter:
 
         power = self.__tcp_client.read_input_registers(40002, ModbusDataType.INT_32, unit=1) * -1
 
-        topic_str = "openWB/set/system/device/" + str(self.__device_id)+"/component/" + \
-            str(self.component_config["id"])+"/"
+        topic_str = "openWB/pv/" + str(self.component_config["id"]) + "/get/"
         _, counter = self.__sim_count.sim_count(power, topic=topic_str, data=self.__simulation, prefix="pv")
         inverter_state = InverterState(
             power=power,

--- a/packages/modules/saxpower/bat.py
+++ b/packages/modules/saxpower/bat.py
@@ -33,8 +33,7 @@ class SaxpowerBat:
         soc = self.__tcp_client.read_holding_registers(46, ModbusDataType.INT_16, unit=64)
         power = self.__tcp_client.read_holding_registers(47, ModbusDataType.UINT_16, unit=64) * -1
 
-        topic_str = "openWB/set/system/device/" + str(
-            self.__device_id)+"/component/"+str(self.component_config["id"])+"/"
+        topic_str = "openWB/bat/" + str(self.component_config["id"]) + "/get/"
         imported, exported = self.__sim_count.sim_count(
             power, topic=topic_str, data=self.__simulation, prefix="speicher"
         )

--- a/packages/modules/siemens/bat.py
+++ b/packages/modules/siemens/bat.py
@@ -36,8 +36,7 @@ class SiemensBat:
         power = self.__tcp_client.read_holding_registers(6, ModbusDataType.INT_32, unit=1) * -1
         soc = int(self.__tcp_client.read_holding_registers(8, ModbusDataType.INT_32, unit=1))
 
-        topic_str = "openWB/set/system/device/" + str(
-            self.__device_id)+"/component/"+str(self.component_config["id"])+"/"
+        topic_str = "openWB/bat/" + str(self.component_config["id"]) + "/get/"
         imported, exported = self.__sim_count.sim_count(
             power, topic=topic_str, data=self.__simulation, prefix="speicher"
         )

--- a/packages/modules/siemens/counter.py
+++ b/packages/modules/siemens/counter.py
@@ -36,9 +36,7 @@ class SiemensCounter:
 
         power_all = self.__tcp_client.read_holding_registers(14, ModbusDataType.INT_32, unit=1)
 
-        topic_str = "openWB/set/system/device/{}/component/{}/".format(
-            self.__device_id, self.component_config["id"]
-        )
+        topic_str = "openWB/counter/" + str(self.component_config["id"]) + "/get/"
         imported, exported = self.__sim_count.sim_count(
             power_all,
             topic=topic_str,

--- a/packages/modules/siemens/inverter.py
+++ b/packages/modules/siemens/inverter.py
@@ -36,11 +36,8 @@ class SiemensInverter:
         log.MainLogger().debug("Komponente "+self.component_config["name"]+" auslesen.")
         power = self.__tcp_client.read_holding_registers(16, ModbusDataType.INT_32, unit=1) * -1
 
-        topic_str = "openWB/set/system/device/" + \
-            str(self.__device_id)+"/component/" + \
-            str(self.component_config["id"])+"/"
-        _, counter = self.__sim_count.sim_count(
-            power, topic=topic_str, data=self.__simulation, prefix="pv")
+        topic_str = "openWB/pv/" + str(self.component_config["id"]) + "/get/"
+        _, counter = self.__sim_count.sim_count(power, topic=topic_str, data=self.__simulation, prefix="pv")
         inverter_state = InverterState(
             power=power,
             counter=counter

--- a/packages/modules/solax/bat.py
+++ b/packages/modules/solax/bat.py
@@ -33,8 +33,7 @@ class SolaxBat:
         power = self.__tcp_client.read_input_registers(22, ModbusDataType.INT_16)
         soc = self.__tcp_client.read_input_registers(28, ModbusDataType.UINT_16)
 
-        topic_str = "openWB/set/system/device/" + str(
-            self.__device_id)+"/component/"+str(self.component_config["id"])+"/"
+        topic_str = "openWB/bat/" + str(self.component_config["id"]) + "/get/"
         imported, exported = self.__sim_count.sim_count(
             power, topic=topic_str, data=self.__simulation, prefix="speicher"
         )

--- a/packages/modules/sungrow/bat.py
+++ b/packages/modules/sungrow/bat.py
@@ -38,8 +38,7 @@ class SungrowBat:
         if binary[5] == "1":
             power = power * -1
 
-        topic_str = "openWB/set/system/device/" + str(
-            self.__device_id)+"/component/"+str(self.component_config["id"])+"/"
+        topic_str = "openWB/bat/" + str(self.component_config["id"]) + "/get/"
         imported, exported = self.__sim_count.sim_count(
             power, topic=topic_str, data=self.__simulation, prefix="speicher"
         )

--- a/packages/modules/sungrow/counter.py
+++ b/packages/modules/sungrow/counter.py
@@ -38,7 +38,7 @@ class SungrowCounter:
         else:
             power_all = self.__tcp_client.read_input_registers(13009, ModbusDataType.INT_32, unit=unit) * -1
 
-        topic_str = "openWB/set/system/device/{}/component/{}/".format(self.__device_id, self.component_config["id"])
+        topic_str = "openWB/counter/" + str(self.component_config["id"]) + "/get/"
         imported, exported = self.__sim_count.sim_count(
             power_all,
             topic=topic_str,

--- a/packages/modules/sungrow/inverter.py
+++ b/packages/modules/sungrow/inverter.py
@@ -32,11 +32,8 @@ class SungrowInverter:
         log.MainLogger().debug("Komponente "+self.component_config["name"]+" auslesen.")
         power = self.__tcp_client.read_holding_registers(5016, ModbusDataType.INT_32, unit=1) * -1
 
-        topic_str = "openWB/set/system/device/" + \
-            str(self.__device_id)+"/component/" + \
-            str(self.component_config["id"])+"/"
-        _, counter = self.__sim_count.sim_count(
-            power, topic=topic_str, data=self.__simulation, prefix="pv")
+        topic_str = "openWB/pv/" + str(self.component_config["id"]) + "/get/"
+        _, counter = self.__sim_count.sim_count(power, topic=topic_str, data=self.__simulation, prefix="pv")
 
         inverter_state = InverterState(
             power=power,

--- a/packages/modules/victron/bat.py
+++ b/packages/modules/victron/bat.py
@@ -33,8 +33,7 @@ class VictronBat:
         power = self.__tcp_client.read_holding_registers(842, ModbusDataType.INT_16, unit=100)
         soc = self.__tcp_client.read_holding_registers(843, ModbusDataType.UINT_16, unit=100)
 
-        topic_str = "openWB/set/system/device/" + str(
-            self.__device_id)+"/component/"+str(self.component_config["id"])+"/"
+        topic_str = "openWB/bat/" + str(self.component_config["id"]) + "/get/"
         imported, exported = self.__sim_count.sim_count(
             power, topic=topic_str, data=self.__simulation, prefix="speicher"
         )

--- a/packages/modules/victron/counter.py
+++ b/packages/modules/victron/counter.py
@@ -41,9 +41,7 @@ class VictronCounter:
             self.__tcp_client.read_holding_registers(reg, ModbusDataType.UINT_16, unit=unit) / 10
             for reg in [2616, 2618, 2610]]
 
-        topic_str = "openWB/set/system/device/{}/component/{}/".format(
-            self.__device_id, self.component_config["id"]
-        )
+        topic_str = "openWB/counter/" + str(self.component_config["id"]) + "/get/"
         imported, exported = self.__sim_count.sim_count(
             power_all,
             topic=topic_str,

--- a/packages/modules/victron/inverter.py
+++ b/packages/modules/victron/inverter.py
@@ -53,8 +53,7 @@ class VictronInverter:
             power_temp2 = self.__tcp_client.read_holding_registers(850, ModbusDataType.UINT_16, unit=100)
             power = (sum(power_temp1)+power_temp2) * -1
 
-        topic_str = "openWB/set/system/device/" + str(self.__device_id)+"/component/" + \
-            str(self.component_config["id"])+"/"
+        topic_str = "openWB/pv/" + str(self.component_config["id"]) + "/get/"
         _, counter = self.__sim_count.sim_count(power, topic=topic_str, data=self.__simulation, prefix="pv")
         inverter_state = InverterState(
             power=power,


### PR DESCRIPTION
Analog zu PR #1868 werden auch die Simulationswerte des Simcounts unter dem Modul und nicht unter der Komponente abgelegt. (Änderung betriftt nur 2.x)