### PR TITLE
huawei: do not close connection in components

### DIFF
--- a/packages/modules/huawei/bat.py
+++ b/packages/modules/huawei/bat.py
@@ -32,11 +32,11 @@ class HuaweiBat:
 
     def update(self) -> None:
         log.MainLogger().debug("Komponente "+self.component_config["name"]+" auslesen.")
-        with self.__tcp_client:
-            time.sleep(0.1)
-            power = self.__tcp_client.read_holding_registers(37765, ModbusDataType.INT_32, unit=self.__modbus_id)
-            time.sleep(0.1)
-            soc = self.__tcp_client.read_holding_registers(37760, ModbusDataType.INT_16, unit=self.__modbus_id) / 10
+
+        time.sleep(0.1)
+        power = self.__tcp_client.read_holding_registers(37765, ModbusDataType.INT_32, unit=self.__modbus_id)
+        time.sleep(0.1)
+        soc = self.__tcp_client.read_holding_registers(37760, ModbusDataType.INT_16, unit=self.__modbus_id) / 10
 
         topic_str = "openWB/set/system/device/" + str(
             self.__device_id)+"/component/"+str(self.component_config["id"])+"/"

--- a/packages/modules/huawei/counter.py
+++ b/packages/modules/huawei/counter.py
@@ -32,12 +32,11 @@ class HuaweiCounter:
 
     def update(self):
         log.MainLogger().debug("Komponente "+self.component_config["name"]+" auslesen.")
-        with self.__tcp_client:
-            time.sleep(0.1)
-            power = self.__tcp_client.read_holding_registers(37113, ModbusDataType.INT_32, unit=self.__modbus_id) * -1
-            time.sleep(0.1)
-            currents = [val / -100 for val in self.__tcp_client.read_holding_registers(
-                37107, [ModbusDataType.INT_32] * 3, unit=self.__modbus_id)]
+        time.sleep(0.1)
+        power = self.__tcp_client.read_holding_registers(37113, ModbusDataType.INT_32, unit=self.__modbus_id) * -1
+        time.sleep(0.1)
+        currents = [val / -100 for val in self.__tcp_client.read_holding_registers(
+            37107, [ModbusDataType.INT_32] * 3, unit=self.__modbus_id)]
 
         topic_str = "openWB/set/system/device/{}/component/{}/".format(
             self.__device_id, self.component_config["id"]

--- a/packages/modules/huawei/inverter.py
+++ b/packages/modules/huawei/inverter.py
@@ -32,9 +32,8 @@ class HuaweiInverter:
 
     def update(self) -> None:
         log.MainLogger().debug("Komponente "+self.component_config["name"]+" auslesen.")
-        with self.__tcp_client:
-            time.sleep(0.1)
-            power = self.__tcp_client.read_holding_registers(32064, ModbusDataType.INT_32, unit=self.__modbus_id) * -1
+        time.sleep(0.1)
+        power = self.__tcp_client.read_holding_registers(32064, ModbusDataType.INT_32, unit=self.__modbus_id) * -1
 
         topic_str = "openWB/set/system/device/" + \
             str(self.__device_id)+"/component/" + \


### PR DESCRIPTION
Bei Huawei muss auch in openWB 1.x zwingend eine gemeinsame Modbus-Verbindung genutzt werden, da nach jeder neuen Verbindung 7 Sekunden auf den WR gewartet werden muss.