### PR TITLE
Use simcount for fronius

### DIFF
--- a/modules/bezug_fronius_s0/main.sh
+++ b/modules/bezug_fronius_s0/main.sh
@@ -21,13 +21,12 @@ fi
 
 openwbDebugLog ${DMOD} 2 "WR IP: ${wrfroniusip}"
 openwbDebugLog ${DMOD} 2 "WR Erzeugung: ${froniuserzeugung}"
-openwbDebugLog ${DMOD} 2 "WR GEN24: ${wrfroniusisgen24}"
 openwbDebugLog ${DMOD} 2 "WR Var2: ${froniusvar2}"
 openwbDebugLog ${DMOD} 2 "WR MeterLocation: ${froniusmeterlocation}"
 openwbDebugLog ${DMOD} 2 "WR IP2: ${wrfronius2ip}"
 openwbDebugLog ${DMOD} 2 "WR Speicher: ${speichermodul}"
 
-bash "$OPENWBBASEDIR/packages/legacy_run.sh" "modules.fronius.device" "counter_s0" "${wrfroniusip}" "${froniuserzeugung}" "${wrfroniusisgen24}" "${froniusvar2}" "${froniusmeterlocation}" "${wrfronius2ip}" "${speichermodul}" 2>>$MYLOGFILE
+bash "$OPENWBBASEDIR/packages/legacy_run.sh" "modules.fronius.device" "counter_s0" "${wrfroniusip}" "${froniuserzeugung}" "${froniusvar2}" "${froniusmeterlocation}" "${wrfronius2ip}" "${speichermodul}" 2>>$MYLOGFILE
 
 wattbezug=$(<${RAMDISKDIR}/wattbezug)
 echo $wattbezug

--- a/modules/bezug_fronius_sm/main.sh
+++ b/modules/bezug_fronius_sm/main.sh
@@ -21,13 +21,12 @@ fi
 
 openwbDebugLog ${DMOD} 2 "WR IP: ${wrfroniusip}"
 openwbDebugLog ${DMOD} 2 "WR Erzeugung: ${froniuserzeugung}"
-openwbDebugLog ${DMOD} 2 "WR GEN24: ${wrfroniusisgen24}"
 openwbDebugLog ${DMOD} 2 "WR Var2: ${froniusvar2}"
 openwbDebugLog ${DMOD} 2 "WR MeterLocation: ${froniusmeterlocation}"
 openwbDebugLog ${DMOD} 2 "WR IP2: ${wrfronius2ip}"
 openwbDebugLog ${DMOD} 2 "WR Speicher: ${speichermodul}"
 
-bash "$OPENWBBASEDIR/packages/legacy_run.sh" "modules.fronius.device" "counter_sm" "${wrfroniusip}" "${froniuserzeugung}" "${wrfroniusisgen24}" "${froniusvar2}" "${froniusmeterlocation}" "${wrfronius2ip}" "${speichermodul}" 2>>$MYLOGFILE
+bash "$OPENWBBASEDIR/packages/legacy_run.sh" "modules.fronius.device" "counter_sm" "${wrfroniusip}" "${froniuserzeugung}" "${froniusvar2}" "${froniusmeterlocation}" "${wrfronius2ip}" "${speichermodul}" 2>>$MYLOGFILE
 
 wattbezug=$(</var/www/html/openWB/ramdisk/wattbezug)
 echo $wattbezug

--- a/modules/speicher_fronius/main.sh
+++ b/modules/speicher_fronius/main.sh
@@ -18,7 +18,7 @@ fi
 
 openwbDebugLog ${DMOD} 2 "Speicher IP: ${wrfroniusip}"
 
-bash "$OPENWBBASEDIR/packages/legacy_run.sh" "modules.fronius.device" "bat" "${wrfroniusip}" "${froniuserzeugung}" "${wrfroniusisgen24}" "0" "0" "none" "" >>$MYLOGFILE 2>&1
+bash "$OPENWBBASEDIR/packages/legacy_run.sh" "modules.fronius.device" "bat" "${wrfroniusip}" "${froniuserzeugung}" "0" "0" "none" "" >>$MYLOGFILE 2>&1
 ret=$?
 
 openwbDebugLog ${DMOD} 2 "RET: ${ret}"

--- a/modules/wr_fronius/main.sh
+++ b/modules/wr_fronius/main.sh
@@ -20,11 +20,10 @@ if [[ -z "$debug" ]]; then
 fi
 
 openwbDebugLog ${DMOD} 2 "WR IP: ${wrfroniusip}"
-openwbDebugLog ${DMOD} 2 "WR Gen 24: ${wrfroniusisgen24}"
 openwbDebugLog ${DMOD} 2 "WR IP2: ${wrfronius2ip}"
 openwbDebugLog ${DMOD} 2 "WR Speicher: ${speichermodul}"
 
-bash "$OPENWBBASEDIR/packages/legacy_run.sh" "modules.fronius.device" "inverter" "${wrfroniusip}" "0" "${wrfroniusisgen24}" "0" "0" "${wrfronius2ip}" "${speichermodul}" "1" 2>>$MYLOGFILE
+bash "$OPENWBBASEDIR/packages/legacy_run.sh" "modules.fronius.device" "inverter" "${wrfroniusip}" "0" "0" "0" "${wrfronius2ip}" "${speichermodul}" "1" 2>>$MYLOGFILE
 
 pvwatt=$(</var/www/html/openWB/ramdisk/pvwatt) 
 echo $pvwatt

--- a/packages/modules/common/fault_state.py
+++ b/packages/modules/common/fault_state.py
@@ -23,8 +23,6 @@ class ComponentInfo:
 
 
 class FaultState(Exception):
-    type_topic_mapping_comp = {"bat": "houseBattery", "counter": "evu", "inverter": "pv", "vehicle": "lp"}
-
     def __init__(self, fault_str: str, fault_state: FaultStateLevel) -> None:
         self.fault_str = fault_str
         self.fault_state = fault_state
@@ -38,7 +36,7 @@ class FaultState(Exception):
                                        traceback.format_exc())
             ramdisk = compatibility.is_ramdisk_in_use()
             if ramdisk:
-                topic = self.type_topic_mapping_comp.get(component_info.type, component_info.type)
+                topic = self.__type_topic_mapping_comp(component_info.type)
                 prefix = "openWB/set/" + topic + "/"
                 if component_info.id is not None:
                     if topic == "lp":
@@ -58,13 +56,25 @@ class FaultState(Exception):
         except Exception:
             log.MainLogger().exception("Fehler im Modul fault_state")
 
-    def __type_topic_mapping(self, component_type: str):
+    def __type_topic_mapping(self, component_type: str) -> str:
         if "counter" in component_type:
             return "counter"
         elif "inverter" in component_type:
             return "pv"
         else:
             return component_type
+
+    def __type_topic_mapping_comp(self, component_type: str) -> str:
+        if "bat" in component_type:
+            return "houseBattery"
+        elif "counter" in component_type:
+            return "evu"
+        elif "inverter" in component_type:
+            return "pv"
+        elif "vehicle" in component_type:
+            return "lp"
+        else:
+            raise Exception("Unbekannter Komponententyp: "+str(component_type))
 
     @staticmethod
     def error(message: str) -> "FaultState":

--- a/packages/modules/fronius/bat.py
+++ b/packages/modules/fronius/bat.py
@@ -29,7 +29,7 @@ class FroniusBat:
         self.__store = get_bat_value_store(component_config["id"])
         self.component_info = ComponentInfo.from_component_config(component_config)
 
-    def update(self, bat: bool) -> None:
+    def update(self) -> None:
         log.MainLogger().debug("Komponente "+self.component_config["name"]+" auslesen.")
         meter_id = str(self.device_config["meter_id"])
 

--- a/packages/modules/fronius/counter_s0.py
+++ b/packages/modules/fronius/counter_s0.py
@@ -25,7 +25,7 @@ class FroniusS0Counter:
         self.__store = get_counter_value_store(component_config["id"])
         self.component_info = ComponentInfo.from_component_config(component_config)
 
-    def update(self, bat: bool) -> CounterState:
+    def update(self) -> CounterState:
         log.MainLogger().debug("Komponente "+self.component_config["name"]+" auslesen.")
 
         session = req.get_http_session()
@@ -35,29 +35,15 @@ class FroniusS0Counter:
         # Wenn WR aus bzw. im Standby (keine Antwort), ersetze leeren Wert durch eine 0.
         power = float(response.json()["Body"]["Data"]["Site"]["P_Grid"]) or 0
 
-        # Summe der vom Netz bezogene Energie total in Wh
-        # nur für Smartmeter  im Einspeisepunkt!
-        # bei Smartmeter im Verbrauchszweig  entspricht das dem Gesamtverbrauch
-        response = session.get(
-            'http://' + self.device_config["ip_address"] + '/solar_api/v1/GetMeterRealtimeData.cgi',
-            params=(('Scope', 'System'),),
-            timeout=5)
-        meter_id = str(self.device_config["meter_id"])
-        response_json_id = dict(response.json()["Body"]["Data"]).get(meter_id)
-        if "EnergyReal_WAC_Minus_Absolute" in response_json_id and \
-           "EnergyReal_WAC_Plus_Absolute" in response_json_id:
-            imported = float(response_json_id["EnergyReal_WAC_Minus_Absolute"])
-            exported = float(response_json_id["EnergyReal_WAC_Plus_Absolute"])
-        else:
-            topic_str = "openWB/set/system/device/{}/component/{}/".format(
-                self.__device_id, self.component_config["id"]
-            )
-            imported, exported = self.__sim_count.sim_count(
-                power,
-                topic=topic_str,
-                data=self.simulation,
-                prefix="bezug"
-            )
+        topic_str = "openWB/set/system/device/{}/component/{}/".format(
+            self.__device_id, self.component_config["id"]
+        )
+        imported, exported = self.__sim_count.sim_count(
+            power,
+            topic=topic_str,
+            data=self.simulation,
+            prefix="bezug"
+        )
 
         counter_state = CounterState(
             imported=imported,

--- a/packages/modules/fronius/counter_sm.py
+++ b/packages/modules/fronius/counter_sm.py
@@ -49,6 +49,16 @@ class FroniusSmCounter:
         else:
             raise FaultState.error("Unbekannte Variante: "+str(variant))
 
+        topic_str = "openWB/set/system/device/{}/component/{}/".format(
+            self.__device_id, self.component_config["id"]
+        )
+        counter_state.imported, counter_state.exported = self.__sim_count.sim_count(
+            counter_state.power,
+            topic=topic_str,
+            data=self.simulation,
+            prefix="bezug"
+        )
+
         return counter_state, meter_location
 
     def set_counter_state(self, counter_state: CounterState) -> None:
@@ -76,14 +86,7 @@ class FroniusSmCounter:
             params=params,
             timeout=5)
         response_json_id = response.json()["Body"]["Data"]
-        # old request for variant == 1
-        # params = (
-        #     ('Scope', 'System'),
-        # )
-        # response = req.get_http_session().get(
-        #     'http://'+self.device_config["ip_address"]+'/solar_api/v1/GetMeterRealtimeData.cgi',
-        #  params=params, timeout=5)
-        # response_json_id = response["Body"]["Data"][meter_id]
+
         meter_location = MeterLocation(response_json_id["Meter_Location_Current"])
         log.MainLogger().debug("Einbauort: "+str(meter_location))
 
@@ -97,22 +100,10 @@ class FroniusSmCounter:
         power_factors = [response_json_id["PowerFactor_Phase_"+str(num)] for num in range(1, 4)]
         frequency = response_json_id["Frequency_Phase_Average"]
 
-        topic_str = "openWB/set/system/device/{}/component/{}/".format(
-            self.__device_id, self.component_config["id"]
-        )
-        imported, exported = self.__sim_count.sim_count(
-            power,
-            topic=topic_str,
-            data=self.simulation,
-            prefix="bezug"
-        )
-
         return CounterState(
             voltages=voltages,
             currents=currents,
             powers=powers,
-            imported=imported,
-            exported=exported,
             power=power,
             frequency=frequency,
             power_factors=power_factors
@@ -137,22 +128,10 @@ class FroniusSmCounter:
         power_factors = [response_json_id["SMARTMETER_FACTOR_POWER_0"+str(num)+"_F64"] for num in range(1, 4)]
         frequency = response_json_id["GRID_FREQUENCY_MEAN_F32"]
 
-        topic_str = "openWB/set/system/device/{}/component/{}/".format(
-            self.__device_id, self.component_config["id"]
-        )
-        imported, exported = self.__sim_count.sim_count(
-            power,
-            topic=topic_str,
-            data=self.simulation,
-            prefix="bezug"
-        )
-
         return CounterState(
             voltages=voltages,
             currents=currents,
             powers=powers,
-            imported=imported,
-            exported=exported,
             power=power,
             frequency=frequency,
             power_factors=power_factors

--- a/packages/modules/fronius/counter_sm.py
+++ b/packages/modules/fronius/counter_sm.py
@@ -36,7 +36,7 @@ class FroniusSmCounter:
         self.__store = get_counter_value_store(component_config["id"])
         self.component_info = ComponentInfo.from_component_config(component_config)
 
-    def update(self, bat: bool) -> Tuple[CounterState, MeterLocation]:
+    def update(self) -> Tuple[CounterState, MeterLocation]:
         variant = self.component_config["configuration"]["variant"]
         log.MainLogger().debug("Komponente "+self.component_config["name"]+" auslesen.")
 
@@ -112,8 +112,16 @@ class FroniusSmCounter:
         currents = [powers[i] / voltages[i] for i in range(0, 3)]
         power_factors = [response_json_id["PowerFactor_Phase_"+str(num)] for num in range(1, 4)]
         frequency = response_json_id["Frequency_Phase_Average"]
-        imported = response_json_id["EnergyReal_WAC_Sum_Consumed"]
-        exported = response_json_id["EnergyReal_WAC_Sum_Produced"]
+
+        topic_str = "openWB/set/system/device/{}/component/{}/".format(
+            self.__device_id, self.component_config["id"]
+        )
+        imported, exported = self.__sim_count.sim_count(
+            power,
+            topic=topic_str,
+            data=self.simulation,
+            prefix="bezug"
+        )
 
         return CounterState(
             voltages=voltages,
@@ -141,8 +149,16 @@ class FroniusSmCounter:
         currents = [powers[i] / voltages[i] for i in range(0, 3)]
         power_factors = [response_json_id["SMARTMETER_FACTOR_POWER_0"+str(num)+"_F64"] for num in range(1, 4)]
         frequency = response_json_id["GRID_FREQUENCY_MEAN_F32"]
-        imported = response_json_id["SMARTMETER_ENERGYACTIVE_CONSUMED_SUM_F64"]
-        exported = response_json_id["SMARTMETER_ENERGYACTIVE_PRODUCED_SUM_F64"]
+
+        topic_str = "openWB/set/system/device/{}/component/{}/".format(
+            self.__device_id, self.component_config["id"]
+        )
+        imported, exported = self.__sim_count.sim_count(
+            power,
+            topic=topic_str,
+            data=self.simulation,
+            prefix="bezug"
+        )
 
         return CounterState(
             voltages=voltages,

--- a/packages/modules/fronius/inverter.py
+++ b/packages/modules/fronius/inverter.py
@@ -1,18 +1,13 @@
 #!/usr/bin/env python3
-from typing import Optional, Tuple
 
 import requests
-import paho.mqtt.client as mqtt
-import time
 
 from helpermodules import log
-from helpermodules import pub
 from modules.common import req
 from modules.common import simcount
 from modules.common.component_state import InverterState
 from modules.common.fault_state import ComponentInfo
 from modules.common.store import get_inverter_value_store
-from helpermodules import compatibility
 
 
 def get_default_config() -> dict:
@@ -22,8 +17,7 @@ def get_default_config() -> dict:
         "type": "inverter",
         "configuration":
         {
-            "ip_address2": "none",
-            "gen24": False
+            "ip_address2": "none"
         }
     }
 
@@ -38,9 +32,8 @@ class FroniusInverter:
         self.__store = get_inverter_value_store(component_config["id"])
         self.component_info = ComponentInfo.from_component_config(component_config)
 
-    def update(self, bat: bool) -> float:
+    def update(self) -> float:
         log.MainLogger().debug("Komponente "+self.component_config["name"]+" auslesen.")
-        gen24 = self.component_config["configuration"]["gen24"]
 
         # Rückgabewert ist die aktuelle Wirkleistung in [W].
         params = (
@@ -55,23 +48,12 @@ class FroniusInverter:
             # Ohne PV Produktion liefert der WR 'null', ersetze durch Zahl 0
             power = 0
 
-        power2, counter2 = self.__get_wr2()
+        power2 = self.__get_wr2()
         power += power2
         power1 = power
         power *= -1
         topic = "openWB/set/system/device/" + str(self.__device_id)+"/component/" + str(self.component_config["id"])+"/"
-        if gen24:
-            _, counter = self.__sim_count.sim_count(power, topic=topic, data=self.__simulation, prefix="pv")
-        else:
-            counter = float(response.json()["Body"]["Data"]["Site"]["E_Total"])
-            daily_yield = float(response.json()["Body"]["Data"]["Site"]["E_Day"])
-            counter, counter_start, counter_offset = self.__calculate_offset(counter, daily_yield)
-            counter = counter + counter2
-            if counter > 0:
-                counter = self.__add_and_save_offset(daily_yield, counter, counter_start, counter_offset)
-
-        if bat is True:
-            _, counter = self.__sim_count.sim_count(power, topic=topic, data=self.__simulation, prefix="pv")
+        _, counter = self.__sim_count.sim_count(power, topic=topic, data=self.__simulation, prefix="pv")
 
         inverter_state = InverterState(
             power=power,
@@ -82,9 +64,8 @@ class FroniusInverter:
         # Rückgabe der Leistung des ersten WR ohne Vorzeichenumkehr
         return power1
 
-    def __get_wr2(self) -> Tuple[float, float]:
+    def __get_wr2(self) -> float:
         ip_address2 = self.component_config["configuration"]["ip_address2"]
-        counter2 = 0
         if ip_address2 != "none":
             try:
                 params = (('Scope', 'System'),)
@@ -96,138 +77,9 @@ class FroniusInverter:
                 except TypeError:
                     # Ohne PV Produktion liefert der WR 'null', ersetze durch Zahl 0
                     power2 = 0
-                if not self.component_config["configuration"]["gen24"]:
-                    counter2 = float(response.json()["Body"]["Data"]["Site"]["E_Total"])
             except (requests.ConnectTimeout, requests.ConnectionError):
                 # Nachtmodus: WR ist ausgeschaltet
                 power2 = 0
         else:
             power2 = 0
-        return power2, counter2
-
-    def __calculate_offset(self, counter: float, daily_yield: float) -> Tuple[float, float, float]:
-        ramdisk = compatibility.is_ramdisk_in_use()
-        if ramdisk:
-            try:
-                with open("/var/www/html/openWB/ramdisk/pvkwh_offset", "r") as f:
-                    counter_offset = float(f.read())
-            except FileNotFoundError as e:
-                log.MainLogger().exception(str(e))
-                counter_offset = 0
-            try:
-                with open("/var/www/html/openWB/ramdisk/pvkwh_start", "r") as f:
-                    counter_start = float(f.read())
-            except FileNotFoundError as e:
-                log.MainLogger().exception(str(e))
-                counter_start = counter - daily_yield
-                with open("/var/www/html/openWB/ramdisk/pvkwh_start", "w") as f:
-                    f.write(str(counter_start))
-        else:
-            topic = "openWB/system/device/" + str(self.__device_id)+"/component/" + \
-                str(self.component_config["id"])+"/counter_offset"
-            counter_offset = Offset().offset(topic)
-            if counter_offset is None:
-                counter_offset = 0
-            topic = "openWB/system/device/" + str(self.__device_id)+"/component/" + \
-                str(self.component_config["id"])+"/counter_start"
-            counter_start = Offset().offset(topic)
-
-        if counter_start is not None:
-            counter_new = counter_start + daily_yield + counter_offset
-            if counter_new > counter:
-                if counter_new - counter >= 100:
-                    # Korrigiere Abweichung
-                    counter_diff = counter_new - counter - 99
-                    counter_offset -= counter_diff
-                    counter_new -= counter_diff
-                counter = counter_new
-            else:
-                # Berechne Abweichung als Mittelwert von aktueller und bisheriger Abweichung
-                counter_offset = round((counter_offset + counter - counter_start - daily_yield) / 2)
-        else:
-            counter_start = 0
-        return counter, counter_start, counter_offset
-
-    def __add_and_save_offset(
-            self, daily_yield: float, counter: float, counter_start: float, counter_offset: float) -> float:
-        ramdisk = compatibility.is_ramdisk_in_use()
-        if daily_yield == 0 and \
-           counter > counter_start + counter_offset and \
-           self.component_config["configuration"]["ip_address2"] == "none":
-            if ramdisk:
-                with open("/var/www/html/openWB/ramdisk/pvkwh_start", "w") as f:
-                    f.write(str(counter))
-                with open("/var/www/html/openWB/ramdisk/pvkwh", "r") as ff:
-                    counter_old = float(ff.read())
-            else:
-                topic = "openWB/set/system/device/" + str(self.__device_id)+"/component/" + \
-                    str(self.component_config["id"])+"/pvkwh_start"
-                pub.pub_single(topic, counter)
-                topic = "openWB/pv/" + str(self.component_config["id"])+"/counter"
-                try:
-                    counter_old = float(Offset().offset(topic))
-                except ValueError:
-                    counter_old = 0
-            counter_offset = counter_old - counter
-            counter += counter_offset
-            if ramdisk:
-                with open("/var/www/html/openWB/ramdisk/pvkwh_offset", "w") as f:
-                    f.write(str(counter_offset))
-            else:
-                topic = "openWB/set/system/device/" + str(self.__device_id)+"/component/" + \
-                    str(self.component_config["id"])+"/counter_offset"
-                pub.pub_single(topic, counter_offset)
-        else:
-            if ramdisk:
-                with open("/var/www/html/openWB/ramdisk/pvkwh_offset", "w") as f:
-                    f.write(str(counter_offset))
-            else:
-                topic = "openWB/set/system/device/" + str(self.__device_id)+"/component/" + \
-                    str(self.component_config["id"])+"/counter_offset"
-                pub.pub_single(topic, counter_offset)
-        return counter
-
-
-class Offset():
-    def offset(self, topic: str) -> Optional[float]:
-        try:
-            self.temp = None
-            self.topic = topic
-            client = mqtt.Client("openWB-fronius_offset-" + str(self.__getserial()))
-
-            client.on_connect = self.__on_connect
-            client.on_message = self.__on_message
-
-            client.connect("localhost", 1883)
-            client.loop_start()
-            time.sleep(0.5)
-            client.loop_stop()
-        except Exception:
-            log.MainLogger().exception("Fehler in der Restore-Klasse")
-        finally:
-            return self.temp
-
-    def __on_connect(self, client, userdata, flags, rc):
-        """ connect to broker and subscribe to set topics
-        """
-        try:
-            client.subscribe(self.topic, 2)
-        except Exception:
-            log.MainLogger().exception("Fehler in der Restore-Klasse")
-
-    def __on_message(self, client, userdata, msg):
-        """ wartet auf eingehende Topics.
-        """
-        self.temp = float(msg.payload)
-
-    def __getserial(self):
-        """ Extract serial from cpuinfo file
-        """
-        try:
-            with open('/proc/cpuinfo', 'r') as f:
-                for line in f:
-                    if line[0:6] == 'Serial':
-                        return line[10:26]
-                return "0000000000000000"
-        except Exception:
-            log.MainLogger().exception("Fehler in der Restore-Klasse")
+        return power2

--- a/runs/updateConfig.sh
+++ b/runs/updateConfig.sh
@@ -2114,9 +2114,6 @@ updateConfig(){
 		echo "soc_evcc_vin_lp2=''" >> $ConfigFile
 		echo "soc_evcc_token_lp2=''" >> $ConfigFile
 	fi
-	if ! grep -Fq "wrfroniusisgen24=" $ConfigFile; then
-		echo "wrfroniusisgen24=0" >> $ConfigFile
-	fi
 	if ! grep -Fq "cpunterbrechungmindestlaufzeitaktiv=" $ConfigFile; then
 		echo "cpunterbrechungmindestlaufzeitaktiv=0" >> $ConfigFile
 		echo "cpunterbrechungmindestlaufzeit=30" >> $ConfigFile

--- a/web/settings/modulconfigpv.php
+++ b/web/settings/modulconfigpv.php
@@ -684,22 +684,6 @@
 								</div>
 							</div>
 							<div class="form-row mb-1">
-								<label class="col-md-4 col-form-label">Handelt es sich um einen Gen24?</label>
-								<div class="col">
-									<div class="btn-group btn-group-toggle btn-block" data-toggle="buttons">
-										<label class="btn btn-outline-info<?php if($wrfroniusisgen24old == 0) echo " active" ?>">
-											<input type="radio" name="wrfroniusisgen24" id="wrfroniusisgen24No" value="0"<?php if($wrfroniusisgen24old == 0) echo " checked=\"checked\"" ?>>Nein
-										</label>
-										<label class="btn btn-outline-info<?php if($wrfroniusisgen24old == 1) echo " active" ?>">
-											<input type="radio" name="wrfroniusisgen24" id="wrfroniusisgen24Yes" value="1"<?php if($wrfroniusisgen24old == 1) echo " checked=\"checked\"" ?>>Ja
-										</label>
-									</div>
-									<span class="form-text small">
-										Diese Option aktivieren wenn es sich um einen Gen24 handelt.
-									</span>
-								</div>
-							</div>
-							<div class="form-row mb-1">
 								<label for="wrfronius2ip" class="col-md-4 col-form-label">WR Fronius 2 IP</label>
 								<div class="col">
 									<input class="form-control" type="text" pattern="^((\d{1,2}|1\d\d|2[0-4]\d|25[0-5])\.){3}(\d{1,2}|1\d\d|2[0-4]\d|25[0-5])|none$" name="wrfronius2ip" id="wrfronius2ip" value="<?php echo $wrfronius2ipold ?>">


### PR DESCRIPTION
Da bei einigen Fronius-Modulen keine oder falsche Zählerstände ausgegeben werden, wird in allen Fronius-Modulen simcount verwendet.