### PR TITLE
soc_vwid: atreboot.sh fix missing quotes

### DIFF
--- a/runs/atreboot.sh
+++ b/runs/atreboot.sh
@@ -317,7 +317,7 @@ else
 fi
 #Prepare for secrets used in soc module libvwid in Python
 VWIDMODULEDIR=$OPENWBBASEDIR/modules/soc_vwid
-if python3 -c import secrets &> /dev/null; then
+if python3 -c "import secrets" &> /dev/null; then
 	echo 'soc_vwid: python3 secrets installed...'
 	if [ -L $VWIDMODULEDIR/secrets.py ]; then
 		echo 'soc_vwid: remove local python3 secrets.py...'


### PR DESCRIPTION
atreboot.sh: quotes missing in check for installed secrets.py
stretch: no impact
buster: missing quotes resulted on buster in fail, leading to unrequired enabling secrets locally in soc_vwid