### PR TITLE
fix huawei counter values are not read by loadvars

### DIFF
--- a/modules/bezug_huawei/main.sh
+++ b/modules/bezug_huawei/main.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
+OPENWBBASEDIR=$(cd $(dirname "${BASH_SOURCE[0]}")/../.. && pwd)
 
 #datenauslesung erfolgt im PV Modul
-echo $watt < /var/www/html/openWB/ramdisk/wattbezug
-echo $watt
+cat "$OPENWBBASEDIR/ramdisk/wattbezug"


### PR DESCRIPTION
Im Forum beschwert man sich, dass [huawei EVU nicht geht](https://openwb.de/forum/viewtopic.php?f=9&t=4621).

Zumindest zeigt ein kurzer Blick auf die modules/bezug_huawei/main.sh, dass die Datei so mit Sicherheit nicht das tut, was der Autor im Sinn hatte. Getestet ist das zwar nicht, aber es kann nur besser werden :-).