### PR TITLE
Stop wlan0 only if up

### DIFF
--- a/runs/cron5min.sh
+++ b/runs/cron5min.sh
@@ -338,13 +338,16 @@ else
 	if (( ethstate == 1 )); then
 		sudo ifconfig eth0:0 $virtual_ip_eth0 netmask 255.255.255.0 up
 		if [ -d /sys/class/net/wlan0 ]; then
-			sudo ifconfig wlan0:0 $virtual_ip_wlan0 netmask 255.255.255.0 down
 			wlanstate=$(</sys/class/net/wlan0/carrier)
 			if (( wlanstate == 1 )); then
-				sudo systemctl stop hostapd
-				sudo systemctl stop dnsmasq
+				sudo ifconfig wlan0:0 $virtual_ip_wlan0 netmask 255.255.255.0 down
+				wlanstate=$(</sys/class/net/wlan0/carrier)
+				if (( wlanstate == 1 )); then
+					sudo systemctl stop hostapd
+					sudo systemctl stop dnsmasq
+				fi
 			fi
-		fi
+		fi	
 	else
 		if [ -d /sys/class/net/wlan0 ]; then
 			sudo ifconfig wlan0:0 $virtual_ip_wlan0 netmask 255.255.255.0 up


### PR DESCRIPTION
In der /var/log/syslog und in der /var/log/daemon.log sammeln sich Zeilen dieser Art:
```
Feb 16 13:10:02 openWB avahi-daemon[367]: Joining mDNS multicast group on interface wlan0.IPv4 with address 192.168.193.6.
Feb 16 13:10:02 openWB avahi-daemon[367]: New relevant interface wlan0.IPv4 for mDNS.
Feb 16 13:10:02 openWB avahi-daemon[367]: Registering new address record for 192.168.193.6 on wlan0.IPv4.
Feb 16 13:10:02 openWB avahi-daemon[367]: Withdrawing address record for 192.168.193.6 on wlan0.
Feb 16 13:10:02 openWB avahi-daemon[367]: Leaving mDNS multicast group on interface wlan0.IPv4 with address 192.168.193.6.
Feb 16 13:10:02 openWB avahi-daemon[367]: Interface wlan0.IPv4 no longer relevant for mDNS.
```
Alle 5 minuten das gleiche. In meiner syslog sind 480 der 526 Zeilen vom avahi-damon.
Dieser Fix stop das.