### PR TITLE
meterlocation enum only for internal use

### DIFF
--- a/packages/modules/fronius/device.py
+++ b/packages/modules/fronius/device.py
@@ -126,7 +126,7 @@ def read_legacy(
         component_config = COMPONENT_TYPE_TO_MODULE[component_type].get_default_config()
         if component_type == "counter_sm":
             component_config["configuration"]["variant"] = variant
-            component_config["configuration"]["meter_location"] = meter.MeterLocation(meter_location)
+            component_config["configuration"]["meter_location"] = meter_location
         elif component_type == "inverter":
             component_config["configuration"]["ip_address2"] = ip_address2
             component_config["configuration"]["gen24"] = bool(gen24)


### PR DESCRIPTION
Die Meterlocation in der Komponentenkonfiguration muss im json-Format sein. Innerhalb der Komponente kann dann mit dem Enum gearbeitet werden.