### PR TITLE
restore old rct module

### DIFF
--- a/modules/bezug_rct/main.sh
+++ b/modules/bezug_rct/main.sh
@@ -1,31 +1,22 @@
 #!/bin/bash
-OPENWBBASEDIR=$(cd `dirname $0`/../../ && pwd)
+OPENWBBASEDIR=$(cd "$(dirname "$0")/../../" && pwd)
 RAMDISKDIR="${OPENWBBASEDIR}/ramdisk"
-MODULEDIR=$(cd `dirname $0` && pwd)
-#DMOD="EVU"
+MODULEDIR=$(cd "$(dirname "$0")" && pwd)
 DMOD="MAIN"
-Debug=$debug
 
-#For development only
-#Debug=1
 
-if [ ${DMOD} == "MAIN" ]; then
-        MYLOGFILE="${RAMDISKDIR}/openWB.log"
-else
-        MYLOGFILE="${RAMDISKDIR}/evu.log"
-fi
+wattbezug=$(echo "scale=0; $(python "${MODULEDIR}/rct_read.py" --ip="$bezug1_ip" --name='g_sync.p_ac_sc_sum')/1" | bc)
+openwbDebugLog ${DMOD} 2 "Bezug RCT Leistung: ${wattbezug}"
 
-#
-# Exportere Volt/Ampere/Frequenz etc in die Ramdisk
-#   
-bash "$OPENWBBASEDIR/packages/legacy_run.sh" "bezug_rct2.rct_read_bezug" "${bezug1_ip}" >>${MYLOGFILE} 2>&1
-ret=$?
+watt1=$(echo "scale=0; $(python "${MODULEDIR}/rct_read.py" --ip="$bezug1_ip" --id='0x27BE51D9')/230/1" | bc)
+watt2=$(echo "scale=0; $(python "${MODULEDIR}/rct_read.py" --ip="$bezug1_ip" --id='0xF5584F90')/230/1" | bc)
+watt3=$(echo "scale=0; $(python "${MODULEDIR}/rct_read.py" --ip="$bezug1_ip" --id='0xB221BCFA')/230/1" | bc)
+openwbDebugLog ${DMOD} 2 "Bezug RCT Strom L1: ${watt1} L2: ${watt2} L3: ${watt3}"
 
-openwbDebugLog ${DMOD} 2 "RET: ${ret}"
+echo "$watt1" > "${RAMDISKDIR}/bezuga1"
+echo "$watt2" > "${RAMDISKDIR}/bezuga2"
+echo "$watt3" > "${RAMDISKDIR}/bezuga3"
+echo "$wattbezug" > "${RAMDISKDIR}/wattbezug"
 
-#
-# Nehme wattbezug als ergbenis mit zurueck da beim Bezug-Module ein Returnwert erwartet wird.
-#  
-wattbezug=$(</var/www/html/openWB/ramdisk/wattbezug)
-echo $wattbezug
-
+# Gebe wattbezug als Ergbenis mit zurueck da beim Bezug-Module ein Returnwert erwartet wird.
+echo "$wattbezug"

--- a/modules/bezug_rct/rct_read.py
+++ b/modules/bezug_rct/rct_read.py
@@ -3,25 +3,27 @@ import sys
 import rct
 import fnmatch
 
+
 # Entry point with parameter check
 def main():
     rct.init(sys.argv)
 
     clientsocket = rct.connect_to_server()
     if clientsocket is not None:
-        fmt = '#0x{:08X} {:'+str(rct.param_len)+'}'# {:'+str(rct.desc_len)+'}:'
+        fmt = '#0x{:08X} {:'+str(rct.param_len)+'}'  # {:'+str(rct.desc_len)+'}:'
         for obj in rct.id_tab:
             if rct.search_id > 0 and obj.id != rct.search_id:
                 continue
-            
-            if rct.search_name is not None and fnmatch.fnmatch(obj.name, rct.search_name) == False:
+
+            if rct.search_name is not None and fnmatch.fnmatch(obj.name, rct.search_name) is False:
                 continue
-            
+
             value = rct.read(clientsocket, obj.id)
-            if rct.dbglog(fmt.format(obj.id, obj.name), value) == False:
+            if rct.dbglog(fmt.format(obj.id, obj.name), value) is False:
                 print(value)
         rct.close(clientsocket)
     sys.exit(0)
+
 
 if __name__ == "__main__":
     main()

--- a/modules/speicher_rct/main.sh
+++ b/modules/speicher_rct/main.sh
@@ -1,21 +1,9 @@
 #!/bin/bash
-OPENWBBASEDIR=$(cd `dirname $0`/../../ && pwd)
+OPENWBBASEDIR=$(cd "$(dirname "$0")/../../" && pwd)
 RAMDISKDIR="${OPENWBBASEDIR}/ramdisk"
-MODULEDIR=$(cd `dirname $0` && pwd)
-#DMOD="BAT"
-DMOD="MAIN"
-Debug=$debug
+MODULEDIR=$(cd "$(dirname "$0")" && pwd)
 
-#For development only
-#Debug=1
-
-if [ ${DMOD} == "MAIN" ]; then
-        MYLOGFILE="${RAMDISKDIR}/openWB.log"
-else
-        MYLOGFILE="${RAMDISKDIR}/bat.log"
-fi
-
-bash "$OPENWBBASEDIR/packages/legacy_run.sh" "bezug_rct2.rct_read_speicher" "${bezug1_ip}" >>${MYLOGFILE} 2>&1
-ret=$?
-
-openwbDebugLog ${DMOD} 2 "BAT RET: ${ret}"
+soc=$(echo "scale=0; $(python "${MODULEDIR}/../bezug_rct/rct_read.py" --ip="$bezug1_ip" --name='battery.soc')*100/1" | bc)
+echo "$soc" > "$RAMDISKDIR/speichersoc"
+watt=$(echo "scale=0; $(python "${MODULEDIR}/../bezug_rct/rct_read.py" --ip="$bezug1_ip" --name='g_sync.p_acc_lp')*-1/1" | bc)
+echo "$watt" > "$RAMDISKDIR/speicherleistung"

--- a/modules/wr_rct/main.sh
+++ b/modules/wr_rct/main.sh
@@ -1,25 +1,11 @@
 #!/bin/bash
-
-OPENWBBASEDIR=$(cd `dirname $0`/../../ && pwd)
+OPENWBBASEDIR=$(cd "$(dirname "$0")/../../" && pwd)
 RAMDISKDIR="${OPENWBBASEDIR}/ramdisk"
-#MODULEDIR=$(cd `dirname $0` && pwd)
-DMOD="PV"
-#DMOD="MAIN"
-Debug=$debug
+MODULEDIR=$(cd "$(dirname "$0")" && pwd)
 
-#For Development only
-#Debug=1
-
-if [ $DMOD == "MAIN" ]; then
-	MYLOGFILE="${RAMDISKDIR}/openWB.log"
-else
-	MYLOGFILE="${RAMDISKDIR}/nurpv.log"
-fi
-
-bash "$OPENWBBASEDIR/packages/legacy_run.sh" "bezug_rct2.rct_read_wr" "${bezug1_ip}" >>$MYLOGFILE 2>&1
-ret=$?
-openwbDebugLog ${DMOD} 2 "RET: ${ret}"
-
-
-watt=$(<${RAMDISKDIR}/pvwatt)
-echo ${watt}
+pv1watt=$(echo "scale=0; $(python "${MODULEDIR}/../bezug_rct/rct_read.py" --ip="$bezug1_ip" --id='0xB5317B78')/1" | bc)
+pv2watt=$(echo "scale=0; $(python "${MODULEDIR}/../bezug_rct/rct_read.py" --ip="$bezug1_ip" --id='0xE96F1844')/1" | bc)
+pv3watt=$(echo "scale=0; $(python "${MODULEDIR}/../bezug_rct/rct_read.py" --ip="$bezug1_ip" --id='0xAA9AA253')/1" | bc)
+pvwatt=$(echo "scale=0; ($pv1watt + $pv2watt + $pv3watt) * -1" | bc)
+echo "$pvwatt" > "$RAMDISKDIR/pvwatt"
+echo "$pvwatt"


### PR DESCRIPTION
Seems that the rct2 modules cannot comlete replace the old rct modules.
So we keep the old version for compatibility.