### PR TITLE
log it if fetching Date from SMA HomeManager/EnergyMeter times out

### DIFF
--- a/modules/bezug_smashm/main.sh
+++ b/modules/bezug_smashm/main.sh
@@ -1,4 +1,5 @@
 #!/bin/bash
 OPENWBBASEDIR=$(cd `dirname $0`/../../ && pwd)
 timeout 3 python3 "$OPENWBBASEDIR/modules/bezug_smashm/sma_em_measurement.py" "$smashmbezugid" >> "$OPENWBBASEDIR/ramdisk/openWB.log" 2>&1
+(($? == 124)) && openwbDebugLog "MAIN" 0 "Fetching SMA counter data timed out"
 cat /var/www/html/openWB/ramdisk/wattbezug


### PR DESCRIPTION
Wenn das Laden von Daten vom SMA HomeManager/EnergyMeter einen timeout erfährt, dann hinterlässt das keine eindeutigen Spuren im Log. Das ist bei der Fehlersuche unpraktisch. Daher ergänzt dieser PR eine Logausgabe.