### PR TITLE
Behandlung ausgeschalteter WRs (Fronius / JSON)

### DIFF
--- a/packages/modules/common/store/_inverter.py
+++ b/packages/modules/common/store/_inverter.py
@@ -13,9 +13,10 @@ class InverterValueStoreRamdisk(ValueStore[InverterState]):
     def set(self, inverter_state: InverterState):
         try:
             self.__pv.power.write(inverter_state.power)
-            self.__pv.energy.write(inverter_state.counter)
-            self.__pv.energy_k.write(inverter_state.counter / 1000)
             self.__pv.currents.write(inverter_state.currents)
+            if inverter_state.counter is not None:
+                self.__pv.energy.write(inverter_state.counter)
+                self.__pv.energy_k.write(inverter_state.counter / 1000)
             log.MainLogger().info('PV Watt: ' + str(inverter_state.power))
         except Exception as e:
             raise FaultState.from_exception(e)
@@ -28,8 +29,9 @@ class InverterValueStoreBroker(ValueStore[InverterState]):
     def set(self, inverter_state: InverterState):
         try:
             pub_to_broker("openWB/set/pv/" + str(self.num) + "/get/power", inverter_state.power, 2)
-            pub_to_broker("openWB/set/pv/" + str(self.num) + "/get/counter", inverter_state.counter, 3)
             pub_to_broker("openWB/set/pv/" + str(self.num) + "/get/currents", inverter_state.currents, 1)
+            if inverter_state.counter is not None:
+                pub_to_broker("openWB/set/pv/" + str(self.num) + "/get/counter", inverter_state.counter, 3)
         except Exception as e:
             raise FaultState.from_exception(e)
 

--- a/packages/modules/json/inverter.py
+++ b/packages/modules/json/inverter.py
@@ -40,11 +40,6 @@ class JsonInverter:
         if config["jq_counter"] == "":
             topic_str = "openWB/pv/" + str(self.component_config["id"]) + "/get/"
             _, counter = self.__sim_count.sim_count(power, topic=topic_str, data=self.simulation, prefix="pv")
-            inverter_state = InverterState(
-                power=power,
-                counter=counter,
-                currents=[0, 0, 0]
-            )
         else:
             counter = jq.compile(config["jq_counter"]).input(response).first()
 


### PR DESCRIPTION
Hintergrund ist die Diskussion hier: https://openwb.de/forum/viewtopic.php?f=9&t=4515

Beim Abschalten nachgelagerter WRs kann man davon ausgehen, dass die Erzeugungsleistung 0 Watt ist, aber ein einfaches Zurücksetzen aller WR-Daten würden den bekannten Zählerstand der Erzeugung überschreiben. Die Erzeugungsleistung selber muss gesetzt werden, um eine Phantomleistung mit dem letzten bekannten Wert zu vermeiden.

Wie kann man das erreichen? Man vermerkt im InverterState, dass der letzte bekannte Zählerstand erhalten werden soll (counter == None). Dann kann man die aktuelle Null-Leistung setzen. 

Ansonsten wird im JSON Modul jede konfigurierte Komponente aufgerufen und kann selber entscheiden, wie mit der Situation umgegangen werden muss.