### PR TITLE
http inverter: compatibility for 1.x

### DIFF
--- a/packages/modules/http/inverter.py
+++ b/packages/modules/http/inverter.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python3
 
-from helpermodules import log
+from helpermodules import log, compatibility
 from modules.common.component_state import InverterState
 from modules.common.fault_state import ComponentInfo
 from modules.common.store import get_inverter_value_store
@@ -30,9 +30,9 @@ class HttpInverter:
 
     def update(self) -> None:
         log.MainLogger().debug("Komponente "+self.component_config["name"]+" auslesen.")
-
         inverter_state = InverterState(
-            power=self.__get_power(),
+            # for compatibility: in 1.x power URL values are positive!
+            power=(-self.__get_power() if compatibility.is_ramdisk_in_use() else self.__get_power()),
             counter=self.__get_counter()
         )
         self.__store.set(inverter_state)

--- a/web/settings/modulconfigpv.php
+++ b/web/settings/modulconfigpv.php
@@ -835,7 +835,7 @@
 								<div class="col">
 									<input class="form-control" type="text" name="wr_http_w_url" id="wr_http_w_url" value="<?php echo htmlspecialchars($wr_http_w_urlold) ?>">
 									<span class="form-text small">
-										Gültige Werte vollständige URL. Die abgerufene Url muss eine reine Zahl zurückgeben. Enthält der Rückgabewert etwas anderes, wird der Wert auf "0" gesetzt. Der Wert muss in Watt sein. Erzeugungsleistung muss negativ angegeben werden!
+										Gültige Werte vollständige URL. Die abgerufene Url muss eine reine Zahl zurückgeben. Enthält der Rückgabewert etwas anderes, wird der Wert auf "0" gesetzt. Der Wert muss in Watt sein. Erzeugungsleistung muss positiv angegeben werden!
 									</span>
 								</div>
 							</div>


### PR DESCRIPTION
- accept inverter power as positive number in 1.x to not break existing installations