### PR TITLE
allow modbus port to be specified using the address

### DIFF
--- a/packages/modules/common/modbus.py
+++ b/packages/modules/common/modbus.py
@@ -4,13 +4,15 @@
 Das Modul baut eine Modbus-TCP-Verbindung auf. Es gibt verschiedene Funktionen, um die gelesenen Register zu
 formatieren.
 """
+import struct
 from enum import Enum
 from typing import Callable, Iterable, Union, overload, List
-import struct
+
 import pymodbus
 from pymodbus.client.sync import ModbusTcpClient
 from pymodbus.constants import Endian
 from pymodbus.payload import BinaryPayloadDecoder
+from urllib3.util import parse_url
 
 from helpermodules import log
 from modules.common.fault_state import FaultState
@@ -39,9 +41,13 @@ Number = Union[int, float]
 
 
 class ModbusClient:
-    def __init__(self, address: str, port: int = 502):
-        self.delegate = ModbusTcpClient(address, port)
-        self.address = address
+    def __init__(self, address: str, default_port: int = 502):
+        parsed_url = parse_url(address)
+        host = parsed_url.host
+        port = default_port if parsed_url.port is None else parsed_url.port
+
+        self.delegate = ModbusTcpClient(host, port)
+        self.address = host
         self.port = port
 
     def __enter__(self):

--- a/web/settings/modulconfigpv.php
+++ b/web/settings/modulconfigpv.php
@@ -569,9 +569,9 @@
 							<div class="form-row mb-1">
 								<label for="solaredgepvip" class="col-md-4 col-form-label">WR Solaredge IP</label>
 								<div class="col">
-									<input class="form-control" type="text" pattern="^((\d{1,2}|1\d\d|2[0-4]\d|25[0-5])\.){3}(\d{1,2}|1\d\d|2[0-4]\d|25[0-5])$" name="solaredgepvip" id="solaredgepvip" value="<?php echo $solaredgepvipold ?>">
+									<input class="form-control" type="text" name="solaredgepvip" id="solaredgepvip" value="<?php echo $solaredgepvipold ?>">
 									<span class="form-text small">
-										Gültige Werte: IP Adresse des SolarEdge Wechselrichters. Modbus TCP muss am WR aktiviert werden, der Port ist auf 502 zu stellen.
+										Gültige Werte: <code>adresse</code> oder <code>adresse:port</code>. Wenn nicht angegeben wird port 502 verwendet. Modbus TCP muss am WR aktiviert sein.
 									</span>
 								</div>
 							</div>


### PR DESCRIPTION
Im Forum kommt immer mal wieder auf, dass bei SolarEdge Modbus standardmäßig auf Port 1502 läuft statt auf Port 502. Man muss dann den Solarteur beauftragen oder ein Ticket bei SE aufmachen, damit die den Port umkonfigurieren. Umständlich. Warum kann man nicht einfach den Port in der openWB ändern?

Dieser PR ändert das. Hier ein paar Beispiele was jetzt funktionieren sollte:

- IPv6: `[2a00:1450:4001:c01::67]`
- IPv6 mit Port: `[2a00:1450:4001:c01::67]:1502`
- IPv4: `173.194.35.7`
- IPv4 mit Port: `173.194.35.7:1502`
- Hostname: `solaredge.home`
- Hostname mit Port: `solaredge.home:1502`

Vor dem PR ging ausschließlich IPv4 ohne Port. (wobei die anderen Optionen ohne Port lediglich an der Valdierung auf der UI gescheitert und nicht daran, dass der Server es nicht gekonnt hätte)