### PR TITLE
refactor powerwall: de-duplicate code, use http-session with logging and automatic error detection

### DIFF
--- a/modules/speicher_powerwall/powerwall.py
+++ b/modules/speicher_powerwall/powerwall.py
@@ -1,87 +1,29 @@
 #!/usr/bin/env python3
 
-import json
 import logging
-from json import JSONDecodeError
 from typing import List
-import requests
-from requests import HTTPError
 
 from helpermodules.cli import run_using_positional_cli_args
 from modules.common.component_state import BatState
+from modules.common.powerwall import powerwall_update, PowerwallHttpClient
 from modules.common.store import get_bat_value_store, RAMDISK_PATH
 
 COOKIE_FILE = RAMDISK_PATH / "powerwall_cookie.txt"
 log = logging.getLogger("Powerwall")
 
 
-def authenticate(url: str, email: str, password: str):
-    '''
-    email is not yet required for login (2022/01), but we simulate the whole login page
-    '''
-    response = requests.post(
-        "https://" + url + "/api/login/Basic",
-        json={"username": "customer", "email": email, "password": password},
-        verify=False,
-        timeout=5
-    )
-    response.raise_for_status()
-    log.debug("Authentication endpoint responded %s", response.text)
-    log.debug("Authentication endpoint send cookies %s", str(response.cookies))
-    return {"AuthCookie": response.cookies["AuthCookie"], "UserRecord": response.cookies["UserRecord"]}
-
-
-def read_soc(address: str, cookie) -> float:
-    response = requests.get("https://" + address + "/api/system_status/soe", cookies=cookie, verify=False, timeout=5)
-    response.raise_for_status()
-    log.debug("SoC-Response: %s", response.text)
-    return response.json()["percentage"]
-
-
-def read_aggregate(address: str, cookie):
-    response = requests.get("https://" + address + "/api/meters/aggregates", cookies=cookie, verify=False, timeout=5)
-    response.raise_for_status()
-    return response.json()
-
-
-def update_using_cookie(address: str, cookie):
-    aggregate = read_aggregate(address, cookie)
+def update_using_powerwall_client(client: PowerwallHttpClient):
+    aggregate = client.get_json("/api/meters/aggregates")
     get_bat_value_store(1).set(BatState(
         imported=aggregate["battery"]["energy_imported"],
         exported=aggregate["battery"]["energy_exported"],
         power=-aggregate["battery"]["instant_power"],
-        soc=read_soc(address, cookie)
+        soc=client.get_json("/api/system_status/soe")["percentage"]
     ))
 
 
-def authenticate_and_update(address: str, email: str, password: str):
-    cookie = authenticate(address, email, password)
-    COOKIE_FILE.write_text(json.dumps(cookie))
-    update_using_cookie(address, cookie)
-
-
 def update(address: str, email: str, password: str):
-    log.debug("Beginning update")
-    cookies = None
-    try:
-        cookies = json.loads(COOKIE_FILE.read_text())
-    except FileNotFoundError:
-        log.debug("Cookie-File <%s> does not exist. It will be created.", COOKIE_FILE)
-    except JSONDecodeError as e:
-        log.warning("Could not parse Cookie-File <%s>. It will be re-created.", COOKIE_FILE, exc_info=e)
-
-    if cookies is None:
-        authenticate_and_update(address, email, password)
-        return
-    try:
-        update_using_cookie(address, cookies)
-        return
-    except HTTPError as e:
-        if e.response.status_code != 401 and e.response.status_code != 403:
-            raise e
-        log.warning("Login to powerwall with existing cookie failed. Will retry with new cookie...")
-    authenticate_and_update(address, email, password)
-    log.debug("Update completed successfully")
+    powerwall_update(address, email, password, update_using_powerwall_client)
 
 
 def main(argv: List[str]):

--- a/modules/wr_powerwall/powerwall.py
+++ b/modules/wr_powerwall/powerwall.py
@@ -1,44 +1,19 @@
 #!/usr/bin/env python3
 
-import json
 import logging
-from json import JSONDecodeError
 from typing import List
-import requests
-from requests import HTTPError
 
 from helpermodules.cli import run_using_positional_cli_args
 from modules.common.component_state import InverterState
+from modules.common.powerwall import PowerwallHttpClient, powerwall_update
 from modules.common.store import get_inverter_value_store, RAMDISK_PATH
 
 COOKIE_FILE = RAMDISK_PATH / "powerwall_cookie.txt"
 log = logging.getLogger("Powerwall")
 
 
-def authenticate(url: str, email: str, password: str):
-    '''
-    email is not yet required for login (2022/01), but we simulate the whole login page
-    '''
-    response = requests.post(
-        "https://" + url + "/api/login/Basic",
-        json={"username": "customer", "email": email, "password": password},
-        verify=False,
-        timeout=5
-    )
-    response.raise_for_status()
-    log.debug("Authentication endpoint responded %s", response.text)
-    log.debug("Authentication endpoint send cookies %s", str(response.cookies))
-    return {"AuthCookie": response.cookies["AuthCookie"], "UserRecord": response.cookies["UserRecord"]}
-
-
-def read_aggregate(address: str, cookie):
-    response = requests.get("https://" + address + "/api/meters/aggregates", cookies=cookie, verify=False, timeout=5)
-    response.raise_for_status()
-    return response.json()
-
-
-def update_using_cookie(address: str, cookie):
-    aggregate = read_aggregate(address, cookie)
+def update_using_powerwall_client(client: PowerwallHttpClient):
+    aggregate = client.get_json("/api/meters/aggregates")
     pv_watt = aggregate["solar"]["instant_power"]
     if pv_watt > 5:
         pv_watt = pv_watt*-1
@@ -48,34 +23,8 @@ def update_using_cookie(address: str, cookie):
     ))
 
 
-def authenticate_and_update(address: str, email: str, password: str):
-    cookie = authenticate(address, email, password)
-    COOKIE_FILE.write_text(json.dumps(cookie))
-    update_using_cookie(address, cookie)
-
-
 def update(address: str, email: str, password: str):
-    log.debug("Beginning update")
-    cookies = None
-    try:
-        cookies = json.loads(COOKIE_FILE.read_text())
-    except FileNotFoundError:
-        log.debug("Cookie-File <%s> does not exist. It will be created.", COOKIE_FILE)
-    except JSONDecodeError as e:
-        log.warning("Could not parse Cookie-File <%s>. It will be re-created.", COOKIE_FILE, exc_info=e)
-
-    if cookies is None:
-        authenticate_and_update(address, email, password)
-        return
-    try:
-        update_using_cookie(address, cookies)
-        return
-    except HTTPError as e:
-        if e.response.status_code != 401 and e.response.status_code != 403:
-            raise e
-        log.warning("Login to powerwall with existing cookie failed. Will retry with new cookie...")
-    authenticate_and_update(address, email, password)
-    log.debug("Update completed successfully")
+    powerwall_update(address, email, password, update_using_powerwall_client)
 
 
 def main(argv: List[str]):

--- a/packages/modules/common/powerwall.py
+++ b/packages/modules/common/powerwall.py
@@ -1,0 +1,76 @@
+import json
+import logging
+from json import JSONDecodeError
+from typing import Callable
+
+import requests
+from requests import HTTPError
+
+from modules.common.req import get_http_session
+from modules.common.store import RAMDISK_PATH
+
+COOKIE_FILE = RAMDISK_PATH / "powerwall_cookie.txt"
+log = logging.getLogger("Powerwall")
+
+
+class PowerwallHttpClient:
+    def __init__(self, host: str, session: requests.Session, cookies):
+        self.__base_url = "https://" + host
+        self.__cookies = cookies
+        self.__session = session
+
+    def get_json(self, relative_url: str):
+        url = self.__base_url + relative_url
+        return self.__session.get(url, cookies=self.__cookies, verify=False, timeout=5).json()
+
+
+UpdateFunction = Callable[[PowerwallHttpClient], None]
+
+
+def _authenticate(session: requests.Session, url: str, email: str, password: str):
+    """
+    email is not yet required for login (2022/01), but we simulate the whole login page
+    """
+    response = session.post(
+        "https://" + url + "/api/login/Basic",
+        json={"username": "customer", "email": email, "password": password},
+        verify=False,
+        timeout=5
+    )
+    log.debug("Authentication endpoint send cookies %s", str(response.cookies))
+    return {"AuthCookie": response.cookies["AuthCookie"], "UserRecord": response.cookies["UserRecord"]}
+
+
+def _authenticate_and_update(session: requests.Session,
+                             address: str,
+                             email: str,
+                             password: str,
+                             update_function: UpdateFunction):
+    cookie = _authenticate(session, address, email, password)
+    COOKIE_FILE.write_text(json.dumps(cookie))
+    update_function(PowerwallHttpClient(address, session, cookie))
+
+
+def powerwall_update(address: str, email: str, password: str, update_function: UpdateFunction):
+    log.debug("Beginning update")
+    cookies = None
+    try:
+        cookies = json.loads(COOKIE_FILE.read_text())
+    except FileNotFoundError:
+        log.debug("Cookie-File <%s> does not exist. It will be created.", COOKIE_FILE)
+    except JSONDecodeError as e:
+        log.warning("Could not parse Cookie-File <%s>. It will be re-created.", COOKIE_FILE, exc_info=e)
+
+    session = get_http_session()
+    if cookies is None:
+        _authenticate_and_update(session, address, email, password, update_function)
+        return
+    try:
+        update_function(PowerwallHttpClient(address, session, cookies))
+        return
+    except HTTPError as e:
+        if e.response.status_code != 401 and e.response.status_code != 403:
+            raise e
+        log.warning("Login to powerwall with existing cookie failed. Will retry with new cookie...")
+    _authenticate_and_update(session, address, email, password, update_function)
+    log.debug("Update completed successfully")


### PR DESCRIPTION
Wegen [diesen Forenthread](https://openwb.de/forum/viewtopic.php?f=9&t=4810) habe ich nochmal in das Powerwall-Script reingeschaut, dessen Batterieteil ich vor kurzem in #1817 überarbeitet habe.

Es werden natürlich alle möglichen HTTP-Responses in dem Modul geloggt, aber leider nicht die Response, um die es in dem Thread im Forum geht.

Allgemein ist der Code ist nicht mehr auf dem Stand der Technik. Dank #1823 gibt es die Möglichkeit automatisch zu loggen und auch die Fehlerekennung (`raise_for_status()`) automatisch zu machen und damit kann jede Menge Code entfallen.

Leider hatte der Code mit #1889 ein erhebliches Copy&paste-Erlebnis erlitten. Wenn man jetzt irgendwas irgendwo fixen will muss man das gleich 3x machen.

Ich habe daher den ganzen Code überarbeitet: Der Teil, der zwischen allen Modulen geteilt wird, ist in eine gemeinsame Bibliothek extrahiert und dank der Verwendung von `get_http_session` wird jetzt alles geloggt, was per http zurück kommt. Das wird zwar das im Forum beschriebene Problem nicht lösen, aber das debugging des Problems erleichtern.

Der von mir in #1817 erzeugte Unittest ist noch da und funktioniert, das gibt etwas Konfidenz darein, dass die Änderungen nicht alles völlig kaputt gemacht haben, allerdings sind die anderen beiden Module vollends ungetestet und mangels Powerwall habe ich überhaupt nichts im laufenden Betrieb testen können.