### PR TITLE
Use legacy run server in remaining modules

### DIFF
--- a/modules/bezug_alphaess/main.sh
+++ b/modules/bezug_alphaess/main.sh
@@ -15,7 +15,7 @@ else
         MYLOGFILE="${RAMDISKDIR}/evu.log"
 fi
 
-python3 ${OPENWBBASEDIR}/packages/modules/alpha_ess/device.py "counter" "${alphav123}" >>${MYLOGFILE} 2>&1
+bash "$OPENWBBASEDIR/packages/legacy_run.sh" "modules.alpha_ess.device" "counter" "${alphav123}" >>${MYLOGFILE} 2>&1
 ret=$?
 
 openwbDebugLog ${DMOD} 2 "EVU RET: ${ret}"

--- a/modules/bezug_carlogavazzilan/main.sh
+++ b/modules/bezug_carlogavazzilan/main.sh
@@ -15,7 +15,7 @@ else
 	MYLOGFILE="${RAMDISKDIR}/evu_carlo_gavazzi.log"
 fi
 
-python3 ${OPENWBBASEDIR}/packages/modules/carlo_gavazzi/device.py "counter" "${bezug1_ip}" >>${MYLOGFILE} 2>&1
+bash "$OPENWBBASEDIR/packages/legacy_run.sh" "modules.carlo_gavazzi.device" "counter" "${bezug1_ip}" >>${MYLOGFILE} 2>&1
 ret=$?
 
 openwbDebugLog ${DMOD} 2 "EVU RET: ${ret}"

--- a/modules/bezug_ethmpm3pm/main.sh
+++ b/modules/bezug_ethmpm3pm/main.sh
@@ -15,7 +15,7 @@ else
         MYLOGFILE="${RAMDISKDIR}/evu.log"
 fi
 
-python3 ${OPENWBBASEDIR}/packages/modules/openwb/device.py "counter" "${evukitversion}" >>${MYLOGFILE} 2>&1
+bash "$OPENWBBASEDIR/packages/legacy_run.sh" "modules.openwb.device" "counter" "${evukitversion}" >>${MYLOGFILE} 2>&1
 ret=$?
 
 openwbDebugLog ${DMOD} 2 "EVU RET: ${ret}"

--- a/modules/bezug_ethmpm3pmflex/main.sh
+++ b/modules/bezug_ethmpm3pmflex/main.sh
@@ -15,7 +15,7 @@ else
 	MYLOGFILE="${RAMDISKDIR}/evu_json.log"
 fi
 
-python3 ${OPENWBBASEDIR}/packages/modules/openwb_flex/device.py "counter" "${evuflexversion}" "${evuflexip}" "${evuflexport}" "${evuflexid}" >>${MYLOGFILE} 2>&1
+bash "$OPENWBBASEDIR/packages/legacy_run.sh" "modules.openwb_flex.device" "counter" "${evuflexversion}" "${evuflexip}" "${evuflexport}" "${evuflexid}" >>${MYLOGFILE} 2>&1
 ret=$?
 
 openwbDebugLog ${DMOD} 2 "EVU RET: ${ret}"

--- a/modules/bezug_http/main.sh
+++ b/modules/bezug_http/main.sh
@@ -15,7 +15,7 @@ else
     MYLOGFILE="$RAMDISKDIR/evu.log"
 fi
 
-python3 /var/www/html/openWB/packages/modules/http/device.py "counter" "${bezug_http_w_url}" "${bezug_http_ikwh_url}" "${bezug_http_ekwh_url}" "${bezug_http_l1_url}" "${bezug_http_l2_url}" "${bezug_http_l3_url}" >>$MYLOGFILE 2>&1
+bash "$OPENWBBASEDIR/packages/legacy_run.sh" "modules.http.device" "counter" "${bezug_http_w_url}" "${bezug_http_ikwh_url}" "${bezug_http_ekwh_url}" "${bezug_http_l1_url}" "${bezug_http_l2_url}" "${bezug_http_l3_url}" >>$MYLOGFILE 2>&1
 ret=$?
 
 openwbDebugLog ${DMOD} 2 "RET: ${ret}"

--- a/modules/bezug_janitza/main.sh
+++ b/modules/bezug_janitza/main.sh
@@ -15,7 +15,7 @@ else
 	MYLOGFILE="${RAMDISKDIR}/evu_janitza.log"
 fi
 
-python3 ${OPENWBBASEDIR}/packages/modules/janitza/device.py "counter" "${bezug1_ip}" >>${MYLOGFILE} 2>&1
+bash "$OPENWBBASEDIR/packages/legacy_run.sh" "modules.janitza.device" "counter" "${bezug1_ip}" >>${MYLOGFILE} 2>&1
 ret=$?
 
 openwbDebugLog ${DMOD} 2 "EVU RET: ${ret}"

--- a/modules/bezug_json/main.sh
+++ b/modules/bezug_json/main.sh
@@ -20,7 +20,7 @@ openwbDebugLog ${DMOD} 2 "Filter Watt : ${bezugjsonwatt}"
 openwbDebugLog ${DMOD} 2 "Filter Bezug: ${bezugjsonkwh}"
 openwbDebugLog ${DMOD} 2 "Filter Einsp: ${einspeisungjsonkwh}"
 
-python3 $OPENWBBASEDIR/packages/modules/json/device.py "counter" "${bezugjsonurl}" "${bezugjsonwatt}" "${bezugjsonkwh}" "${einspeisungjsonkwh}" >>$MYLOGFILE 2>&1
+bash "$OPENWBBASEDIR/packages/legacy_run.sh" "modules.json.device" "counter" "${bezugjsonurl}" "${bezugjsonwatt}" "${bezugjsonkwh}" "${einspeisungjsonkwh}" >>$MYLOGFILE 2>&1
 ret=$?
 
 openwbDebugLog ${DMOD} 2 "RET: ${ret}"

--- a/modules/bezug_powerdog/main.sh
+++ b/modules/bezug_powerdog/main.sh
@@ -16,7 +16,7 @@ else
 	MYLOGFILE="${RAMDISKDIR}/evu_powerdog.log"
 fi
 
-python3 ${OPENWBBASEDIR}/packages/modules/powerdog/device.py "counter" "${bezug1_ip}" >>${MYLOGFILE} 2>&1
+bash "$OPENWBBASEDIR/packages/legacy_run.sh" "modules.powerdog.device" "counter" "${bezug1_ip}" >>${MYLOGFILE} 2>&1
 ret=$?
 
 openwbDebugLog ${DMOD} 2 "EVU RET: ${ret}"

--- a/modules/bezug_siemens/main.sh
+++ b/modules/bezug_siemens/main.sh
@@ -15,7 +15,7 @@ else
         MYLOGFILE="${RAMDISKDIR}/evu.log"
 fi
 
-python3 ${OPENWBBASEDIR}/packages/modules/siemens/device.py "counter" "${bezug1_ip}" >>${MYLOGFILE} 2>&1
+bash "$OPENWBBASEDIR/packages/legacy_run.sh" "modules.siemens.device" "counter" "${bezug1_ip}" >>${MYLOGFILE} 2>&1
 ret=$?
 
 openwbDebugLog ${DMOD} 2 "EVU RET: ${ret}"

--- a/modules/bezug_solax/main.sh
+++ b/modules/bezug_solax/main.sh
@@ -15,7 +15,7 @@ else
 	MYLOGFILE="${RAMDISKDIR}/evu.log"
 fi
 
-python3 ${OPENWBBASEDIR}/packages/modules/solax/device.py "counter" "${solaxip}" >>${MYLOGFILE} 2>&1
+bash "$OPENWBBASEDIR/packages/legacy_run.sh" "modules.solax.device" "counter" "${solaxip}" >>${MYLOGFILE} 2>&1
 ret=$?
 
 openwbDebugLog ${DMOD} 2 "EVU RET: ${ret}"

--- a/modules/bezug_victrongx/main.sh
+++ b/modules/bezug_victrongx/main.sh
@@ -15,7 +15,7 @@ else
 	MYLOGFILE="${RAMDISKDIR}/evu.log"
 fi
 
-python3 ${OPENWBBASEDIR}/packages/modules/victron/device.py "counter" "${bezug_victronip}" "${bezug_id}" >>${MYLOGFILE} 2>&1
+bash "$OPENWBBASEDIR/packages/legacy_run.sh" "modules.victron.device" "counter" "${bezug_victronip}" "${bezug_id}" >>${MYLOGFILE} 2>&1
 ret=$?
 
 openwbDebugLog ${DMOD} 2 "EVU RET: ${ret}"

--- a/modules/speicher_alphaess/main.sh
+++ b/modules/speicher_alphaess/main.sh
@@ -19,7 +19,7 @@ fi
 
 openwbDebugLog ${DMOD} 2 "Speicher Version: ${alphav123}"
 
-python3 $OPENWBBASEDIR/packages/modules/alpha_ess/device.py "bat" "${alphav123}" >>$MYLOGFILE 2>&1
+bash "$OPENWBBASEDIR/packages/legacy_run.sh" "modules.alpha_ess.device" "bat" "${alphav123}" >>$MYLOGFILE 2>&1
 ret=$?
 
 openwbDebugLog ${DMOD} 2 "RET: ${ret}"

--- a/modules/speicher_fronius/main.sh
+++ b/modules/speicher_fronius/main.sh
@@ -18,7 +18,7 @@ fi
 
 openwbDebugLog ${DMOD} 2 "Speicher IP: ${wrfroniusip}"
 
-python3 /var/www/html/openWB/packages/modules/fronius/device.py "bat" "${wrfroniusip}" "${froniuserzeugung}" "${wrfroniusisgen24}" "0" "0" "none" "" >>$MYLOGFILE 2>&1
+bash "$OPENWBBASEDIR/packages/legacy_run.sh" "modules.fronius.device" "bat" "${wrfroniusip}" "${froniuserzeugung}" "${wrfroniusisgen24}" "0" "0" "none" "" >>$MYLOGFILE 2>&1
 ret=$?
 
 openwbDebugLog ${DMOD} 2 "RET: ${ret}"

--- a/modules/speicher_http/main.sh
+++ b/modules/speicher_http/main.sh
@@ -21,7 +21,7 @@ openwbDebugLog ${DMOD} 2 "Speicher Import: ${speicherikwh_http}"
 openwbDebugLog ${DMOD} 2 "Speicher Watt: ${speicherleistung_http}"
 openwbDebugLog ${DMOD} 2 "Speicher SoC: ${speichersoc_http}"
 
-python3 /var/www/html/openWB/packages/modules/http/device.py "bat" "${speicherleistung_http}" "${speicherikwh_http}" "${speicherekwh_http}" "${speichersoc_http}" >>$MYLOGFILE 2>&1
+bash "$OPENWBBASEDIR/packages/legacy_run.sh" "modules.http.device" "bat" "${speicherleistung_http}" "${speicherikwh_http}" "${speicherekwh_http}" "${speichersoc_http}" >>$MYLOGFILE 2>&1
 ret=$?
 
 openwbDebugLog ${DMOD} 2 "RET: ${ret}"

--- a/modules/speicher_json/main.sh
+++ b/modules/speicher_json/main.sh
@@ -21,7 +21,7 @@ openwbDebugLog ${DMOD} 2 "Speicher URL: ${battjsonurl}"
 openwbDebugLog ${DMOD} 2 "Speicher Watt: ${battjsonwatt}"
 openwbDebugLog ${DMOD} 2 "Speicher SoC: ${battjsonsoc}"
 
-python3 $OPENWBBASEDIR/packages/modules/json/device.py "bat" "${battjsonurl}" "${battjsonwatt}" "${battjsonsoc}" >>$MYLOGFILE 2>&1
+bash "$OPENWBBASEDIR/packages/legacy_run.sh" "modules.json.device" "bat" "${battjsonurl}" "${battjsonwatt}" "${battjsonsoc}" >>$MYLOGFILE 2>&1
 ret=$?
 
 openwbDebugLog ${DMOD} 2 "RET: ${ret}"

--- a/modules/speicher_mpm3pm/main.sh
+++ b/modules/speicher_mpm3pm/main.sh
@@ -15,7 +15,7 @@ else
         MYLOGFILE="${RAMDISKDIR}/bat.log"
 fi
 
-python3 ${OPENWBBASEDIR}/packages/modules/openwb/device.py "bat" "${speicherkitversion}" >>${MYLOGFILE} 2>&1
+bash "$OPENWBBASEDIR/packages/legacy_run.sh" "modules.openwb.device" "bat" "${speicherkitversion}" >>${MYLOGFILE} 2>&1
 ret=$?
 
 openwbDebugLog ${DMOD} 2 "BAT RET: ${ret}"

--- a/modules/speicher_saxpower/main.sh
+++ b/modules/speicher_saxpower/main.sh
@@ -15,7 +15,7 @@ else
         MYLOGFILE="${RAMDISKDIR}/bat.log"
 fi
 
-python3 ${OPENWBBASEDIR}/packages/modules/saxpower/device.py "bat" "${speicher1_ip}" >>${MYLOGFILE} 2>&1
+bash "$OPENWBBASEDIR/packages/legacy_run.sh" "modules.saxpower.device" "bat" "${speicher1_ip}" >>${MYLOGFILE} 2>&1
 ret=$?
 
 openwbDebugLog ${DMOD} 2 "BAT RET: ${ret}"

--- a/modules/speicher_siemens/main.sh
+++ b/modules/speicher_siemens/main.sh
@@ -15,7 +15,7 @@ else
         MYLOGFILE="${RAMDISKDIR}/bat.log"
 fi
 
-python3 ${OPENWBBASEDIR}/packages/modules/siemens/device.py "bat" "${speicher1_ip}" >>${MYLOGFILE} 2>&1
+bash "$OPENWBBASEDIR/packages/legacy_run.sh" "modules.siemens.device" "bat" "${speicher1_ip}" >>${MYLOGFILE} 2>&1
 ret=$?
 
 openwbDebugLog ${DMOD} 2 "BAT RET: ${ret}"

--- a/modules/speicher_solax/main.sh
+++ b/modules/speicher_solax/main.sh
@@ -15,7 +15,7 @@ else
         MYLOGFILE="${RAMDISKDIR}/bat.log"
 fi
 
-python3 ${OPENWBBASEDIR}/packages/modules/solax/device.py "bat" "${solaxip}" >>${MYLOGFILE} 2>&1
+bash "$OPENWBBASEDIR/packages/legacy_run.sh" "modules.solax.device" "bat" "${solaxip}" >>${MYLOGFILE} 2>&1
 ret=$?
 
 openwbDebugLog ${DMOD} 2 "BAT RET: ${ret}"

--- a/modules/speicher_sunnyisland/main.sh
+++ b/modules/speicher_sunnyisland/main.sh
@@ -15,7 +15,7 @@ else
         MYLOGFILE="${RAMDISKDIR}/bat.log"
 fi
 
-python3 ${OPENWBBASEDIR}/packages/modules/sunny_island/device.py "bat" "${sunnyislandip}" >>${MYLOGFILE} 2>&1
+bash "$OPENWBBASEDIR/packages/legacy_run.sh" "modules.sunny_island.device" "bat" "${sunnyislandip}" >>${MYLOGFILE} 2>&1
 ret=$?
 
 openwbDebugLog ${DMOD} 2 "BAT RET: ${ret}"

--- a/modules/speicher_victron/main.sh
+++ b/modules/speicher_victron/main.sh
@@ -15,7 +15,7 @@ else
         MYLOGFILE="${RAMDISKDIR}/bat.log"
 fi
 
-python3 ${OPENWBBASEDIR}/packages/modules/victron/device.py "bat" "${bezug_victronip}" >>${MYLOGFILE} 2>&1
+bash "$OPENWBBASEDIR/packages/legacy_run.sh" "modules.victron.device" "bat" "${bezug_victronip}" >>${MYLOGFILE} 2>&1
 ret=$?
 
 openwbDebugLog ${DMOD} 2 "BAT RET: ${ret}"

--- a/modules/wr2_ethlovato/main.sh
+++ b/modules/wr2_ethlovato/main.sh
@@ -17,7 +17,7 @@ fi
 
 #python3 ${OPENWBBASEDIR}/modules/wr_pvkitflex/test.py "2" ${pvflexip} ${pvflexport} ${pvflexid} >>${MYLOGFILE} 2>&1
 
-python3 ${OPENWBBASEDIR}/packages/modules/openwb/device.py "inverter" "${pvkitversion}" "2">>${MYLOGFILE} 2>&1
+bash "$OPENWBBASEDIR/packages/legacy_run.sh" "modules.openwb.device" "inverter" "${pvkitversion}" "2">>${MYLOGFILE} 2>&1
 
 pvwatt=$(<${RAMDISKDIR}/pv2watt)
 echo $pvwatt

--- a/modules/wr2_json/main.sh
+++ b/modules/wr2_json/main.sh
@@ -23,7 +23,7 @@ openwbDebugLog ${DMOD} 2 "PV URL : ${wr2jsonurl}"
 openwbDebugLog ${DMOD} 2 "PV Watt: ${wr2jsonwatt}"
 openwbDebugLog ${DMOD} 2 "PV kWh : ${wr2jsonkwh}"
 
-python3 $OPENWBBASEDIR/packages/modules/json/device.py "inverter" "${wr2jsonurl}" "${wr2jsonwatt}" "${wr2jsonkwh}" "2" >>$MYLOGFILE 2>&1
+bash "$OPENWBBASEDIR/packages/legacy_run.sh" "modules.json.device" "inverter" "${wr2jsonurl}" "${wr2jsonwatt}" "${wr2jsonkwh}" "2" >>$MYLOGFILE 2>&1
 ret=$?
 
 openwbDebugLog ${DMOD} 2 "RET: ${ret}"

--- a/modules/wr2_pvkitflex/main.sh
+++ b/modules/wr2_pvkitflex/main.sh
@@ -24,7 +24,7 @@ openwbDebugLog ${DMOD} 2 "PV ID : ${pv2flexid}"
 
 #python3 ${OPENWBBASEDIR}/modules/wr_pvkitflex/test.py "2" ${pv2flexip} ${pv2flexport} ${pv2flexid} >>${MYLOGFILE} 2>&1
 
-python3 ${OPENWBBASEDIR}/packages/modules/openwb_flex/device.py "inverter" "${pv2flexversion}" "${pv2flexip}" "${pv2flexport}" "${pv2flexid}" "2">>${MYLOGFILE} 2>&1
+bash "$OPENWBBASEDIR/packages/legacy_run.sh" "modules.openwb_flex.device" "inverter" "${pv2flexversion}" "${pv2flexip}" "${pv2flexport}" "${pv2flexid}" "2">>${MYLOGFILE} 2>&1
 
 pvwatt=$(<${RAMDISKDIR}/pv2watt)
 echo $pvwatt

--- a/modules/wr2_solax/main.sh
+++ b/modules/wr2_solax/main.sh
@@ -18,7 +18,7 @@ fi
 openwbDebugLog ${DMOD} 2 "PV2 IP: ${pv2ip}"
 
 
-python3 ${OPENWBBASEDIR}/packages/modules/solax/device.py "inverter" "${pv2ip}" "2">>${MYLOGFILE} 2>&1
+bash "$OPENWBBASEDIR/packages/legacy_run.sh" "modules.solax.device" "inverter" "${pv2ip}" "2">>${MYLOGFILE} 2>&1
 
 pvwatt=$(<${RAMDISKDIR}/pvwatt)
 echo $pvwatt

--- a/modules/wr2_victron/main.sh
+++ b/modules/wr2_victron/main.sh
@@ -16,7 +16,7 @@ else
 fi
 
 
-python3 ${OPENWBBASEDIR}/packages/modules/victron/device.py "inverter" "${pv2ip}" "${pv2id}" "1" "2">>${MYLOGFILE} 2>&1
+bash "$OPENWBBASEDIR/packages/legacy_run.sh" "modules.victron.device" "inverter" "${pv2ip}" "${pv2id}" "1" "2">>${MYLOGFILE} 2>&1
 
 pvwatt=$(<${RAMDISKDIR}/pvwatt)
 echo $pvwatt

--- a/modules/wr_alphaess/main.sh
+++ b/modules/wr_alphaess/main.sh
@@ -21,7 +21,7 @@ fi
 
 openwbDebugLog ${DMOD} 2 "Speicher Version: ${alphav123}"
 
-python3 $OPENWBBASEDIR/packages/modules/alpha_ess/device.py "inverter" "${alphav123}" "1">>$MYLOGFILE 2>&1
+bash "$OPENWBBASEDIR/packages/legacy_run.sh" "modules.alpha_ess.device" "inverter" "${alphav123}" "1">>$MYLOGFILE 2>&1
 ret=$?
 
 openwbDebugLog ${DMOD} 2 "RET: ${ret}"

--- a/modules/wr_http/main.sh
+++ b/modules/wr_http/main.sh
@@ -16,7 +16,7 @@ else
 fi
 
 
-python3 ${OPENWBBASEDIR}/packages/modules/http/device.py "inverter" "${wr_http_w_url}" "${wr_http_kwh_url}" "1">>${MYLOGFILE} 2>&1
+bash "$OPENWBBASEDIR/packages/legacy_run.sh" "modules.http.device" "inverter" "${wr_http_w_url}" "${wr_http_kwh_url}" "1">>${MYLOGFILE} 2>&1
 
 pvwatt=$(<${RAMDISKDIR}/pvwatt)
 echo $pvwatt

--- a/modules/wr_huawei/main.sh
+++ b/modules/wr_huawei/main.sh
@@ -16,7 +16,7 @@ else
 fi
 
 
-python3 ${OPENWBBASEDIR}/packages/modules/huawei/device.py "${pv1_ipa}" "${pv1_ida}">>${MYLOGFILE} 2>&1
+bash "$OPENWBBASEDIR/packages/legacy_run.sh" "modules.huawei.device" "${pv1_ipa}" "${pv1_ida}">>${MYLOGFILE} 2>&1
 
 pvwatt=$(<${RAMDISKDIR}/pvwatt)
 echo $pvwatt

--- a/modules/wr_json/main.sh
+++ b/modules/wr_json/main.sh
@@ -23,7 +23,7 @@ openwbDebugLog ${DMOD} 2 "PV URL : ${wrjsonurl}"
 openwbDebugLog ${DMOD} 2 "PV Watt: ${wrjsonwatt}"
 openwbDebugLog ${DMOD} 2 "PV kWh : ${wrjsonkwh}"
 
-python3 $OPENWBBASEDIR/packages/modules/json/device.py "inverter" "${wrjsonurl}" "${wrjsonwatt}" "${wrjsonkwh}" "1" >>$MYLOGFILE 2>&1
+bash "$OPENWBBASEDIR/packages/legacy_run.sh" "modules.json.device" "inverter" "${wrjsonurl}" "${wrjsonwatt}" "${wrjsonkwh}" "1" >>$MYLOGFILE 2>&1
 ret=$?
 
 openwbDebugLog ${DMOD} 2 "RET: ${ret}"

--- a/modules/wr_powerdog/main.sh
+++ b/modules/wr_powerdog/main.sh
@@ -21,7 +21,7 @@ fi
 
 openwbDebugLog ${DMOD} 2 "powerdog ip: ${bezug1_ip}"
 
-python3 $OPENWBBASEDIR/packages/modules/powerdog/device.py "inverter" "${bezug1_ip}" "1">>$MYLOGFILE 2>&1
+bash "$OPENWBBASEDIR/packages/legacy_run.sh" "modules.powerdog.device" "inverter" "${bezug1_ip}" "1">>$MYLOGFILE 2>&1
 ret=$?
 
 openwbDebugLog ${DMOD} 2 "RET: ${ret}"

--- a/modules/wr_pvkit/main.sh
+++ b/modules/wr_pvkit/main.sh
@@ -16,7 +16,7 @@ else
 fi
 
 
-python3 ${OPENWBBASEDIR}/packages/modules/openwb/device.py "inverter" "${pvkitversion}" "1">>${MYLOGFILE} 2>&1
+bash "$OPENWBBASEDIR/packages/legacy_run.sh" "modules.openwb.device" "inverter" "${pvkitversion}" "1">>${MYLOGFILE} 2>&1
 
 pvwatt=$(<${RAMDISKDIR}/pvwatt)
 echo $pvwatt

--- a/modules/wr_pvkitflex/main.sh
+++ b/modules/wr_pvkitflex/main.sh
@@ -25,7 +25,7 @@ openwbDebugLog ${DMOD} 2 "PV ID : ${pvflexid}"
 
 #python3 ${OPENWBBASEDIR}/modules/wr_pvkitflex/test.py "1" ${pvflexip} ${pvflexport} ${pvflexid} >>${MYLOGFILE} 2>&1
 
-python3 ${OPENWBBASEDIR}/packages/modules/openwb_flex/device.py "inverter" "${pvflexversion}" "${pvflexip}" "${pvflexport}" "${pvflexid}" "1">>${MYLOGFILE} 2>&1
+bash "$OPENWBBASEDIR/packages/legacy_run.sh" "modules.openwb_flex.device" "inverter" "${pvflexversion}" "${pvflexip}" "${pvflexport}" "${pvflexid}" "1">>${MYLOGFILE} 2>&1
 
 pvwatt=$(<${RAMDISKDIR}/pvwatt)
 echo $pvwatt

--- a/modules/wr_siemens/main.sh
+++ b/modules/wr_siemens/main.sh
@@ -16,7 +16,7 @@ else
 fi
 
 
-python3 ${OPENWBBASEDIR}/packages/modules/siemens/device.py "inverter" "${pv1_ipa}" "1">>${MYLOGFILE} 2>&1
+bash "$OPENWBBASEDIR/packages/legacy_run.sh" "modules.siemens.device" "inverter" "${pv1_ipa}" "1">>${MYLOGFILE} 2>&1
 
 pvwatt=$(<${RAMDISKDIR}/pvwatt)
 echo $pvwatt

--- a/modules/wr_solax/main.sh
+++ b/modules/wr_solax/main.sh
@@ -18,7 +18,7 @@ fi
 openwbDebugLog ${DMOD} 2 "PV IP: ${solaxip}"
 
 
-python3 ${OPENWBBASEDIR}/packages/modules/solax/device.py "inverter" "${solaxip}" "1">>${MYLOGFILE} 2>&1
+bash "$OPENWBBASEDIR/packages/legacy_run.sh" "modules.solax.device" "inverter" "${solaxip}" "1">>${MYLOGFILE} 2>&1
 
 pvwatt=$(<${RAMDISKDIR}/pvwatt)
 echo $pvwatt

--- a/modules/wr_sunways/main.sh
+++ b/modules/wr_sunways/main.sh
@@ -19,7 +19,7 @@ fi
 openwbDebugLog ${DMOD} 2 "PV IP: ${wrsunwaysip}"
 openwbDebugLog ${DMOD} 2 "PV Passwort: ${wrsunwayspw}"
 
-python3 /var/www/html/openWB/packages/modules/sunways/device.py "inverter" "${wrsunwaysip}" "${wrsunwayspw}" "1">>$MYLOGFILE 2>&1
+bash "$OPENWBBASEDIR/packages/legacy_run.sh" "modules.sunways.device" "inverter" "${wrsunwaysip}" "${wrsunwayspw}" "1">>$MYLOGFILE 2>&1
 ret=$?
 
 openwbDebugLog ${DMOD} 2 "RET: ${ret}"

--- a/modules/wr_victron/main.sh
+++ b/modules/wr_victron/main.sh
@@ -16,7 +16,7 @@ else
 fi
 
 
-python3 ${OPENWBBASEDIR}/packages/modules/victron/device.py "inverter" "${pv1_ipa}" "100" "0" "1">>${MYLOGFILE} 2>&1
+bash "$OPENWBBASEDIR/packages/legacy_run.sh" "modules.victron.device" "inverter" "${pv1_ipa}" "100" "0" "1">>${MYLOGFILE} 2>&1
 
 pvwatt=$(<${RAMDISKDIR}/pvwatt)
 echo $pvwatt

--- a/packages/modules/alpha_ess/device.py
+++ b/packages/modules/alpha_ess/device.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python3
 """ Modul zum Auslesen von Alpha Ess Speichern, Zählern und Wechselrichtern.
 """
-from typing import Dict, Union, Optional
+from typing import Dict, Union, Optional, List
 
 from helpermodules import log
 from helpermodules.cli import run_using_positional_cli_args
@@ -88,8 +88,5 @@ def read_legacy(component_type: str, version: int, num: Optional[int]) -> None:
     dev.update()
 
 
-if __name__ == "__main__":
-    try:
-        run_using_positional_cli_args(read_legacy)
-    except Exception:
-        log.MainLogger().exception("Fehler im Alpha Ess Skript")
+def main(argv: List[str]):
+    run_using_positional_cli_args(read_legacy, argv)

--- a/packages/modules/carlo_gavazzi/device.py
+++ b/packages/modules/carlo_gavazzi/device.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python3
-from typing import Dict, Optional
+from typing import Dict, Optional, List
 
 from helpermodules import log
 from helpermodules.cli import run_using_positional_cli_args
@@ -82,8 +82,5 @@ def read_legacy(component_type: str, ip_address: str, num: Optional[int]) -> Non
     dev.update()
 
 
-if __name__ == "__main__":
-    try:
-        run_using_positional_cli_args(read_legacy)
-    except Exception:
-        log.MainLogger().exception("Fehler im Carlo Gavazzi Skript")
+def main(argv: List[str]):
+    run_using_positional_cli_args(read_legacy, argv)

--- a/packages/modules/fronius/device.py
+++ b/packages/modules/fronius/device.py
@@ -6,8 +6,8 @@ from helpermodules.cli import run_using_positional_cli_args
 from modules.common.abstract_device import AbstractDevice
 from modules.common.component_context import MultiComponentUpdateContext
 from modules.fronius import bat
-from modules.fronius import counter_sm
 from modules.fronius import counter_s0
+from modules.fronius import counter_sm
 from modules.fronius import inverter
 from modules.fronius import meter
 
@@ -147,10 +147,3 @@ def read_legacy(
 
 def main(argv: List[str]) -> None:
     run_using_positional_cli_args(read_legacy, argv)
-
-
-if __name__ == "__main__":
-    try:
-        run_using_positional_cli_args(read_legacy)
-    except Exception:
-        log.MainLogger().exception("Fehler im Fronius Skript")

--- a/packages/modules/http/device.py
+++ b/packages/modules/http/device.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python3
 import re
-from typing import Dict, Union
+from typing import Dict, Union, List
 
 from urllib3.util import parse_url
 
@@ -141,7 +141,7 @@ def read_legacy_inverter(power_path: str, counter_path: str, num: int):
     run_device_legacy(create_legacy_device_config(power_path), component_config)
 
 
-if __name__ == "__main__":
+def main(argv: List[str]):
     run_using_positional_cli_args(
-        {"bat": read_legacy_bat, "counter": read_legacy_counter, "inverter": read_legacy_inverter}
+        {"bat": read_legacy_bat, "counter": read_legacy_counter, "inverter": read_legacy_inverter}, argv
     )

--- a/packages/modules/huawei/device.py
+++ b/packages/modules/huawei/device.py
@@ -1,10 +1,9 @@
 #!/usr/bin/env python3
 import time
-from typing import Dict, Union
+from typing import Dict, Union, List
 
 from helpermodules import log
 from helpermodules.cli import run_using_positional_cli_args
-from helpermodules.log import setup_logging_stdout
 from modules.common import modbus
 from modules.common.abstract_device import AbstractDevice
 from modules.common.component_context import SingleComponentUpdateContext
@@ -106,6 +105,5 @@ def read_legacy(ip_address: str, modbus_id: int) -> None:
     dev.update()
 
 
-if __name__ == "__main__":
-    setup_logging_stdout()
-    run_using_positional_cli_args(read_legacy)
+def main(argv: List[str]):
+    run_using_positional_cli_args(read_legacy, argv)

--- a/packages/modules/janitza/device.py
+++ b/packages/modules/janitza/device.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python3
-from typing import Dict, Optional
+from typing import Dict, Optional, List
 
 from helpermodules import log
 from helpermodules.cli import run_using_positional_cli_args
@@ -82,8 +82,5 @@ def read_legacy(component_type: str, ip_address: str, num: Optional[int]) -> Non
     dev.update()
 
 
-if __name__ == "__main__":
-    try:
-        run_using_positional_cli_args(read_legacy)
-    except Exception:
-        log.MainLogger().exception("Fehler im Janitza Skript")
+def main(argv: List[str]):
+    run_using_positional_cli_args(read_legacy, argv)

--- a/packages/modules/openwb/device.py
+++ b/packages/modules/openwb/device.py
@@ -1,4 +1,4 @@
-from typing import Dict, Union, Optional
+from typing import Dict, Union, Optional, List
 
 from helpermodules import log
 from helpermodules.cli import run_using_positional_cli_args
@@ -79,8 +79,5 @@ def read_legacy(component_type: str, version: int, num: Optional[int]):
     dev.update()
 
 
-if __name__ == "__main__":
-    try:
-        run_using_positional_cli_args(read_legacy)
-    except Exception:
-        log.MainLogger().exception("Fehler im Modul openwb")
+def main(argv: List[str]):
+    run_using_positional_cli_args(read_legacy, argv)

--- a/packages/modules/openwb_flex/device.py
+++ b/packages/modules/openwb_flex/device.py
@@ -1,4 +1,4 @@
-from typing import Dict, Union, Optional
+from typing import Dict, Union, Optional, List
 
 from helpermodules import log
 from helpermodules.cli import run_using_positional_cli_args
@@ -98,8 +98,5 @@ def read_legacy(component_type: str, version: int, ip_address: str, port: int, i
     dev.update()
 
 
-if __name__ == "__main__":
-    try:
-        run_using_positional_cli_args(read_legacy)
-    except Exception:
-        log.MainLogger().exception("Fehler im Modul openwb_flex")
+def main(argv: List[str]):
+    run_using_positional_cli_args(read_legacy, argv)

--- a/packages/modules/powerdog/device.py
+++ b/packages/modules/powerdog/device.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python3
-from typing import Dict, Union, Optional
+from typing import Dict, Union, Optional, List
 
 from helpermodules import log
 from helpermodules.cli import run_using_positional_cli_args
@@ -111,8 +111,5 @@ def read_legacy(component_type: str, ip_address: str, num: Optional[int]) -> Non
     dev.update()
 
 
-if __name__ == "__main__":
-    try:
-        run_using_positional_cli_args(read_legacy)
-    except Exception:
-        log.MainLogger().exception("Fehler im Powerdog Skript")
+def main(argv: List[str]):
+    run_using_positional_cli_args(read_legacy, argv)

--- a/packages/modules/saxpower/device.py
+++ b/packages/modules/saxpower/device.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python3
-from typing import Dict
+from typing import Dict, List
 
 from helpermodules import log
 from helpermodules.cli import run_using_positional_cli_args
@@ -82,8 +82,5 @@ def read_legacy(component_type: str, ip_address: str) -> None:
     dev.update()
 
 
-if __name__ == "__main__":
-    try:
-        run_using_positional_cli_args(read_legacy)
-    except Exception:
-        log.MainLogger().exception("Fehler im Saxpower Skript")
+def main(argv: List[str]):
+    run_using_positional_cli_args(read_legacy, argv)

--- a/packages/modules/siemens/device.py
+++ b/packages/modules/siemens/device.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python3
-from typing import Dict, Union, Optional
+from typing import Dict, Union, Optional, List
 
 from helpermodules import log
 from helpermodules.cli import run_using_positional_cli_args
@@ -84,8 +84,5 @@ def read_legacy(component_type: str, ip_address: str, num: Optional[int]) -> Non
     dev.update()
 
 
-if __name__ == "__main__":
-    try:
-        run_using_positional_cli_args(read_legacy)
-    except Exception:
-        log.MainLogger().exception("Fehler im Siemens Skript")
+def main(argv: List[str]):
+    run_using_positional_cli_args(read_legacy, argv)

--- a/packages/modules/solax/device.py
+++ b/packages/modules/solax/device.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python3
-from typing import Dict, Optional
+from typing import Dict, Optional, List
 
 from helpermodules import log
 from helpermodules.cli import run_using_positional_cli_args
@@ -87,8 +87,5 @@ def read_legacy(component_type: str, ip_address: str, num: Optional[int]) -> Non
     dev.update()
 
 
-if __name__ == "__main__":
-    try:
-        run_using_positional_cli_args(read_legacy)
-    except Exception:
-        log.MainLogger().exception("Fehler im Solax Skript")
+def main(argv: List[str]):
+    run_using_positional_cli_args(read_legacy, argv)

--- a/packages/modules/sunny_island/device.py
+++ b/packages/modules/sunny_island/device.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python3
 """ Modul zum Auslesen von Alpha Ess Speichern, Zählern und Wechselrichtern.
 """
-from typing import Dict, Optional
+from typing import Dict, Optional, List
 
 from helpermodules import log
 from helpermodules.cli import run_using_positional_cli_args
@@ -83,8 +83,5 @@ def read_legacy(component_type: str, ip_address: str, num: Optional[int]) -> Non
     dev.update()
 
 
-if __name__ == "__main__":
-    try:
-        run_using_positional_cli_args(read_legacy)
-    except Exception:
-        log.MainLogger().exception("Fehler im Sunny Island Skript")
+def main(argv: List[str]):
+    run_using_positional_cli_args(read_legacy, argv)

--- a/packages/modules/sunways/device.py
+++ b/packages/modules/sunways/device.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python3
-from typing import Dict, Optional
+from typing import Dict, Optional, List
 
 from helpermodules import log
 from helpermodules.cli import run_using_positional_cli_args
@@ -84,8 +84,5 @@ def read_legacy(component_type: str, ip_address: str, password: str, num: Option
     dev.update()
 
 
-if __name__ == "__main__":
-    try:
-        run_using_positional_cli_args(read_legacy)
-    except Exception:
-        log.MainLogger().exception("Fehler im Sunways Skript")
+def main(argv: List[str]):
+    run_using_positional_cli_args(read_legacy, argv)

--- a/packages/modules/victron/device.py
+++ b/packages/modules/victron/device.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python3
-from typing import Dict, Optional, Union
+from typing import Dict, Optional, Union, List
 
 from helpermodules import log
 from helpermodules.cli import run_using_positional_cli_args
@@ -98,8 +98,5 @@ def read_legacy(
     dev.update()
 
 
-if __name__ == "__main__":
-    try:
-        run_using_positional_cli_args(read_legacy)
-    except Exception:
-        log.MainLogger().exception("Fehler im Victron Skript")
+def main(argv: List[str]):
+    run_using_positional_cli_args(read_legacy, argv)


### PR DESCRIPTION
So bin ich vorgegangen:

1. Module gesucht die nach "Standardformat" aufgerufen werden:
    ```regex
    if __name__ == "__main__":\s*try:\s*run_using_positional_cli_args\(([^)]+)\)\s*except Exception:\s*.*
    ```
    Und das ersetzt durch:
    ```
    def main(argv: List[str]):\n    run_using_positional_cli_args($1, argv)
    ```
2. Alle Module ermittelt die dadurch geändert wurden:
    ```bash
    git status -uno --porcelain | cut -d '/' -f 3 | tr '\n' '|'
    ```
    Und dann die Aufrufe von den Scripten geändert mit dem Regex:
    ```regex
    python3 \$\{?OPENWBBASEDIR\}?/packages/modules/(alpha_ess|carlo_gavazzi|fronius|janitza|openwb|openwb_flex|powerdog|saxpower|siemens|solax|sunny_island|sunways|victron)/device.py
    ```
    Ersetzt durch:
    ```
    bash "\$OPENWBBASEDIR/packages/legacy_run.sh" "modules.$1.device"
    ```
3. Alle geänderten Python-Dateien durchgegangen und die Imports geprüft (bei manchen fehlte `List`)
4. Nochmal mit dem Regex:
    ```regex
    (alpha_ess|carlo_gavazzi|fronius|janitza|openwb|openwb_flex|powerdog|saxpower|siemens|solax|sunny_island|sunways|victron)/device.py
    ```
    Geschaut ob es noch Aufrufe von den entsprechenden Dateien gibt die nicht durch Schritt 2 erfasst wurden. Zwei Dateien gefunden: "speicher_fronius" und "wr_sunways". Auf Basis von dem Ergebnis den Regex aus Schritt 2 nochmal erweitert und wiederholt:
    ```regex
    python3 (?:\$\{?OPENWBBASEDIR\}?|/var/www/html/openWB)/packages/modules/(alpha_ess|carlo_gavazzi|fronius|janitza|openwb|openwb_flex|powerdog|saxpower|siemens|solax|sunny_island|sunways|victron)/device.py
    ```
5. Mit dem Regex `packages/(?!legacy_run\.sh)` geschaut ob noch was übrig geblieben ist. `json`, `huawei` und `http` gefunden. In einem zweiten Commit: Diese Module noch manuell angepasst und Schritte 4 und 5 wiederholt