### PR TITLE
fix: mqttsub.py fails to start in atreboot.sh because PYTHONPATH is not set

### DIFF
--- a/runs/atreboot.sh
+++ b/runs/atreboot.sh
@@ -6,6 +6,7 @@ echo "atreboot.sh started"
 # read openwb.conf
 echo "loading config"
 . /var/www/html/openWB/loadconfig.sh
+. "$OPENWBBASEDIR/helperFunctions.sh"
 
 # load functions to init ramdisk and update config
 # no code will run here, functions need to be called


### PR DESCRIPTION
Schaut man aktuell direkt nach einem Reboot ins log steht dort:
```
Traceback (most recent call last):
  File "/var/www/html/openWB/runs/mqttsub.py", line 15, in <module>
    from modules.common.store.ramdisk import files
ImportError: No module named 'modules'
```
Das liegt daran, dass ich in #1879 das entsprechende Import hinzugefügt habe, das aber nur funktioniert, wenn `PYTHONPATH` korrekt gesetzt ist, was in `helperFunctions.sh` passiert. Diese Datei wird in der `atreboot.sh` aber nicht gesourced. Zunächst ist das nicht aufgefallen, da der 5-Minuten-Cronjob nach kurzer Zeit das Programm doch wieder startet.