### PR TITLE
fix kostal piko var2: PV power must be negative

### DIFF
--- a/modules/wr_kostalpikovar2/kostal_piko_var2.py
+++ b/modules/wr_kostalpikovar2/kostal_piko_var2.py
@@ -18,7 +18,7 @@ def parse_kostal_piko_var2_html(html: str):
         raise Exception("Given HTML does not match the expected regular expression. Ignoring.")
     return InverterState(
         counter=int(result.group(2)) * 1000,
-        power=int(result.group(1))
+        power=-int(result.group(1))
     )
 
 

--- a/modules/wr_kostalpikovar2/kostal_piko_var2_test.py
+++ b/modules/wr_kostalpikovar2/kostal_piko_var2_test.py
@@ -19,5 +19,5 @@ def test_parse_html(mock_ramdisk: MockRamdisk):
     actual = parse_kostal_piko_var2_html(sample_html)
 
     # evaluation
-    assert actual.power == 50
+    assert actual.power == -50
     assert actual.counter == 73288000


### PR DESCRIPTION
Und was habe ich in #1872 noch vergessen? openWB erwartet, dass die PV-Leistung immer ein negativer Wert ist -.-

[Siehe Forum](https://openwb.de/forum/viewtopic.php?p=54611#p54611)