### PR TITLE
Legacy run server: fix "maximum recursion depth exceeded"

### DIFF
--- a/packages/helpermodules/debouncing_executor.py
+++ b/packages/helpermodules/debouncing_executor.py
@@ -1,0 +1,38 @@
+import itertools
+import threading
+from typing import Callable, Optional
+
+_counter = itertools.count().__next__
+
+
+class DebouncingExecutor:
+    """Executes a function only after a particular time span has passed without call."""
+    def __init__(self, debounce_time: float, delegate: Callable[[], None]):
+        self._debounce_time = debounce_time
+        self._delegate = delegate
+        self._current_signal_id = 0
+        self._worker_condition = threading.Condition()
+        self._timer = None  # type: Optional[threading.Timer]
+        threading.Thread(target=self._worker, name="DebouncingExecutor-%d" % _counter()).start()
+
+    def __call__(self, *args, **kwargs):
+        # We want this method to be reentrant, so that this method can be called from a signal handler which might
+        # might be interrupted by another signal.
+        # Thus the _worker_condition uses an RLock and the actual processing happens in a separate thread which is
+        # notified by the _worker_condition. This separate thread will then not need to be reentrant, because signals
+        # are always processed in the main thread.
+        with self._worker_condition:
+            self._current_signal_id += 1
+            self._worker_condition.notify()
+
+    def _worker(self):
+        completed_signal_id = 0
+        with self._worker_condition:
+            while True:
+                while self._current_signal_id == completed_signal_id:
+                    self._worker_condition.wait()
+                completed_signal_id = self._current_signal_id
+                if self._timer:
+                    self._timer.cancel()
+                self._timer = threading.Timer(self._debounce_time, self._delegate)
+                self._timer.start()


### PR DESCRIPTION
Siehe auch #1994

Aktuell ist es so, dass wenn die Konfigdatei geändert wird, dies ein Signal bei Python auslöst. Wichtiges Hintergrundwissen [aus der Doku](https://docs.python.org/3/library/signal.html?highlight=signal#module-signal):

> A Python signal handler does not get executed inside the low-level (C) signal handler. Instead, the low-level signal handler sets a flag which tells the [virtual machine](https://docs.python.org/3/glossary.html#term-virtual-machine) to execute the corresponding Python signal handler at a later point(for example at the next [bytecode](https://docs.python.org/3/glossary.html#term-bytecode) instruction).
> [..]
> A long-running calculation implemented purely in C (such as regular expression matching on a large body of text) may run uninterrupted for an arbitrary amount of time, regardless of any signals received. The Python signal handlers will be called when the calculation finishes.
> [..]
> Python signal handlers are always executed in the main Python thread of the main interpreter, even if the signal was received in another thread.

Aktuell ist es so, dass für den Legacy Run Server im Main-Thread die Verbindungen abgearbeitet werden. Insbesondere wird dort auch diese Zeile abgearbeitet:
```python
connection = self.__sock.accept()[0]
```
Diese Zeile blockiert, bis eine Verbindung zustande kommt. Während dieser Code auf eine Verbindung wartet ist der Main-Thread blockiert und es werden keine Signals abgearbeitet. In dieser Zeit können sich Signals ansammeln die nicht abgearbeitet werden. Wenn dann endlich eine neue Verbindung kommt, versucht Python alle angesammelten Signals abzuarbeiten. Dafür wird der Main-Thread unterbrochen und der Signal-Handler ausgeführt, der wiederrum unterbrochen wird für das nächste Signal etc. etc. Dies kann bereits zu einem "maximum recursion depth exceeded"-Fehler führen, wenn sich genügend Signals angesammelt haben.

Schlimmer noch gibt es Probleme mit dem Logging im Signal-Handler. Aus [der Doku](https://docs.python.org/3/library/logging.html?highlight=logging#thread-safety):

> If you are implementing asynchronous [signal](https://docs.python.org/3/library/signal.html#module-signal) handlers using the signal module, you may not be able to use logging from within such handlers. This is because lock implementations in the [threading](https://docs.python.org/3/library/threading.html#module-threading) module are not always re-entrant, and so cannot be invoked from such signal handlers.

Wenn während der Signal-Handler ausgeführt wird etwas gelogged wird, dann besteht das Risiko, dass der Main-Thread sich selbst Dead-locked. Der Main-Thread wird dann komplett blockiert und der legacy-run-Server stellt seine Arbeit komplett ein. Das ist vermutlich die Ursache für das [hier beschriebene Problem](https://github.com/snaptec/openWB/pull/1967#commitcomment-64829569)

Dieser PR behebt das:
1. Das Abarbeiten der Verbindungen wird nicht mehr im Main-Thread gemacht, sondern in einem separaten Thread. Dadurch erledigt sich das Problem, dass sich signals über einen längeren Zeitraum ansammeln und nicht abgearbeitet werden können, weil der Main-Thread nicht zur Verfügung steht
2. Der Mechanismus des Signal-Handlers is re-designed: Es gibt einen separaten Thread, der Signale abarbeitet. Der Signal-Handler der im signal-Modul registriert wird übernimmt nurnoch die Aufgabe den Signal-Handling-Thread über die neuen Signals zu informieren. Dadurch beschränkt sich der signal-handler auf das absolut notwendige Minimum. Es gibt keine Logausgaben im Signal-Handler und der Signal-Handler ist sehr schnell.