### PR TITLE
fix requests headers and data

### DIFF
--- a/modules/wr_tripower9000/tripower.py
+++ b/modules/wr_tripower9000/tripower.py
@@ -15,13 +15,16 @@ log = logging.getLogger("SMA ModbusTCP WR")
 
 
 def update_sma_webbox(address: str):
+    # response = requests.post('http://' + address + '/rpc', json=data, timeout=3)
+    # does not give the same result
+    headers = {'Content-Type': 'application/json', }
     data = {'RPC': '{"version": "1.0","proc": "GetPlantOverview","id": "1","format": "JSON"}'}
-    response = requests.post('http://' + address + '/rpc', json=data, timeout=3)
+    response = requests.post('http://' + address + '/rpc', headers=headers, data=data, timeout=3)
     response.raise_for_status()
     response_data = response.json()
     get_inverter_value_store(1).set(InverterState(
-        counter=response_data["result"]["overview"][2]["value"] * 1000,
-        power=-response_data["result"]["overview"][0]["value"]
+        counter=float(response_data["result"]["overview"][2]["value"]) * 1000,
+        power=-int(response_data["result"]["overview"][0]["value"])
     ))
 
 


### PR DESCRIPTION
```python
data = {'RPC': '{"version": "1.0","proc": "GetPlantOverview","id": "1","format": "JSON"}'}
response = requests.post('http://' + address + '/rpc', json=data, timeout=3)
```
sollte das gleiche Ergebnis liefern wie
```
headers = {'Content-Type': 'application/json', }
data = {'RPC': '{"version": "1.0","proc": "GetPlantOverview","id": "1","format": "JSON"}'}
response = requests.post('http://' + address + '/rpc', headers=headers, data=data, timeout=3)
```

Das war offensichtlich nicht der Fall.