### PR TITLE
provide default values for optional arguments

### DIFF
--- a/packages/modules/alpha_ess/device.py
+++ b/packages/modules/alpha_ess/device.py
@@ -64,7 +64,7 @@ class Device(AbstractDevice):
             )
 
 
-def read_legacy(component_type: str, version: int, num: Optional[int]) -> None:
+def read_legacy(component_type: str, version: int, num: Optional[int] = None) -> None:
     COMPONENT_TYPE_TO_MODULE = {
         "bat": bat,
         "counter": counter,

--- a/packages/modules/carlo_gavazzi/device.py
+++ b/packages/modules/carlo_gavazzi/device.py
@@ -60,7 +60,7 @@ class Device(AbstractDevice):
             )
 
 
-def read_legacy(component_type: str, ip_address: str, num: Optional[int]) -> None:
+def read_legacy(component_type: str, ip_address: str, num: Optional[int] = None) -> None:
     COMPONENT_TYPE_TO_MODULE = {
         "counter": counter
     }

--- a/packages/modules/common/fault_state.py
+++ b/packages/modules/common/fault_state.py
@@ -79,7 +79,7 @@ class FaultState(Exception):
         return FaultState("Kein Fehler.", FaultStateLevel.NO_ERROR)
 
     @staticmethod
-    def from_exception(exception: Optional[Exception]) -> "FaultState":
+    def from_exception(exception: Optional[Exception] = None) -> "FaultState":
         if exception is None:
             return FaultState.no_error()
         if isinstance(exception, FaultState):

--- a/packages/modules/janitza/device.py
+++ b/packages/modules/janitza/device.py
@@ -60,7 +60,7 @@ class Device(AbstractDevice):
             )
 
 
-def read_legacy(component_type: str, ip_address: str, num: Optional[int]) -> None:
+def read_legacy(component_type: str, ip_address: str, num: Optional[int] = None) -> None:
     COMPONENT_TYPE_TO_MODULE = {
         "counter": counter
     }

--- a/packages/modules/openwb/device.py
+++ b/packages/modules/openwb/device.py
@@ -53,7 +53,7 @@ class Device(AbstractDevice):
             )
 
 
-def read_legacy(component_type: str, version: int, num: Optional[int]):
+def read_legacy(component_type: str, version: int, num: Optional[int] = None):
     """ Ausführung des Moduls als Python-Skript
     """
     COMPONENT_TYPE_TO_MODULE = {

--- a/packages/modules/openwb_flex/device.py
+++ b/packages/modules/openwb_flex/device.py
@@ -64,7 +64,7 @@ class Device(AbstractDevice):
             )
 
 
-def read_legacy(component_type: str, version: int, ip_address: str, port: int, id: int, num: Optional[int]):
+def read_legacy(component_type: str, version: int, ip_address: str, port: int, id: int, num: Optional[int] = None):
     """ Ausführung des Moduls als Python-Skript
     """
     COMPONENT_TYPE_TO_MODULE = {

--- a/packages/modules/openwb_pv_evu/device.py
+++ b/packages/modules/openwb_pv_evu/device.py
@@ -49,7 +49,7 @@ class Device(AbstractDevice):
             )
 
 
-def read_legacy(version: int, num: Optional[int]):
+def read_legacy(version: int, num: Optional[int] = None):
     component_config = inverter.get_default_config()
     component_config["id"] = num
     component_config["configuration"]["version"] = version

--- a/packages/modules/powerdog/device.py
+++ b/packages/modules/powerdog/device.py
@@ -86,7 +86,7 @@ class Device(AbstractDevice):
             )
 
 
-def read_legacy(component_type: str, ip_address: str, num: Optional[int]) -> None:
+def read_legacy(component_type: str, ip_address: str, num: Optional[int] = None) -> None:
     device_config = get_default_config()
     device_config["configuration"]["ip_address"] = ip_address
     dev = Device(device_config)

--- a/packages/modules/siemens/device.py
+++ b/packages/modules/siemens/device.py
@@ -60,7 +60,7 @@ class Device(AbstractDevice):
             )
 
 
-def read_legacy(component_type: str, ip_address: str, num: Optional[int]) -> None:
+def read_legacy(component_type: str, ip_address: str, num: Optional[int] = None) -> None:
     COMPONENT_TYPE_TO_MODULE = {
         "bat": bat,
         "counter": counter,

--- a/packages/modules/solax/device.py
+++ b/packages/modules/solax/device.py
@@ -63,7 +63,7 @@ class Device(AbstractDevice):
                 ": Es konnten keine Werte gelesen werden, da noch keine Komponenten konfiguriert wurden.")
 
 
-def read_legacy(component_type: str, ip_address: str, num: Optional[int]) -> None:
+def read_legacy(component_type: str, ip_address: str, num: Optional[int] = None) -> None:
     COMPONENT_TYPE_TO_MODULE = {
         "bat": bat,
         "counter": counter,

--- a/packages/modules/studer/device.py
+++ b/packages/modules/studer/device.py
@@ -67,7 +67,7 @@ class Device(AbstractDevice):
             )
 
 
-def read_legacy(ip_address: str, component_config: dict, id: Optional[int], **kwargs):
+def read_legacy(ip_address: str, component_config: dict, id: Optional[int] = None, **kwargs):
     component_config["id"] = id
     component_config["configuration"].update(kwargs)
     device_config = get_default_config()
@@ -77,11 +77,11 @@ def read_legacy(ip_address: str, component_config: dict, id: Optional[int], **kw
     dev.update()
 
 
-def read_legacy_bat(ip_address: str, num: Optional[int]):
+def read_legacy_bat(ip_address: str, num: Optional[int] = None):
     read_legacy(ip_address, bat.get_default_config(), num)
 
 
-def read_legacy_inverter(ip_address: str, vc_count: int, vc_type: str, num: Optional[int]):
+def read_legacy_inverter(ip_address: str, vc_count: int, vc_type: str, num: int):
     read_legacy(ip_address, inverter.get_default_config(), num, vc_count=vc_count, vc_type=vc_type)
 
 

--- a/packages/modules/sungrow/device.py
+++ b/packages/modules/sungrow/device.py
@@ -67,7 +67,7 @@ class Device(AbstractDevice):
             )
 
 
-def read_legacy(ip_address: str, component_config: dict, id: Optional[int], **kwargs):
+def read_legacy(ip_address: str, component_config: dict, id: Optional[int] = None, **kwargs):
     component_config["id"] = id
     component_config["configuration"].update(kwargs)
     device_config = get_default_config()
@@ -77,7 +77,7 @@ def read_legacy(ip_address: str, component_config: dict, id: Optional[int], **kw
     dev.update()
 
 
-def read_legacy_bat(ip_address: str, num: Optional[int]):
+def read_legacy_bat(ip_address: str, num: Optional[int] = None):
     read_legacy(ip_address, bat.get_default_config(), num)
 
 
@@ -85,7 +85,7 @@ def read_legacy_counter(ip_address: str, version: int):
     read_legacy(ip_address, counter.get_default_config(), version=version)
 
 
-def read_legacy_inverter(ip_address: str, num: Optional[int]):
+def read_legacy_inverter(ip_address: str, num: int):
     read_legacy(ip_address, inverter.get_default_config(), num)
 
 

--- a/packages/modules/sunny_island/device.py
+++ b/packages/modules/sunny_island/device.py
@@ -62,7 +62,7 @@ class Device(AbstractDevice):
             )
 
 
-def read_legacy(component_type: str, ip_address: str, num: Optional[int]) -> None:
+def read_legacy(component_type: str, ip_address: str, num: Optional[int] = None) -> None:
     COMPONENT_TYPE_TO_MODULE = {
         "bat": bat
     }


### PR DESCRIPTION
- arguments with class `Optional` still require a default value to be really optional
- for inverter components a `id` or `num` is mandatory
```
2022-01-18 19:53:24: PID: 1836: legacy run server: Received command ["modules.sungrow.device","counter","192.168.178.69","0"]
2022-01-18 19:53:24: PID: 1836: legacy run server: Unhandled exception
Traceback (most recent call last):
File "/var/www/html/openWB/packages/legacy_run_server.py", line 44, in redirect_stdout_stderr_exceptions_to_log
yield
File "/var/www/html/openWB/packages/legacy_run_server.py", line 83, in handle_connection
self.__callback(read_all_bytes(connection))
File "/var/www/html/openWB/packages/legacy_run_server.py", line 104, in handle_message
importlib.import_module(parsed[0]).main(parsed[1:])
File "/var/www/html/openWB/packages/modules/sungrow/device.py", line 94, in main
{"bat": read_legacy_bat, "counter": read_legacy_counter, "inverter": read_legacy_inverter}, argv
File "/var/www/html/openWB/packages/helpermodules/cli/_run_using_positional_cli_args.py", line 34, in run_using_positional_cli_args
args.RUN(args)
File "/var/www/html/openWB/packages/helpermodules/cli/_run_using_positional_cli_args.py", line 19, in
parser.set_defaults(RUN=lambda args: function(*[getattr(args, argument_name) for argument_name in arg_spec.args]))
File "/var/www/html/openWB/packages/modules/sungrow/device.py", line 85, in read_legacy_counter
read_legacy(ip_address, counter.get_default_config(), version=version)
TypeError: read_legacy() missing 1 required positional argument: 'id'
```