### PR TITLE
when storing anything in a `ValueStore`, log the value

### DIFF
--- a/packages/helpermodules/auto_str.py
+++ b/packages/helpermodules/auto_str.py
@@ -1,0 +1,14 @@
+from typing import TypeVar
+
+T = TypeVar('T')
+
+
+def auto_str(cls: T) -> T:
+    def __str__(self):
+        return '%s(%s)' % (
+            type(self).__name__,
+            ', '.join('%s=%s' % item for item in vars(self).items())
+        )
+
+    cls.__str__ = __str__
+    return cls

--- a/packages/modules/common/component_state.py
+++ b/packages/modules/common/component_state.py
@@ -1,6 +1,9 @@
 from typing import List
 
+from helpermodules.auto_str import auto_str
 
+
+@auto_str
 class BatState:
     def __init__(self, imported: float = 0, exported: float = 0, power: float = 0, soc: float = 0):
         self.imported = imported
@@ -9,6 +12,7 @@ class BatState:
         self.soc = soc
 
 
+@auto_str
 class CounterState:
     def __init__(self,
                  imported: float = 0,
@@ -40,6 +44,7 @@ class CounterState:
         self.frequency = frequency
 
 
+@auto_str
 class InverterState:
     def __init__(
         self,
@@ -54,6 +59,7 @@ class InverterState:
         self.counter = counter
 
 
+@auto_str
 class CarState:
     def __init__(self, soc: float):
         self.soc = soc

--- a/packages/modules/common/store/_api.py
+++ b/packages/modules/common/store/_api.py
@@ -1,10 +1,21 @@
+import logging
 from abc import abstractmethod
 from typing import Generic, TypeVar
 
 T = TypeVar("T")
+log = logging.getLogger("ValueStore")
 
 
 class ValueStore(Generic[T]):
     @abstractmethod
     def set(self, state: T) -> None:
         pass
+
+
+class LoggingValueStore(Generic[T], ValueStore[T]):
+    def __init__(self, delegate: ValueStore[T]):
+        self.delegate = delegate
+
+    def set(self, state: T) -> None:
+        log.debug("Saving %s", state)
+        self.delegate.set(state)

--- a/packages/modules/common/store/_counter.py
+++ b/packages/modules/common/store/_counter.py
@@ -1,6 +1,7 @@
-from helpermodules import log, compatibility
+from helpermodules import compatibility
 from modules.common.component_state import CounterState
 from modules.common.store import ValueStore
+from modules.common.store._api import LoggingValueStore
 from modules.common.store._broker import pub_to_broker
 from modules.common.store._util import process_error
 from modules.common.store.ramdisk import files
@@ -17,9 +18,6 @@ class CounterValueStoreRamdisk(ValueStore[CounterState]):
             files.evu.energy_export.write(counter_state.exported)
             files.evu.power_import.write(counter_state.power)
             files.evu.frequency.write(counter_state.frequency)
-            log.MainLogger().info('EVU Watt: ' + str(counter_state.power))
-            log.MainLogger().info('EVU Bezug: ' + str(counter_state.imported))
-            log.MainLogger().info('EVU Einspeisung: ' + str(counter_state.exported))
         except Exception as e:
             process_error(e)
 
@@ -43,6 +41,6 @@ class CounterValueStoreBroker(ValueStore[CounterState]):
 
 
 def get_counter_value_store(component_num: int) -> ValueStore[CounterState]:
-    if compatibility.is_ramdisk_in_use():
-        return CounterValueStoreRamdisk()
-    return CounterValueStoreBroker(component_num)
+    return LoggingValueStore(
+        CounterValueStoreRamdisk() if compatibility.is_ramdisk_in_use() else CounterValueStoreBroker(component_num)
+    )


### PR DESCRIPTION
Mir wurde von @okaegi die Anregung zugetragen, ob man beim Speichern nicht mehr loggen könnte. Insbesondere hat er sich für den Zählerstand interessiert.

Ich habe da mal was gebaut. Bei mir sieht damit die Ausgabe wie folgt aus:
```
2022-01-21 10:26:25: PID: 26115: ValueStore: Saving InverterState(counter=10420500.0, currents=[0.75, 0.81, 0.88], power=-364.0)
2022-01-21 10:26:28: PID: 11123: ValueStore: Saving CounterState(currents=[-0.4007846556233653, 0.06142668428005284, 0.03372446762277271], imported=3202494.1745, power=-70.23, voltages=[229.4, 227.1, 230.1], exported=5513137.3984, frequency=50, powers=[-91.94, 13.95, 7.76], power_factors=[0, 0, 0])
```
So wie ich es gebaut habe kommt das Log auch in der Broker-Variante raus in der vorher garkeine Logausgaben waren. War das kalkulierte Absicht? Wenn ja würde ich das da wieder rausnehmen.