### PR TITLE
E3DC Bezug Anpassung V2 Korrektur

### DIFF
--- a/loadvars.sh
+++ b/loadvars.sh
@@ -1051,7 +1051,7 @@ loadvars(){
 	fi
 	echo $hausverbrauch > /var/www/html/openWB/ramdisk/hausverbrauch
 	usesimbezug=0
-	if [[ $wattbezugmodul == "bezug_e3dc" ]] || [[ $wattbezugmodul == "bezug_solarwatt" ]]|| [[ $wattbezugmodul == "bezug_rct" ]]|| [[ $wattbezugmodul == "bezug_varta" ]] || [[ $wattbezugmodul == "bezug_lgessv1" ]] || [[ $wattbezugmodul == "bezug_kostalpiko" ]] || [[ $wattbezugmodul == "bezug_kostalplenticoreem300haus" ]] || [[ $wattbezugmodul == "bezug_sbs25" ]] || [[ $wattbezugmodul == "bezug_solarlog" ]] ; then
+	if [[ $wattbezugmodul == "bezug_solarwatt" ]]|| [[ $wattbezugmodul == "bezug_rct" ]]|| [[ $wattbezugmodul == "bezug_varta" ]] || [[ $wattbezugmodul == "bezug_lgessv1" ]] || [[ $wattbezugmodul == "bezug_kostalpiko" ]] || [[ $wattbezugmodul == "bezug_kostalplenticoreem300haus" ]] || [[ $wattbezugmodul == "bezug_sbs25" ]] || [[ $wattbezugmodul == "bezug_solarlog" ]] ; then
 		usesimbezug=1
 	fi
 	if [[ $usesimbezug == "1" ]]; then

--- a/modules/bezug_e3dc/e3dc.py
+++ b/modules/bezug_e3dc/e3dc.py
@@ -23,8 +23,8 @@ def update(ipaddress: str):
     cnt= SimCountFactory().get_sim_counter()().sim_count(power_all, prefix="bezug")
     #print ('0 %f, 1 %f' % (cnt[0],cnt[1]))  
     get_counter_value_store(1).set(CounterState(
-        imported= float("%.3f" % cnt[0]),
-        exported= float("%.3f" % cnt[1]),  
+        imported= cnt[0],
+        exported= cnt[1],  
         power=power_all,
         powers=powers
     ))

--- a/modules/bezug_e3dc/e3dc.py
+++ b/modules/bezug_e3dc/e3dc.py
@@ -1,30 +1,34 @@
 #!/usr/bin/python
 from pymodbus.constants import Endian
 import logging
+import math
+from typing import List
 
 from helpermodules.cli import run_using_positional_cli_args
 from helpermodules.log import setup_logging_stdout
 from modules.common.component_state import CounterState
 from modules.common.modbus import ModbusClient, ModbusDataType
 from modules.common.store import get_counter_value_store
+from modules.common.simcount import SimCountFactory
 
 log = logging.getLogger("E3DC EVU")
-
 
 def update(ipaddress: str):
     log.debug("Beginning update")
     client = ModbusClient(ipaddress, port=502)
-    # 40074 EVU Punkt negativ -> Einspeisung in Watt
+#40074 EVU Punkt negativ -> Einspeisung in Watt
     power_all = client.read_holding_registers(40073, ModbusDataType.INT_32, wordorder=Endian.Little, unit=1)
-    # 40130 Phasenleistung in Watt
+#40130 Phasenleistung in Watt
     powers = client.read_holding_registers(40129, [ModbusDataType.INT_16] * 3, unit=1)
+    cnt= SimCountFactory().get_sim_counter()().sim_count(power_all, prefix="bezug")
+    #print ('0 %f, 1 %f' % (cnt[0],cnt[1]))  
     get_counter_value_store(1).set(CounterState(
+        imported= float("%.3f" % cnt[0]),
+        exported= float("%.3f" % cnt[1]),  
         power=power_all,
         powers=powers
     ))
     log.debug("Update completed successfully")
-
-
 if __name__ == '__main__':
     setup_logging_stdout()
     run_using_positional_cli_args(update)

--- a/packages/modules/common/simcount.py
+++ b/packages/modules/common/simcount.py
@@ -88,12 +88,12 @@ class SimCountLegacy:
                 try:
                     counter_import_present = int(float(read_ramdisk_file(prefix+'watt0pos')))
                 except Exception:
-                    counter_import_present = int(Restore().restore_value("watt0pos", prefix))
+                    counter_import_present = int(float(Restore().restore_value("watt0pos", prefix)))
                 counter_import_previous = counter_import_present
                 try:
                     counter_export_present = int(float(read_ramdisk_file(prefix+'watt0neg')))
                 except Exception:
-                    counter_export_present = int(Restore().restore_value("watt0neg", prefix))
+                    counter_export_present = int(float(Restore().restore_value("watt0neg", prefix)))
                 if counter_export_present < 0:
                     # runs/simcount.py speichert das Zwischenergebnis des Exports negativ ab.
                     counter_export_present = counter_export_present * -1
@@ -157,8 +157,11 @@ class Restore():
             time.sleep(0.5)
             client.loop_stop()
 
-            ra = '^-?[0-9]+$'
-            if re.search(ra, str(self.temp)) is None:
+            #ra = '^-?[0-9]+$'
+            #if re.search(ra, str(self.temp)) is None:
+            try:
+                float(self.temp)
+            except ValueError:
                 log.MainLogger().info("Keine Werte auf dem Broker gefunden. neue Simulation gestartet.")
                 self.temp = "0"
             write_ramdisk_file(prefix+value, self.temp)

--- a/packages/modules/common/simcount.py
+++ b/packages/modules/common/simcount.py
@@ -2,7 +2,6 @@
 Berechnet die importierte und exportierte Leistung, wenn der Zähler / PV-Modul / Speicher diese nicht liefert.
 """
 import os
-import re
 import paho.mqtt.client as mqtt
 import time
 import typing
@@ -157,8 +156,6 @@ class Restore():
             time.sleep(0.5)
             client.loop_stop()
 
-            #ra = '^-?[0-9]+$'
-            #if re.search(ra, str(self.temp)) is None:
             try:
                 float(self.temp)
             except ValueError:

--- a/packages/modules/common/simcount.py
+++ b/packages/modules/common/simcount.py
@@ -87,12 +87,12 @@ class SimCountLegacy:
                 try:
                     counter_import_present = int(float(read_ramdisk_file(prefix+'watt0pos')))
                 except Exception:
-                    counter_import_present = int(float(Restore().restore_value("watt0pos", prefix)))
+                    counter_import_present = int(Restore().restore_value("watt0pos", prefix))
                 counter_import_previous = counter_import_present
                 try:
                     counter_export_present = int(float(read_ramdisk_file(prefix+'watt0neg')))
                 except Exception:
-                    counter_export_present = int(float(Restore().restore_value("watt0neg", prefix)))
+                    counter_export_present = int(Restore().restore_value("watt0neg", prefix))
                 if counter_export_present < 0:
                     # runs/simcount.py speichert das Zwischenergebnis des Exports negativ ab.
                     counter_export_present = counter_export_present * -1

--- a/packages/modules/common/simcount.py
+++ b/packages/modules/common/simcount.py
@@ -141,7 +141,7 @@ class SimCountLegacy:
 
 
 class Restore():
-    def restore_value(self, value: str, prefix: str) -> str:
+    def restore_value(self, value: str, prefix: str) -> float:
         try:
             self.temp = ""
             self.value = value
@@ -155,12 +155,12 @@ class Restore():
             client.loop_start()
             time.sleep(0.5)
             client.loop_stop()
-
             try:
-                float(self.temp)
+                result = float(self.temp)
             except ValueError:
                 log.MainLogger().info("Keine Werte auf dem Broker gefunden. neue Simulation gestartet.")
                 self.temp = "0"
+                result = 0
             write_ramdisk_file(prefix+value, self.temp)
             if value == "watt0pos":
                 log.MainLogger().info(
@@ -171,7 +171,7 @@ class Restore():
         except Exception:
             log.MainLogger().exception("Fehler in der Restore-Klasse")
         finally:
-            return self.temp
+            return result
 
     def __on_connect(self, client, userdata, flags, rc):
         """ connect to broker and subscribe to set topics


### PR DESCRIPTION
Simcount wird nun direkt im Bezugsmodul e3dc gelesen
Simcount für e3dc Bezug im Loadvars.sh entfernt
Simcount (SimCountFactory) für V2 persistiert nun korrekt die EVU Topics (Lösung mit @yankee42 erarbeitet), Zähler fing nach Reboot bei 0 an da er nur auf ganze Zahlen (nicht float) checkte
Dadurch sollte das Daily Excel wieder stimmen