### PR TITLE
parse faultStr on the UI, so that the user does not need to read JSON encoded text

### DIFF
--- a/web/status/processAllMqttMsg.js
+++ b/web/status/processAllMqttMsg.js
@@ -7,6 +7,19 @@
  * @author Lena Kümmel
  */
 
+function formatJsonString(str) {
+	try {
+		parsed = JSON.parse(str)
+		if (typeof parsed === 'string') {
+			return parsed
+		}
+		// if it is not a string, we just use the json as supplied
+	} catch (e) {
+		// ignore error - just use the original text
+	}
+	return str
+}
+
 function getIndex(topic) {
 	// get occurrence of numbers between / / in topic
 	// since this is supposed to be the index like in openwb/lp/4/w
@@ -118,7 +131,7 @@ function processEvuMsg (mqttmsg, mqttpayload) {
 			setWarningLevel(mqttpayload, '#faultStrEvuRow');
 			break;
 		case "openWB/evu/faultStr":
-			textShow(mqttpayload, '#faultStrEvu');
+			textShow(formatJsonString(mqttpayload), '#faultStrEvu');
 			break;
 	}
 }
@@ -154,7 +167,7 @@ function processPvMsg (mqttmsg, mqttpayload) {
 		}
 		else if ( mqttmsg.match(/^openWB\/pv\/[0-9]+\/faultStr$/i) )
 		{
-			textShow(mqttpayload, '#inverter' + index + ' .faultStrPv');
+			textShow(formatJsonString(mqttpayload), '#inverter' + index + ' .faultStrPv');
 		}
 		else if ( mqttmsg.match(/^openWB\/pv\/[0-9]+\/boolPVConfigured$/i) )
 		{
@@ -209,7 +222,7 @@ function processBatMsg (mqttmsg, mqttpayload) {
 			setWarningLevel(mqttpayload, '#faultStrBatRow');
 			break;
 		case "openWB/housebattery/faultStr":
-			textShow(mqttpayload, '#faultStrBat');
+			textShow(formatJsonString(mqttpayload), '#faultStrBat');
 			break;
 	}
 }
@@ -296,13 +309,13 @@ function processLpMsg (mqttmsg, mqttpayload) {
 		setWarningLevel(mqttpayload, '#lp' + index + ' .faultStrLpRow');
 	}
 	else if ( mqttmsg.match( /^openwb\/lp\/[1-9][0-9]*\/faultStr$/i ) ) {
-		textShow(mqttpayload, '#lp' + index + ' .faultStrLp');
+		textShow(formatJsonString(mqttpayload), '#lp' + index + ' .faultStrLp');
 	}
 	else if ( mqttmsg.match( /^openwb\/lp\/[1-9][0-9]*\/socFaultState$/i ) ) {
 		setWarningLevel(mqttpayload, '#lp' + index + ' .faultStrSocLpRow');
 	}
 	else if ( mqttmsg.match( /^openwb\/lp\/[1-9][0-9]*\/socFaultStr$/i ) ) {
-		textShow(mqttpayload, '#lp' + index + ' .faultStrSocLp');
+		textShow(formatJsonString(mqttpayload), '#lp' + index + ' .faultStrSocLp');
 	}
 	else {
 		switch (mqttmsg) {


### PR DESCRIPTION
Der Server macht sich die Mühe beim Versenden der FaultStrings diese zu JSON-encoden. Im Status auf der UI sieht man dann JSON encodierte Fehlermeldungen. Das ist garnicht so richtig schön. Vorallem wenn Umlaute darin vorkommen.

Mir fallen zwei Lösungen ein: Entweder die Daten nicht JSON encodieren (warum sollte man auch?) oder... was dieser PR macht: Die Daten auf dem client wieder dekodieren (unter der Annahme, dass hinter dem JSON-encode ein tieferer Plan steckt.).