### PR TITLE
change legacy_run_server watch_config

### DIFF
--- a/runs/atreboot.sh
+++ b/runs/atreboot.sh
@@ -37,6 +37,7 @@ mkdir -p /var/www/html/openWB/web/logging/data/monthly
 mkdir -p /var/www/html/openWB/web/logging/data/ladelog
 mkdir -p /var/www/html/openWB/web/logging/data/v001
 sudo chmod -R 777 /var/www/html/openWB/web/logging/data/
+sudo chmod +x /var/www/html/openWB/packages/*.sh
 
 # update openwb.conf
 updateConfig


### PR DESCRIPTION
In manchen Situationen treten beim Neustart des legacy_run_server oder beim Speichern von Einstellungen (openwb.conf wird aktualisiert) folgende Meldungen im Log auf:
```
File "/var/www/html/openWB/packages/legacy_run_server.py", line 183, in signal_handler
threading.Thread(target=signal_handler_delayed, args=(latest_signal_id.increment_and_get(),)).start()
File "/usr/lib/python3.5/threading.py", line 782, in __init__
self._name = str(name or _newname())
File "/usr/lib/python3.5/threading.py", line 726, in _newname
return template % _counter()
```
Die Meldungen wiederholen sich, bis zum Ende eine Rekursionsschleife erkannt und beendet wird:
```
File "/var/www/html/openWB/packages/legacy_run_server.py", line 183, in signal_handler
threading.Thread(target=signal_handler_delayed, args=(latest_signal_id.increment_and_get(),)).start()
File "/usr/lib/python3.5/threading.py", line 791, in __init__
self._started = Event()
RecursionError: maximum recursion depth exceeded while calling a Python object
```
Dieser PR ändert das Verhalten so ab, dass lediglich bei Erhalt einer neuen Nachricht geprüft wird, ob sich die openwb.conf inzwischen geändert hat. ~~Das Flag `debug_dirty` wird direkt im Signal Handler gesetzt und nicht verzögert ausgeführt, was vermutlich vorher zu der Schleife geführt hat.~~ Der Signal Handler wurde komplett entfernt, um die Verarbeitung möglichst einfach zu halten. Stattdessen wird der Zeitstempel der letzten Änderung genutzt.