### PR TITLE
E3DC Bezug...

### DIFF
--- a/modules/bezug_e3dc/e3dc.py
+++ b/modules/bezug_e3dc/e3dc.py
@@ -16,17 +16,25 @@ log = logging.getLogger("E3DC EVU")
 def update(ipaddress: str):
     log.debug("Beginning update")
     client = ModbusClient(ipaddress, port=502)
-#40074 EVU Punkt negativ -> Einspeisung in Watt
+    #40074 EVU Punkt negativ -> Einspeisung in Watt
     power_all = client.read_holding_registers(40073, ModbusDataType.INT_32, wordorder=Endian.Little, unit=1)
-#40130 Phasenleistung in Watt
-    powers = client.read_holding_registers(40129, [ModbusDataType.INT_16] * 3, unit=1)
-    cnt= SimCountFactory().get_sim_counter()().sim_count(power_all, prefix="bezug")
-    #print ('0 %f, 1 %f' % (cnt[0],cnt[1]))  
+    #40130 Phasenleistung in Watt
+    # max 6 Leistungsmesser verbaut ab 410105, typ 1 ist evu
+    # bei den meisten e3dc auf 40128
+    #for i in range (40104,40132,4):
+    for i in range (40128,40103,-4):
+    #powers = client.read_holding_registers(40129, [ModbusDataType.INT_16] * 3, unit=1)
+        powers = client.read_holding_registers(i, [ModbusDataType.INT_16] * 4, unit=1)
+        log.debug("I: %d, p[0] typ %d p[1] a1 %d p[2] a2 %d p[3] a3 %d",i,powers[0],powers[1],powers[2],powers[3])
+        if powers [0] == 1:
+            log.debug("Evu Leistungsmessung gefunden")
+            break
+    counter_import, counter_export= SimCountFactory().get_sim_counter()().sim_count(power_all, prefix="bezug")
     get_counter_value_store(1).set(CounterState(
-        imported= cnt[0],
-        exported= cnt[1],  
+        imported= counter_import,
+        exported= counter_export,  
         power=power_all,
-        powers=powers
+        powers=powers[1:]
     ))
     log.debug("Update completed successfully")
 if __name__ == '__main__':


### PR DESCRIPTION
Der Zähler vom Hausanschluss wird nicht mehr Fix auf Modbus Adresse 40130 erwartet.
Es werden die 6 relevanten Zähler Modbusadressen abgefragt und der Type vom Zähler (=1) geprüft. Somti werden auch E3DC unterstützt, die den Hausanaschlusszähler an einer anderen Modbusadresse haben. Aus Perfromancegründen wird die bisherige Hardcodierte Adresse (40130) als erstes abgefragt.
https://openwb.de/forum/viewtopic.php?p=56101#p56101