### PR TITLE
soc tesla - fix file permissions

### DIFF
--- a/modules/soc_tesla/tesla.php
+++ b/modules/soc_tesla/tesla.php
@@ -314,6 +314,7 @@
 								$tokenFileP = fopen( $token_file, 'w' );
 								fwrite( $tokenFileP, json_encode( $token ) );
 								fclose( $tokenFileP );
+								chmod( $token_file, 0666 );
 								?>
 									<div class="alert alert-success">
 										Anmeldung erfolgreich!<br>


### PR DESCRIPTION
The token file is created from inside apache and only writeable for this user. The token refresh is run inside the main loop from another user. So the token file needs to be writeable for other users.