### PR TITLE
Update mqttsub.py pv/W

### DIFF
--- a/runs/mqttsub.py
+++ b/runs/mqttsub.py
@@ -1370,7 +1370,7 @@ def on_message(client, userdata, msg):
                 elif subtopic == "W":
                     value = abs(float(msg.payload))
                     if value <= 100000000:
-                        pv.power.write(-float(msg.payload))
+                        pv.power.write(-float(value))
             if (msg.topic == "openWB/set/lp/1/AutolockStatus"):
                 if (int(msg.payload) >= 0 and int(msg.payload) <=3):
                     f = open('/var/www/html/openWB/ramdisk/autolockstatuslp1', 'w')


### PR DESCRIPTION
Wiederherstellung der Kompatiblititat zu <1.9.25x
Wenn, wie vorher, negative Zahlen per MQTT  eingeliefert werden,  dann werden die akzeptiert. 
Meine MQTT Quell kann die 1.9'er nicht unterscheiden und liefert immer Negative Zahlen ein.