### PR TITLE
fix reading sonnenbatterie variant 2

### DIFF
--- a/packages/modules/sonnenbatterie/bat.py
+++ b/packages/modules/sonnenbatterie/bat.py
@@ -110,7 +110,7 @@ class SonnenbatterieBat:
         response = requests.get('http://' + self.__device_address + ':7979/rest/devices/battery/' + element, timeout=5)
         response.raise_for_status()
         response.encoding = 'utf-8'
-        return response.text.replace("\n", "")
+        return response.text.strip(" \n\r")
 
     def __update_variant_2(self) -> BatState:
         # Auslesen einer Sonnenbatterie Eco 6 über die integrierte REST-API des Batteriesystems


### PR DESCRIPTION
strip more characters from response in `__read_variant_2`: `\n` and `\r`