### PR TITLE
SimCount Bugfix

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,3 +14,4 @@ modules/soc_tesla/tokens.*
 modules/soc_i3/token*
 modules/soc_eq/soc_eq_acc_*
 .vscode/settings.json
+.pytest_cache

--- a/packages/modules/common/simcount.py
+++ b/packages/modules/common/simcount.py
@@ -107,7 +107,7 @@ class SimCountLegacy:
             if start_new:
                 return 0, 0
             else:
-                timestamp_previous = timestamp_previous+1
+                # timestamp_previous = timestamp_previous + 1  # do not increment time if calculating areas!
                 seconds_since_previous = timestamp_present - timestamp_previous
                 imp_exp = calculate_import_export(
                     seconds_since_previous, power_previous, power_present)
@@ -249,7 +249,7 @@ class SimCount:
                 pub.Pub().pub(topic+"simulation/present_exported", 0)
                 return 0, 0
             else:
-                timestamp_previous = timestamp_previous+1
+                # timestamp_previous = timestamp_previous + 1  # do not increment time if calculating areas!
                 seconds_since_previous = timestamp_present - timestamp_previous
                 imp_exp = calculate_import_export(seconds_since_previous, power_previous, power_present)
                 counter_export_present = counter_export_present + imp_exp[1]

--- a/packages/modules/common/simcount.py
+++ b/packages/modules/common/simcount.py
@@ -97,9 +97,9 @@ class SimCountLegacy:
                     # runs/simcount.py speichert das Zwischenergebnis des Exports negativ ab.
                     counter_export_present = counter_export_present * -1
                 counter_export_previous = counter_export_present
-                log.MainLogger().debug("simcount Zwischenergebnisse letzte Berechnung: Import: " + str(
-                    counter_import_previous) + " Export: " + str(counter_export_previous) + " Power: " + str(
-                    power_previous))
+                log.MainLogger().debug("simcount Zwischenergebnisse letzte Berechnung: Import: " +
+                                       str(counter_import_previous) + " Export: " + str(counter_export_previous) +
+                                       " Leistung: " + str(power_previous))
                 start_new = False
             write_ramdisk_file(prefix+'sec0', "%22.6f" % timestamp_present)
             write_ramdisk_file(prefix+'wh0', power_present)
@@ -117,16 +117,17 @@ class SimCountLegacy:
                     "simcount aufsummierte Energie: Bezug[Ws]: " + str(counter_import_present) + ", Einspeisung[Ws]: " +
                     str(counter_export_present)
                 )
-                wattposkh = counter_import_present/3600
-                wattnegkh = counter_export_present/3600
+                energy_positive_kWh = counter_import_present / 3600
+                energy_negative_kWh = counter_export_present / 3600
                 log.MainLogger().info(
-                    "simcount Ergebnis: Bezug[Wh]: " + str(wattposkh) + ", Einspeisung[Wh]: " + str(wattnegkh)
+                    "simcount Ergebnis: Bezug[Wh]: " + str(energy_positive_kWh) +
+                    ", Einspeisung[Wh]: " + str(energy_negative_kWh)
                 )
 
                 topic = get_topic(prefix)
                 log.MainLogger().debug(
-                    "simcount Zwischenergebnisse atkuelle Berechnung: Import: " + str(counter_import_present) +
-                    " Export: " + str(counter_export_present) + " Power: " + str(power_present)
+                    "simcount Zwischenergebnisse aktuelle Berechnung: Import: " + str(counter_import_present) +
+                    " Export: " + str(counter_export_present) + " Leistung: " + str(power_present)
                 )
                 write_ramdisk_file(prefix+'watt0pos', counter_import_present)
                 if counter_import_present != counter_import_previous:
@@ -135,7 +136,7 @@ class SimCountLegacy:
                 if counter_export_present != counter_export_previous:
                     pub.pub_single("openWB/"+topic+"/WHExport_temp",
                                    counter_export_present, no_json=True)
-                return wattposkh, wattnegkh
+                return energy_positive_kWh, energy_negative_kWh
         except Exception as e:
             process_error(e)
 
@@ -212,7 +213,7 @@ class SimCount:
         Parameters
         ----------
         power_present: aktuelle Leistung
-        topic: str Topic, an das gepublished werden soll
+        topic: str Topic, in welches veröffentlicht werden soll
         data: Komponenten-Daten
         Return
         ------
@@ -236,7 +237,7 @@ class SimCount:
                 else:
                     counter_export_present = 0
                 log.MainLogger().debug(
-                    "Fortsetzen der Simulation: Importzaehler: " + str(counter_import_present)+"Ws, Export-Zaehler: " +
+                    "Fortsetzen der Simulation: Importzähler: " + str(counter_import_present)+"Ws, Export-Zähler: " +
                     str(counter_export_present) + "Ws"
                 )
                 start_new = False
@@ -259,18 +260,19 @@ class SimCount:
                     ", Einspeisung[Ws]: " +
                     str(counter_export_present)
                 )
-                wattposkh = counter_import_present/3600
-                wattnegkh = counter_export_present/3600
+                energy_positive_kWh = counter_import_present / 3600
+                energy_negative_kWh = counter_export_present / 3600
                 log.MainLogger().info(
-                    "simcount Ergebnis: Bezug[Wh]: " + str(wattposkh) + ", Einspeisung[Wh]: " + str(wattnegkh)
+                    "simcount Ergebnis: Bezug[Wh]: " + str(energy_positive_kWh) +
+                    ", Einspeisung[Wh]: " + str(energy_negative_kWh)
                 )
                 log.MainLogger().debug(
-                    "simcount Zwischenergebnisse atkuelle Berechnung: Import: " + str(counter_import_present) +
+                    "simcount Zwischenergebnisse aktuelle Berechnung: Import: " + str(counter_import_present) +
                     " Export: " + str(counter_export_present) + " Power: " + str(power_present)
                 )
                 pub.Pub().pub(topic+"simulation/present_imported", counter_import_present)
                 pub.Pub().pub(topic+"simulation/present_exported", counter_export_present)
-                return wattposkh, wattnegkh
+                return energy_positive_kWh, energy_negative_kWh
         except Exception as e:
             process_error(e)
 

--- a/runs/simcount.py
+++ b/runs/simcount.py
@@ -2,80 +2,78 @@
 import sys
 import os
 import time
-import getopt
 
 watt2 = int(sys.argv[1])
-pref = str(sys.argv[2])
-importfn = str(sys.argv[3])
-exportfn = str(sys.argv[4])
+prefix = str(sys.argv[2])
+import_filename = str(sys.argv[3])
+export_filename = str(sys.argv[4])
 
 # emulate import  export
-seconds2= time.time()
-watt1=0
-seconds1=0.0
-if os.path.isfile('/var/www/html/openWB/ramdisk/'+pref+'sec0'): 
-    f = open('/var/www/html/openWB/ramdisk/'+pref+'sec0', 'r')
-    seconds1=float(f.read())
+seconds2 = time.time()
+watt1 = 0
+seconds1 = 0.0
+if os.path.isfile('/var/www/html/openWB/ramdisk/' + prefix + 'sec0'):
+    f = open('/var/www/html/openWB/ramdisk/' + prefix + 'sec0', 'r')
+    seconds1 = float(f.read())
     f.close()
-    f = open('/var/www/html/openWB/ramdisk/'+pref+'wh0', 'r')
-    watt1=int(f.read())
+    f = open('/var/www/html/openWB/ramdisk/' + prefix + 'wh0', 'r')
+    watt1 = int(f.read())
     f.close()
-    f = open('/var/www/html/openWB/ramdisk/'+pref+'watt0pos', 'r')
-    wattposh=int(f.read())
+    f = open('/var/www/html/openWB/ramdisk/' + prefix + 'watt0pos', 'r')
+    wattposh = int(f.read())
     f.close()
-    f = open('/var/www/html/openWB/ramdisk/'+pref+'watt0neg', 'r')
-    wattnegh=int(f.read())
+    f = open('/var/www/html/openWB/ramdisk/' + prefix + 'watt0neg', 'r')
+    wattnegh = int(f.read())
     f.close()
-    f = open('/var/www/html/openWB/ramdisk/'+pref+'sec0', 'w')
+    f = open('/var/www/html/openWB/ramdisk/' + prefix + 'sec0', 'w')
     value1 = "%22.6f" % seconds2
     f.write(str(value1))
     f.close()
-    f = open('/var/www/html/openWB/ramdisk/'+pref+'wh0', 'w')
+    f = open('/var/www/html/openWB/ramdisk/' + prefix + 'wh0', 'w')
     f.write(str(watt2))
     f.close()
-    seconds1=seconds1+1
-    deltasec = seconds2- seconds1
-    deltasectrun =int(deltasec* 1000) / 1000
-    stepsize = int((watt2-watt1)/deltasec)
+    seconds1 = seconds1 + 1
+    deltasec = seconds2 - seconds1
+    deltasectrun = int(deltasec * 1000) / 1000
+    stepsize = int((watt2 - watt1) / deltasec)
     while seconds1 <= seconds2:
         if watt1 < 0:
-            wattnegh= wattnegh + watt1
+            wattnegh = wattnegh + watt1
         else:
-            wattposh= wattposh + watt1
+            wattposh = wattposh + watt1
         watt1 = watt1 + stepsize
         if stepsize < 0:
-            watt1 = max(watt1,watt2)
+            watt1 = max(watt1, watt2)
         else:
-            watt1 = min(watt1,watt2)
-        seconds1= seconds1 +1
-    rest= deltasec - deltasectrun
-    seconds1= seconds1  - 1 + rest
+            watt1 = min(watt1, watt2)
+        seconds1 = seconds1 + 1
+    rest = deltasec - deltasectrun
+    seconds1 = seconds1 - 1 + rest
     if rest > 0:
         watt1 = int(watt1 * rest)
         if watt1 < 0:
-            wattnegh= wattnegh + watt1
+            wattnegh = wattnegh + watt1
         else:
-            wattposh= wattposh + watt1
-    wattposkh=wattposh/3600
-    wattnegkh=(wattnegh*-1)/3600
-    f = open('/var/www/html/openWB/ramdisk/'+pref+'watt0pos', 'w')
+            wattposh = wattposh + watt1
+    wattposkh = wattposh / 3600
+    wattnegkh = (wattnegh * -1) / 3600
+    f = open('/var/www/html/openWB/ramdisk/' + prefix + 'watt0pos', 'w')
     f.write(str(wattposh))
     f.close()
-    f = open('/var/www/html/openWB/ramdisk/'+pref+'watt0neg', 'w')
+    f = open('/var/www/html/openWB/ramdisk/' + prefix + 'watt0neg', 'w')
     f.write(str(wattnegh))
     f.close()
-    f = open('/var/www/html/openWB/ramdisk/'+ importfn,'w')
+    f = open('/var/www/html/openWB/ramdisk/' + import_filename, 'w')
     f.write(str(wattposkh))
     f.close()
-    f = open('/var/www/html/openWB/ramdisk/' +exportfn , 'w')
+    f = open('/var/www/html/openWB/ramdisk/' + export_filename, 'w')
     f.write(str(wattnegkh))
     f.close()
-else: 
-    f = open('/var/www/html/openWB/ramdisk/'+pref+'sec0', 'w')
+else:
+    f = open('/var/www/html/openWB/ramdisk/' + prefix + 'sec0', 'w')
     value1 = "%22.6f" % seconds2
     f.write(str(value1))
     f.close()
-    f = open('/var/www/html/openWB/ramdisk/'+pref+'wh0', 'w')
+    f = open('/var/www/html/openWB/ramdisk/' + prefix + 'wh0', 'w')
     f.write(str(watt2))
     f.close()
-  


### PR DESCRIPTION
relevant changes in commit [7bc2a2faaf027846239cebe2abde0a1c9ab7b2ef](https://github.com/snaptec/openWB/commit/7bc2a2faaf027846239cebe2abde0a1c9ab7b2ef)

Skipping first second results in incorrect calculation as we are calculating areas in a diagramm (integral). This step was only necessary in the old simcount under runs as that was a discrete calculation.
