### PR TITLE
fix timeout and error reporting for speedwire devices

### DIFF
--- a/modules/bezug_smashm/main.sh
+++ b/modules/bezug_smashm/main.sh
@@ -15,13 +15,9 @@ else
         MYLOGFILE="${RAMDISKDIR}/evu.log"
 fi
 
-timeout 3 bash "$OPENWBBASEDIR/packages/legacy_run.sh" "modules.sma.device" "counter" "${smashmbezugid}" >>${MYLOGFILE} 2>&1
+bash "$OPENWBBASEDIR/packages/legacy_run.sh" "modules.sma.device" "counter" "${smashmbezugid}" >>${MYLOGFILE} 2>&1
 ret=$?
-if [[ $ret -eq 124 ]] ; then
-    openwbModulePublishState "EVU" 2 "Die Werte konnten nicht innerhalb des Timeouts abgefragt werden. Bitte Konfiguration und Gerätestatus prüfen."
-    openwbDebugLog "MAIN" 0 "Fetching SMA counter data timed out"
-else
-    openwbDebugLog ${DMOD} 2 "EVU RET: ${ret}"
-fi
+openwbDebugLog ${DMOD} 2 "EVU RET: ${ret}"
+
 wattbezug=$(<${RAMDISKDIR}/wattbezug)
 echo $wattbezug

--- a/modules/smaemd_pv/main.sh
+++ b/modules/smaemd_pv/main.sh
@@ -21,15 +21,9 @@ fi
 
 openwbDebugLog ${DMOD} 2 "SMA serials: ${smaemdpvid}"
 
-timeout 3 bash "$OPENWBBASEDIR/packages/legacy_run.sh" "modules.sma.device" "inverter" "${smaemdpvid}" "1">>$MYLOGFILE 2>&1
+bash "$OPENWBBASEDIR/packages/legacy_run.sh" "modules.sma.device" "inverter" "${smaemdpvid}" "1">>$MYLOGFILE 2>&1
 ret=$?
-
-if [[ $ret -eq 124 ]] ; then
-    openwbModulePublishState "PV" 2 "Die Werte konnten nicht innerhalb des Timeouts abgefragt werden. Bitte Konfiguration und Gerätestatus prüfen." "1"
-    openwbDebugLog "MAIN" 0 "Fetching SMA counter data timed out"
-else
-    openwbDebugLog ${DMOD} 2 "EVU RET: ${ret}"
-fi
+openwbDebugLog ${DMOD} 2 "EVU RET: ${ret}"
 
 watt=$(<${RAMDISKDIR}/pvwatt)
 echo ${watt}

--- a/packages/modules/common/component_context.py
+++ b/packages/modules/common/component_context.py
@@ -1,3 +1,6 @@
+import threading
+from typing import Optional, List, Union, Any, Dict
+
 from modules.common.fault_state import ComponentInfo, FaultState
 
 
@@ -17,8 +20,7 @@ class SingleComponentUpdateContext:
         return None
 
     def __exit__(self, exception_type, exception, exception_traceback) -> bool:
-        fault_state = FaultState.from_exception(exception)
-        fault_state.store_error(self.__component_info)
+        MultiComponentUpdateContext.override_subcomponent_state(self.__component_info, exception)
         return True
 
 
@@ -30,15 +32,40 @@ class MultiComponentUpdateContext:
             for component in self._components:
                 component.update()
     """
+    __thread_local = threading.local()
 
-    def __init__(self, device_components: dict):
-        self.__device_components = device_components
+    def __init__(self, device_components: Union[Dict[Any, Any], List[Any]]):
+        self.__device_components = \
+            device_components.values() if isinstance(device_components, dict) else device_components
+        self.__ignored_components = []  # type: List[ComponentInfo]
 
     def __enter__(self):
+        if hasattr(self.__thread_local, "active_context"):
+            raise Exception("Nesting MultiComponentUpdateContext is not supported")
+        MultiComponentUpdateContext.__thread_local.active_context = self
         return None
 
     def __exit__(self, exception_type, exception, exception_traceback) -> bool:
         fault_state = FaultState.from_exception(exception)
         for component in self.__device_components:
-            fault_state.store_error(self.__device_components[component].component_info)
+            component_info = component.component_info
+            if component_info not in self.__ignored_components:
+                fault_state.store_error(component_info)
+        delattr(MultiComponentUpdateContext.__thread_local, "active_context")
         return True
+
+    def ignore_subcomponent_state(self, component: ComponentInfo):
+        self.__ignored_components.append(component)
+
+    @staticmethod
+    def override_subcomponent_state(component_info: ComponentInfo, exception):
+        active_context = getattr(
+            MultiComponentUpdateContext.__thread_local, "active_context", None
+        )  # type: Optional[MultiComponentUpdateContext]
+        if active_context:
+            # If a MultiComponentUpdateContext is active, we need make sure that it will not override
+            # the value for the individual component
+            active_context.ignore_subcomponent_state(component_info)
+
+        fault_state = FaultState.from_exception(exception)
+        fault_state.store_error(component_info)

--- a/packages/modules/sma/counter.py
+++ b/packages/modules/sma/counter.py
@@ -1,17 +1,15 @@
 #!/usr/bin/env python3
 from math import copysign
 
-
-from helpermodules import log
 from modules.common.component_state import CounterState
-from modules.common.fault_state import ComponentInfo
 from modules.common.store import get_counter_value_store
+from modules.sma.utils import SpeedwireComponent
 
 
 def get_default_config() -> dict:
     return {
         "name": "SMA Smarthome Manager Zähler",
-        "id": 0,
+        "id": None,
         "type": "counter",
         "configuration": {
             "serials": None
@@ -19,31 +17,26 @@ def get_default_config() -> dict:
     }
 
 
-class SmaCounter:
-    def __init__(self, component_config: dict) -> None:
-        self.component_config = component_config
-        self.__store = get_counter_value_store(component_config["id"])
-        self.component_info = ComponentInfo.from_component_config(component_config)
+def parse_datagram(sma_data: dict):
+    def get_power(phase_str: str = ""):
+        # "consume" and "supply" are always >= 0. Thus we need to check both "supply" and "consume":
+        power_import = sma_data["p" + phase_str + "consume"]
+        return -sma_data["p" + phase_str + "supply"] if power_import == 0 else power_import
 
-    def update(self, sma_data):
-        log.MainLogger().debug(
-            "Komponente "+self.component_config["name"]+" auslesen.")
+    powers = [get_power(str(phase)) for phase in range(1, 4)]
 
-        def get_power(phase_str: str = ""):
-            # "consume" and "supply" are always >= 0. Thus we need to check both "supply" and "consume":
-            power_import = sma_data["p" + phase_str + "consume"]
-            return -sma_data["p" + phase_str + "supply"] if power_import == 0 else power_import
+    return CounterState(
+        imported=sma_data['pconsumecounter'] * 1000,
+        exported=sma_data['psupplycounter'] * 1000,
+        power=get_power(),
+        voltages=[sma_data["u" + str(phase)] for phase in range(1, 4)],
+        # currents reported are always absolute values. We get the sign from power:
+        currents=[copysign(sma_data["i" + str(phase)], powers[phase - 1]) for phase in range(1, 4)],
+        powers=powers,
+        power_factors=[sma_data["cosphi" + str(phase)] for phase in range(1, 4)],
+        frequency=sma_data.get("frequency")
+    )
 
-        powers = [get_power(str(phase)) for phase in range(1, 4)]
 
-        self.__store.set(CounterState(
-            imported=sma_data['pconsumecounter'] * 1000,
-            exported=sma_data['psupplycounter'] * 1000,
-            power=get_power(),
-            voltages=[sma_data["u" + str(phase)] for phase in range(1, 4)],
-            # currents reported are always absolute values. We get the sign from power:
-            currents=[copysign(sma_data["i" + str(phase)], powers[phase - 1]) for phase in range(1, 4)],
-            powers=powers,
-            power_factors=[sma_data["cosphi" + str(phase)] for phase in range(1, 4)],
-            frequency=sma_data.get("frequency")
-        ))
+def create_component(component_config: dict):
+    return SpeedwireComponent(get_counter_value_store, parse_datagram, component_config)

--- a/packages/modules/sma/counter_test.py
+++ b/packages/modules/sma/counter_test.py
@@ -2,8 +2,8 @@ import base64
 
 import pytest
 
-from modules.sma import counter, speedwiredecoder
 from helpermodules import compatibility
+from modules.sma import counter, speedwiredecoder
 from test_utils.mock_ramdisk import MockRamdisk
 
 # This sample was collected from an SMA Energy Meter with Firmware 2.0.18.R on 2021-12-22:
@@ -32,10 +32,10 @@ def test_process_datagram_energy_meter(mock_ramdisk):
     # setup
     data = base64.b64decode(SAMPLE_SMA_ENERGY_EM)
     sma_data = speedwiredecoder.decode_speedwire(data)
-    sma_counter = counter.SmaCounter(counter.get_default_config())
+    sma_counter = counter.create_component(counter.get_default_config())
 
     # execution
-    sma_counter.update(sma_data)
+    sma_counter.read_datagram(sma_data)
 
     # evaluation
     assert mock_ramdisk.files["wattbezug"] == "-11967"

--- a/packages/modules/sma/speedwire_listener.py
+++ b/packages/modules/sma/speedwire_listener.py
@@ -1,0 +1,39 @@
+import socket
+import struct
+from typing import Iterator, Optional
+
+from modules.common.fault_state import FaultState
+from modules.sma.speedwiredecoder import decode_speedwire
+
+
+class SpeedwireListener:
+    def __init__(self, timeout_seconds: float):
+        self.__timeout_seconds = timeout_seconds
+        self.__socket = None  # type: Optional[socket.socket]
+
+    def __enter__(self) -> Iterator[dict]:
+        ip_bind = "0.0.0.0"
+        multicast_group = "239.12.255.254"
+        multicast_port = 9522
+        sock = socket.socket(socket.AF_INET, socket.SOCK_DGRAM, socket.IPPROTO_UDP)
+        try:
+            sock.settimeout(self.__timeout_seconds)
+            sock.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)
+            sock.bind(('', multicast_port))
+            mreq = struct.pack("4s4s", socket.inet_aton(multicast_group), socket.inet_aton(ip_bind))
+            sock.setsockopt(socket.IPPROTO_IP, socket.IP_ADD_MEMBERSHIP, mreq)
+        except BaseException:
+            sock.close()
+            raise FaultState.error("could not connect to multicast group or bind to given interface")
+        self.__socket = sock
+
+        def generator() -> Iterator[dict]:
+            while True:
+                datagram = sock.recv(608)
+                if len(datagram) >= 18 and datagram[16:18] == b'\x60\x69':
+                    yield decode_speedwire(datagram)
+
+        return generator()
+
+    def __exit__(self, exc_type, exc_val, exc_tb):
+        self.__socket.close()

--- a/packages/modules/sma/utils.py
+++ b/packages/modules/sma/utils.py
@@ -1,0 +1,35 @@
+import logging
+from typing import TypeVar, Generic, Callable, Optional
+
+from modules.common.component_context import SingleComponentUpdateContext
+from modules.common.fault_state import ComponentInfo
+from modules.common.store import ValueStore
+
+T = TypeVar("T")
+log = logging.getLogger("SMA Speedwire")
+
+
+def _create_serial_matcher(serial: Optional[int]) -> Callable[[dict], bool]:
+    if isinstance(serial, int):
+        return lambda sma_data: sma_data["serial"] == serial
+    if serial is not None:
+        log.error("Serial <%s> must bei an int or None, but is <%s>. Assuming None.", serial, type(serial))
+    return lambda _: True
+
+
+class SpeedwireComponent(Generic[T]):
+    def __init__(self,
+                 value_store_factory: Callable[[int], ValueStore[T]],
+                 parser: Callable[[dict], T],
+                 component_config: dict):
+        self.__value_store = value_store_factory(component_config["id"])
+        self.__parser = parser
+        self.__serial_matcher = _create_serial_matcher(component_config["configuration"]["serials"])
+        self.component_info = ComponentInfo.from_component_config(component_config)
+
+    def read_datagram(self, datagram: dict) -> bool:
+        if self.__serial_matcher(datagram):
+            with SingleComponentUpdateContext(self.component_info):
+                self.__value_store.set(self.__parser(datagram))
+            return True
+        return False


### PR DESCRIPTION
Ich habe bei mir gerade ein Update auf meiner Wallbox mit SMA Energy Meter als EVU-Zähler gemacht und dabei sind mir ein paar Probleme aufgefallen:

1. Es gibt keinen wirksamen timeout. Die alten Scripte `modules/bezug_smashm/main.sh` und `modules/smaemd_pv/main.sh` haben zwar noch einen timeout, aber die Wirkung davon ist nur begrenzt durchschlagend: Sie trennen die Verbindung zum legacy-run-server, aber beenden nicht das Script. Bei falsch konfigurierter Seriennummer heißt es dann "listening forever". Und jede Regelschleife kommt ein weiterer lauschender Thread hinzu.
2. Das Error-Reporting funktioniert nicht. Im `Device` wird ein `MultiComponentUpdateContext` und innerhalb dieses Context wird dann noch ein `SingleComponentUpdateContext`. Es ist nicht vorgesehen diese beiden Varianten zu mischen und es funktioniert auch nicht: Wenn im `SingleComponentUpdateContext` ein Fehler passiert, dann wird für die Komponente der Fehlerstatus gesetzt und die Exception aufgehalten. Der `MultiComponentUpdateContext` weiß dann von dem Fehler nichts und setzt alles wieder auf grün. Der Nutzer sieht bestenfalls den Fehler im Status aufflackern.
3. Das Fehlerreporting funktioniert aber auch deswegen nicht, weil für den Zähler die `id` nicht auf `None` steht. Dadurch landen die Fehler für die oWB1 im falschen topic.
4. Die Funktion read_legacy ist unnötig kompliziert. Da sind wir technisch schon weiter.

Dieser PR behebt alles. Es kommen wirksame Timeouts rein, Die `*ComponentUpdateContext`-Klassen bekommen Verschachtelungsfähigkeit und diverse weitere refactorings, für alles schöner.

Getestet ist das ganze bei mir mit meinem SMA EM als EVU. Ob das ganze auch für Wechselrichter funktioniert ist noch ungetestet.