### PR TITLE
fix: openWB/set/pv/X/W Vorzeichenfehler

### DIFF
--- a/runs/mqttsub.py
+++ b/runs/mqttsub.py
@@ -1370,7 +1370,7 @@ def on_message(client, userdata, msg):
                 elif subtopic == "W":
                     value = abs(float(msg.payload))
                     if value <= 100000000:
-                        pv.power.write(float(msg.payload))
+                        pv.power.write(-float(msg.payload))
             if (msg.topic == "openWB/set/lp/1/AutolockStatus"):
                 if (int(msg.payload) >= 0 and int(msg.payload) <=3):
                     f = open('/var/www/html/openWB/ramdisk/autolockstatuslp1', 'w')


### PR DESCRIPTION
openWB/pv/X/W liefert negative Ergebnisse für Produktion und openWB/pv/X/W hätte aber gerne positive Zahlen, damit man negative draus machen kann. *roll*

Siehe auch [forum](https://openwb.de/forum/viewtopic.php?p=55564#p55564)