### PR TITLE
Revert "Fronius: MQTT-Topics für Erzeugerwerte angepasst"

### DIFF
--- a/packages/modules/fronius/inverter.py
+++ b/packages/modules/fronius/inverter.py
@@ -123,15 +123,14 @@ class FroniusInverter:
                 with open("/var/www/html/openWB/ramdisk/pvkwh_start", "w") as f:
                     f.write(str(counter_start))
         else:
-            topic = "openWB/pv/"+str(self.component_config["id"])+"/get/counter_offset"
+            topic = "openWB/system/device/" + str(self.__device_id)+"/component/" + \
+                str(self.component_config["id"])+"/counter_offset"
             counter_offset = Offset().offset(topic)
             if counter_offset is None:
                 counter_offset = 0
-            topic = "openWB/pv/"+str(self.component_config["id"])+"/get/counter_start"
+            topic = "openWB/system/device/" + str(self.__device_id)+"/component/" + \
+                str(self.component_config["id"])+"/counter_start"
             counter_start = Offset().offset(topic)
-            if counter_start is None:
-                counter_start = counter - daily_yield
-                pub.pub_single(topic, counter_start)
 
         if counter_start is not None:
             counter_new = counter_start + daily_yield + counter_offset
@@ -161,7 +160,8 @@ class FroniusInverter:
                 with open("/var/www/html/openWB/ramdisk/pvkwh", "r") as ff:
                     counter_old = float(ff.read())
             else:
-                topic = "openWB/pv/"+str(self.component_config["id"])+"/get/counter_start"
+                topic = "openWB/set/system/device/" + str(self.__device_id)+"/component/" + \
+                    str(self.component_config["id"])+"/pvkwh_start"
                 pub.pub_single(topic, counter)
                 topic = "openWB/pv/" + str(self.component_config["id"])+"/counter"
                 try:
@@ -174,14 +174,16 @@ class FroniusInverter:
                 with open("/var/www/html/openWB/ramdisk/pvkwh_offset", "w") as f:
                     f.write(str(counter_offset))
             else:
-                topic = "openWB/pv/"+str(self.component_config["id"])+"/get/counter_offset"
+                topic = "openWB/set/system/device/" + str(self.__device_id)+"/component/" + \
+                    str(self.component_config["id"])+"/counter_offset"
                 pub.pub_single(topic, counter_offset)
         else:
             if ramdisk:
                 with open("/var/www/html/openWB/ramdisk/pvkwh_offset", "w") as f:
                     f.write(str(counter_offset))
             else:
-                topic = "openWB/pv/"+str(self.component_config["id"])+"/get/counter_offset"
+                topic = "openWB/set/system/device/" + str(self.__device_id)+"/component/" + \
+                    str(self.component_config["id"])+"/counter_offset"
                 pub.pub_single(topic, counter_offset)
         return counter
 


### PR DESCRIPTION
Reverts snaptec/openWB#1868

Nachvollziehbarer Gedankengang, allerdings kann in 2.x der Wert aus dem Modul-Topic nicht dem Device und der dazugehörigen Komponente zugeordnet werden.