### PR TITLE
Legacy run server: Paralelle Ausführung mehrere Befehle verhindern

### DIFF
--- a/packages/legacy_run.sh
+++ b/packages/legacy_run.sh
@@ -18,4 +18,4 @@ do
     ((counter++))
 done
 template=${template/%,}"]"
-jq -cn "${args[@]}" "$template" | socat - "unix-client:$SCRIPT_DIR/legacy_run_server.sock"
+jq -cn "${args[@]}" "$template" | socat -t300 - "unix-client:$SCRIPT_DIR/legacy_run_server.sock"


### PR DESCRIPTION
Eigentlich war es so gedacht, dass (mit Ausnahme von den SoC-Modulen) keine Module parallel ausgeführt werden. Es könnte andernfalls zu Problemen kommen, weil dies parallele Dateizugriffe auf der Ramdisk zur Folge haben könnte (und oWB keine Locks verwendet). Oder zu Problemen führen, wenn [ein Modul paralelle Modbusverbindungen aufbaut](https://www.openwb.de/forum/viewtopic.php?p=56406#p56406).

Übersehen habe ich, dass `socat` schon per Standardwert einen timeout von 0.5 Sekunden hat, sobald einer der beiden Kommunikationskanäle zu ist. Damit ist für alle Befehler die >0.5 Sekunden brauchen nicht mehr gegeben, dass festgestellt werden kann, wann diese fertig sind.

Dieser PR behebt das in dem er den timeout auf 5 Minuten setzt. Es sollte kein Script geben, was ansatzweise in die Nähe kommt...