### PR TITLE
remove battery timeout error message

### DIFF
--- a/modules/speicher_bydhv/byd.py
+++ b/modules/speicher_bydhv/byd.py
@@ -6,7 +6,9 @@ from typing import List, Tuple
 import requests
 
 from helpermodules.cli import run_using_positional_cli_args
+from modules.common.component_context import SingleComponentUpdateContext
 from modules.common.component_state import BatState
+from modules.common.fault_state import ComponentInfo
 from modules.common.store import get_bat_value_store
 
 log = logging.getLogger("BYD Battery")
@@ -40,9 +42,11 @@ class BydParser(HTMLParser):
 
 def update(bydhvip: str, bydhvuser: str, bydhvpass: str):
     log.debug("Beginning update")
-    response = requests.get('http://' + bydhvip + '/asp/RunData.asp', auth=(bydhvuser, bydhvpass))
-    response.raise_for_status()
-    get_bat_value_store(1).set(BydParser.parse(response.text))
+    bat_info = ComponentInfo(None, "BYD", "bat")
+    with SingleComponentUpdateContext(bat_info):
+        response = requests.get('http://' + bydhvip + '/asp/RunData.asp', auth=(bydhvuser, bydhvpass))
+        response.raise_for_status()
+        get_bat_value_store(1).set(BydParser.parse(response.text))
     log.debug("Update completed successfully")
 
 

--- a/modules/speicher_e3dc/e3dc.py
+++ b/modules/speicher_e3dc/e3dc.py
@@ -5,7 +5,9 @@ from typing import Iterable, List
 from pymodbus.constants import Endian
 
 from helpermodules.cli import run_using_positional_cli_args
+from modules.common.component_context import SingleComponentUpdateContext
 from modules.common.component_state import InverterState, BatState
+from modules.common.fault_state import ComponentInfo
 from modules.common.modbus import ModbusClient, ModbusDataType
 from modules.common.store import get_inverter_value_store, get_bat_value_store
 from modules.common.simcount import SimCountFactory
@@ -66,7 +68,9 @@ def update(address1: str, address2: str, read_external: int, pvmodul: str):
     log.debug("Beginning update")
     addresses = [address for address in [address1, address2] if address != "none"]
     pv_other = pvmodul != "none"
-    update_e3dc_battery(addresses, read_external, pv_other)
+    bat_info = ComponentInfo(None, "E3DC", "bat")
+    with SingleComponentUpdateContext(bat_info):
+        update_e3dc_battery(addresses, read_external, pv_other)
     log.debug("Update completed successfully")
 
 

--- a/modules/speicher_solaredge/solaredge.py
+++ b/modules/speicher_solaredge/solaredge.py
@@ -6,7 +6,9 @@ from typing import Iterable, List
 from pymodbus.constants import Endian
 
 from helpermodules.cli import run_using_positional_cli_args
+from modules.common.component_context import SingleComponentUpdateContext
 from modules.common.component_state import BatState
+from modules.common.fault_state import ComponentInfo
 from modules.common.modbus import ModbusClient, ModbusDataType
 from modules.common.store import get_bat_value_store
 
@@ -29,8 +31,10 @@ def update_solaredge_battery(client: ModbusClient, slave_ids: Iterable[int]):
 def update(address: str, second_battery: int):
     # `second_battery` is 0 or 1
     log.debug("Beginning update")
-    with ModbusClient(address) as client:
-        update_solaredge_battery(client, range(1, 2 + second_battery))
+    bat_info = ComponentInfo(None, "Solaredge", "bat")
+    with SingleComponentUpdateContext(bat_info):
+        with ModbusClient(address) as client:
+            update_solaredge_battery(client, range(1, 2 + second_battery))
     log.debug("Update completed successfully")
 
 


### PR DESCRIPTION
Das loadvars-Skript setzt eine Fehlermeldung für die Statusseite, wenn die Batterie-Abfrage zu lange dauert. Diese Meldung wurde nicht zurück gesetzt.