### PR TITLE
do not allow the regulation loop to run multiple times in parallel

### DIFF
--- a/regel.sh
+++ b/regel.sh
@@ -23,11 +23,18 @@
 #     along with openWB.  If not, see <https://www.gnu.org/licenses/>.
 #
 #####
+OPENWBBASEDIR=$(cd $(dirname "${BASH_SOURCE[0]}") && pwd)
 
 set -o pipefail
-cd /var/www/html/openWB/
+cd "$OPENWBBASEDIR"
 
 source helperFunctions.sh
+
+if pidof -x -o $$ "${BASH_SOURCE[0]}"
+then
+	openwbDebugLog "MAIN" 0 "Previous regulation loop still running. Skipping."
+	exit
+fi
 
 if [ -e ramdisk/updateinprogress ] && [ -e ramdisk/bootinprogress ]; then
 	updateinprogress=$(<ramdisk/updateinprogress)


### PR DESCRIPTION
Wenn die Regelschleife mehrfach läuft ist das nicht gut. Es kann dazu führen dass diverse Skripte mehrmals laufen, die nicht mehrmals laufen sollten. Zum Beispiel weil sie Modbusverbindungen zu ein und demselben Gerät aufbauen. Oder weil sie gleichzeitig in irgendwelche Dateien schreiben.

Für Huawei-WR taucht der Hinweis auf, man möge die Regelschleife auf langsam stellen. Aber auch andere Geräte können betroffen sein. Gerade wenn man ein Update gemacht hat und die Software neu startet ist es völlig normal, dass die erste Regelschleife sehr langsam läuft, bis diverse Caches gefüllt sind.

Sinnvoll wäre daher, wenn die Regelschleife einfach selbstständig erkennt, wenn sie bereits läuft und ggf. einen Durchlauf überspringt. Das macht dieser PR.