### PR TITLE
fix kostal var2: Value received is in kWh, not Wh

### DIFF
--- a/modules/wr_kostalpikovar2/kostal_piko_var2.py
+++ b/modules/wr_kostalpikovar2/kostal_piko_var2.py
@@ -17,7 +17,7 @@ def parse_kostal_piko_var2_html(html: str):
     if result is None:
         raise Exception("Given HTML does not match the expected regular expression. Ignoring.")
     return InverterState(
-        counter=int(result.group(2)),
+        counter=int(result.group(2)) * 1000,
         power=int(result.group(1))
     )
 

--- a/modules/wr_kostalpikovar2/kostal_piko_var2_test.py
+++ b/modules/wr_kostalpikovar2/kostal_piko_var2_test.py
@@ -20,4 +20,4 @@ def test_parse_html(mock_ramdisk: MockRamdisk):
 
     # evaluation
     assert actual.power == 50
-    assert actual.counter == 73288
+    assert actual.counter == 73288000


### PR DESCRIPTION
Der Wert "Gesamtenergie" vom Kostal var2 kommt in kWh. Muss dann wohl noch mit Tausend multipliziert werden. Mein Fehler.

Siehe auch [forum](https://openwb.de/forum/viewtopic.php?p=54436#p54436)