### PR TITLE
fix mqtt pv description

### DIFF
--- a/web/settings/modulconfigpv.php
+++ b/web/settings/modulconfigpv.php
@@ -117,7 +117,7 @@
 							<div class="alert alert-info">
 								Keine Konfiguration erforderlich.<br>
 								Per MQTT zu schreiben:<br>
-								<span class="text-info">openWB/set/pv/1/W</span> PV-Leistung in Watt, int, negativ<br>
+								<span class="text-info">openWB/set/pv/1/W</span> PV-Erzeugungsleistung in Watt, int, positiv<br>
 								<span class="text-info">openWB/set/pv/1/WhCounter</span> Erzeugte Energie in Wh, float, nur positiv
 							</div>
 						</div>
@@ -1209,7 +1209,7 @@
 							<div class="alert alert-info">
 								Keine Konfiguration erforderlich.<br>
 								Per MQTT zu schreiben:<br>
-								<span class="text-info">openWB/set/pv/2/W</span> PV-Leistung in Watt, int, negativ<br>
+								<span class="text-info">openWB/set/pv/2/W</span> PV-Erzeugungsleistung in Watt, int, positiv<br>
 								<span class="text-info">openWB/set/pv/2/WhCounter</span> Erzeugte Energie in Wh, float, nur positiv
 							</div>
 						</div>


### PR DESCRIPTION
Seit https://github.com/snaptec/openWB/pull/1879 und https://github.com/snaptec/openWB/pull/1942 wird in der `mqttsub.py` nicht mehr der Betrag der gesendeten Leistung gebildet. Als Ergebnis muss die Erzeugungsleistung positiv gesendet werden.