### PR TITLE
SolarView: Allow configuration of command

### DIFF
--- a/modules/wr_solarview/main.sh
+++ b/modules/wr_solarview/main.sh
@@ -19,9 +19,10 @@ fi
 openwbDebugLog ${DMOD} 2 "PV Hostname: ${solarview_hostname}"
 openwbDebugLog ${DMOD} 2 "PV Port: ${solarview_port}"
 openwbDebugLog ${DMOD} 2 "PV Timeout: ${solarview_timeout}"
+openwbDebugLog ${DMOD} 2 "PV Command: ${solarview_command_wr}"
 
 
-python3 /var/www/html/openWB/modules/wr_solarview/solarview.py "${solarview_hostname}" "${solarview_port}" "${solarview_timeout}" >>$MYLOGFILE 2>&1
+python3 /var/www/html/openWB/modules/wr_solarview/solarview.py "${solarview_hostname}" "${solarview_port}" "${solarview_timeout}" "${solarview_command_wr}" >>$MYLOGFILE 2>&1
 ret=$?
 
 openwbDebugLog ${DMOD} 2 "RET: ${ret}"

--- a/modules/wr_solarview/solarview.py
+++ b/modules/wr_solarview/solarview.py
@@ -22,6 +22,14 @@ try:
     solarview_timeout = int(sys.argv[3])
 except:
     solarview_timeout = 1
+try:
+    solarview_command_wr = str(sys.argv[4])
+except:
+    # Sende-Kommando (siehe SolarView-Dokumentation); Beispiele:
+    # '00*': Gesamte Anlage
+    # '01*': Wechselrichter 1
+    # '02*': Wechselrichter 2
+    solarview_command_wr = "00*"
 
 
 def DebugLog(message):
@@ -153,13 +161,10 @@ if solarview_port:
     if solarview_port < 1 or solarview_port > 65535:
         DebugLog("Invalid value "+str(solarview_port)+" for variable 'solarview_port'")
         exit(1)
+if solarview_command_wr == None or solarview_command_wr == "":
+    DebugLog("Missing value for variable 'solarview_command_wr'")
+    exit(1)
 
-# Sende-Kommando (siehe SolarView-Dokumentation); Beispiele:
-# '00*': Gesamte Anlage
-# '01*': Wechselrichter 1
-# '02*': Wechselrichter 2
-command="00*"
-
-request(command)
+request(solarview_command_wr)
 
 exit(0)

--- a/modules/wr_solarview/solarview.py
+++ b/modules/wr_solarview/solarview.py
@@ -158,7 +158,7 @@ if solarview_port:
 # '00*': Gesamte Anlage
 # '01*': Wechselrichter 1
 # '02*': Wechselrichter 2
-command="1:-00*"
+command="00*"
 
 request(command)
 

--- a/runs/updateConfig.sh
+++ b/runs/updateConfig.sh
@@ -1459,7 +1459,7 @@ updateConfig(){
 		echo "solarview_hostname=192.168.0.31" >> $ConfigFile
 	fi
 	if ! grep -Fq "solarview_port=" $ConfigFile; then
-		echo "solarview_port=80" >> $ConfigFile
+		echo "solarview_port=15000" >> $ConfigFile
 	fi
 	if ! grep -Fq "discovergyuser=" $ConfigFile; then
 		echo "discovergyuser=name@mail.de" >> $ConfigFile

--- a/runs/updateConfig.sh
+++ b/runs/updateConfig.sh
@@ -1461,6 +1461,12 @@ updateConfig(){
 	if ! grep -Fq "solarview_port=" $ConfigFile; then
 		echo "solarview_port=15000" >> $ConfigFile
 	fi
+	if ! grep -Fq "solarview_timeout=" $ConfigFile; then
+		echo "solarview_timeout=1" >> $ConfigFile
+	fi
+	if ! grep -Fq "solarview_command_wr=" $ConfigFile; then
+		echo "solarview_command_wr=00*" >> $ConfigFile
+	fi
 	if ! grep -Fq "discovergyuser=" $ConfigFile; then
 		echo "discovergyuser=name@mail.de" >> $ConfigFile
 	fi

--- a/web/settings/modulconfigpv.php
+++ b/web/settings/modulconfigpv.php
@@ -295,7 +295,7 @@
 								<div class="col">
 								<input class="form-control" type="text" pattern="^\d{2}\*$" name="solarview_command_wr" id="solarview_command_wr" value="<?php echo $solarview_command_wrold ?>">
 									<span class="form-text small">
-										Gültige Werte: Kommandos, z.B. 01*
+										Gültige Werte: Kommandos gemäß SolarView-Dokumentation, z.B.: <code>00*</code> (gesamte Anlage), <code>01*</code> (Wechselrichter 1), <code>02*</code> (Wechselrichter 2)
 									</span>
 								</div>
 							</div>

--- a/web/settings/modulconfigpv.php
+++ b/web/settings/modulconfigpv.php
@@ -268,7 +268,7 @@
 								<div class="col">
 									<input class="form-control" type="text" pattern="^((\d{1,2}|1\d\d|2[0-4]\d|25[0-5])\.){3}(\d{1,2}|1\d\d|2[0-4]\d|25[0-5])|[a-zA-Z0-9.\-_]+$" name="solarview_hostname" id="solarview_hostname" value="<?php echo $solarview_hostnameold ?>">
 									<span class="form-text small">
-										Gültige Werte Hostname oder IP-Adresse.
+										Gültige Werte: Hostname oder IP-Adresse
 									</span>
 								</div>
 							</div>
@@ -277,7 +277,25 @@
 								<div class="col">
 									<input class="form-control" type="number" name="solarview_port" id="solarview_port" value="<?php echo htmlspecialchars($solarview_portold) ?>">
 									<span class="form-text small">
-										Gültige Werte Port, z.B. 15000.
+										Gültige Werte: Port, z.B. 15000
+									</span>
+								</div>
+							</div>
+							<div class="form-row mb-1">
+								<label for="solarview_timeout" class="col-md-4 col-form-label">Timeout für den Solarview TCP-Server</label>
+								<div class="col">
+									<input class="form-control" type="number" name="solarview_timeout" id="solarview_timeout" value="<?php echo htmlspecialchars($solarview_timeoutold) ?>">
+									<span class="form-text small">
+										Gültige Werte: Dauer in Sekunden, z.B. 3
+									</span>
+								</div>
+							</div>
+							<div class="form-row mb-1">
+								<label for="solarview_command_wr" class="col-md-4 col-form-label">Kommando für die Abfrage der Wechselrichter</label>
+								<div class="col">
+								<input class="form-control" type="text" pattern="^\d{2}\*$" name="solarview_command_wr" id="solarview_command_wr" value="<?php echo $solarview_command_wrold ?>">
+									<span class="form-text small">
+										Gültige Werte: Kommandos, z.B. 01*
 									</span>
 								</div>
 							</div>


### PR DESCRIPTION
This PR contains:

- A fix for a bug that was introduced when the original shell script was moved to python.
  - The shell script [used the first argument as command](https://github.com/git-developer/openWB/blob/9c8c49cd52f1ad7cc022137ad08ebda14e01355e/modules/wr_solarview/main.sh#L143), defaulting to `00*`.
  - The python module [uses](https://github.com/git-developer/openWB/blob/4583660fcf48468ad86c25af22461be0163b53d8/modules/wr_solarview/solarview.py#L161) the string `1:-00*`.
- A new feature to read a custom command from the configuration file, as requested [in the forum](https://openwb.de/forum/viewtopic.php?p=56018#p56018). This allows users to configure a single inverter as relevant for openWB, and not the whole plant.

The original contribution was [#245](https://github.com/snaptec/openWB/pull/245).