### PR TITLE
fix typos in wr2 modules

### DIFF
--- a/modules/wr2_ethlovatoaevu/main.sh
+++ b/modules/wr2_ethlovatoaevu/main.sh
@@ -1,22 +1,15 @@
 #!/bin/bash
-OPENWBBASEDIR=$(cd `dirname $0`/../../ && pwd)
+OPENWBBASEDIR=$(cd "$(dirname "$0")/../../" && pwd)
 RAMDISKDIR="${OPENWBBASEDIR}/ramdisk"
-MODULEDIR=$(cd `dirname $0` && pwd)
 DMOD="PV"
 #DMOD="MAIN"
-Debug=$debug
-
-#For development only
-#Debug=1
 
 if [ ${DMOD} == "MAIN" ]; then
-        MYLOGFILE="${RAMDISKDIR}/openWB.log"
+	MYLOGFILE="${RAMDISKDIR}/openWB.log"
 else
-        MYLOGFILE="${RAMDISKDIR}/nurpv.log"
+	MYLOGFILE="${RAMDISKDIR}/nurpv.log"
 fi
 
+bash "$OPENWBBASEDIR/packages/legacy_run.sh" "modules.openwb_pv_evu.device" "${pv2kitversion}" "2">>"$MYLOGFILE" 2>&1
 
-bash "$OPENWBBASEDIR/packages/legacy_run.sh" "modules.openwb_pv_evu.device" "${pv2kitversion}" "2">>${MYLOGFILE} 2>&1
-
-pvwatt=$(<${RAMDISKDIR}/pvwatt)
-echo $pvwatt
+cat "$RAMDISKDIR/pv2watt"

--- a/modules/wr2_kostalsteca/kostal_steca.py
+++ b/modules/wr2_kostalsteca/kostal_steca.py
@@ -16,8 +16,10 @@ def update(pv2ip: str):
     # Unfortunately Kostal has introduced the third version of interface: XML
     # This script is for Kostal_Piko_MP_plus and StecaGrid coolcept (single phase inverter)
     # In fact Kostal is not developing own single phase inverter anymore but is sourcing them from Steca
-    # If you have the chance to test this module for the latest three phase inverter from Kostal (Plenticore) or Steca (coolcept3 or coolcept XL) let us know if it works
-    # DetMoerk 20210323: Anpassung fuer ein- und dreiphasige WR der Serie. Anstatt eine feste Zeile aus dem Ergebnis zu schneiden wird nach der Zeile mit AC_Power gesucht.
+    # If you have the chance to test this module for the latest three phase inverter from Kostal (Plenticore)
+    # or Steca (coolcept3 or coolcept XL) let us know if it works
+    # DetMoerk 20210323: Anpassung für ein- und dreiphasige WR der Serie. Anstatt eine feste Zeile aus
+    # dem Ergebnis zu schneiden wird nach der Zeile mit AC_Power gesucht.
 
     log.debug('PV Kostal Steca IP:' + pv2ip)
 
@@ -31,7 +33,7 @@ def update(pv2ip: str):
 
     # allow only numbers
     regex = '^-?[0-9]+$'
-    if re.search(regex, str(power_kostal_piko_MP)) == None:
+    if re.search(regex, str(power_kostal_piko_MP)) is None:
         power_kostal_piko_MP = "0"
 
     log.debug("'PVWatt: "+str(power_kostal_piko_MP)+"'")
@@ -43,7 +45,7 @@ def update(pv2ip: str):
     response = requests.get("http://"+pv2ip+"/yields.xml", timeout=2).text
     pvkwh_kostal_piko_MP = ET.fromstring(response).find("YieldValue").get("Value")
 
-    if re.search(regex, str(pvkwh_kostal_piko_MP)) == None:
+    if re.search(regex, str(pvkwh_kostal_piko_MP)) is None:
         log.debug("PVkWh: NaN get prev. Value")
         with open("/var/www/html/openWB/ramdisk/pv2kwh", "r") as f:
             pvkwh_kostal_piko_MP = f.read()

--- a/modules/wr2_kostalsteca/main.sh
+++ b/modules/wr2_kostalsteca/main.sh
@@ -1,14 +1,9 @@
 #!/bin/bash
 
-OPENWBBASEDIR=$(cd `dirname $0`/../../ && pwd)
+OPENWBBASEDIR=$(cd "$(dirname "$0")/../../" && pwd)
 RAMDISKDIR="${OPENWBBASEDIR}/ramdisk"
-#MODULEDIR=$(cd `dirname $0` && pwd)
 #DMOD="PV"
 DMOD="MAIN"
-Debug=$debug
-
-#For Development only
-#Debug=1
 
 if [ $DMOD == "MAIN" ]; then
 	MYLOGFILE="${RAMDISKDIR}/openWB.log"
@@ -18,10 +13,9 @@ fi
 
 openwbDebugLog ${DMOD} 2 "PV IP: ${pv2ip}"
 
-bash "$OPENWBBASEDIR/packages/legacy_run.sh" "wr2_kostalsteca.kostal_steca" "${pv2ip}" >>$MYLOGFILE 2>&1
+bash "$OPENWBBASEDIR/packages/legacy_run.sh" "wr2_kostalsteca.kostal_steca" "${pv2ip}" >>"$MYLOGFILE" 2>&1
 ret=$?
 
 openwbDebugLog ${DMOD} 2 "RET: ${ret}"
 
-pvwatt=$(</var/www/html/openWB/ramdisk/pvwatt) 
-echo $pvwatt
+cat "$RAMDISKDIR/pv2watt"

--- a/modules/wr2_solax/main.sh
+++ b/modules/wr2_solax/main.sh
@@ -1,13 +1,8 @@
 #!/bin/bash
-OPENWBBASEDIR=$(cd `dirname $0`/../../ && pwd)
+OPENWBBASEDIR=$(cd "$(dirname "$0")/../../" && pwd)
 RAMDISKDIR="${OPENWBBASEDIR}/ramdisk"
-MODULEDIR=$(cd `dirname $0` && pwd)
-DMOD="PV"
-#DMOD="MAIN"
-Debug=$debug
-
-#For development only
-#Debug=1
+#DMOD="PV"
+DMOD="MAIN"
 
 if [ ${DMOD} == "MAIN" ]; then
 	MYLOGFILE="${RAMDISKDIR}/openWB.log"
@@ -17,8 +12,6 @@ fi
 
 openwbDebugLog ${DMOD} 2 "PV2 IP: ${pv2ip}"
 
+bash "$OPENWBBASEDIR/packages/legacy_run.sh" "modules.solax.device" "inverter" "${pv2ip}" "2">>"$MYLOGFILE" 2>&1
 
-bash "$OPENWBBASEDIR/packages/legacy_run.sh" "modules.solax.device" "inverter" "${pv2ip}" "2">>${MYLOGFILE} 2>&1
-
-pvwatt=$(<${RAMDISKDIR}/pvwatt)
-echo $pvwatt
+cat "$RAMDISKDIR/pv2watt"

--- a/modules/wr2_sungrow/main.sh
+++ b/modules/wr2_sungrow/main.sh
@@ -1,22 +1,15 @@
 #!/bin/bash
-OPENWBBASEDIR=$(cd `dirname $0`/../../ && pwd)
+OPENWBBASEDIR=$(cd "$(dirname "$0")/../../" && pwd)
 RAMDISKDIR="${OPENWBBASEDIR}/ramdisk"
-MODULEDIR=$(cd `dirname $0` && pwd)
-DMOD="PV"
-#DMOD="MAIN"
-Debug=$debug
-
-#For development only
-#Debug=1
+#DMOD="PV"
+DMOD="MAIN"
 
 if [ ${DMOD} == "MAIN" ]; then
-        MYLOGFILE="${RAMDISKDIR}/openWB.log"
+	MYLOGFILE="${RAMDISKDIR}/openWB.log"
 else
-        MYLOGFILE="${RAMDISKDIR}/nurpv.log"
+	MYLOGFILE="${RAMDISKDIR}/nurpv.log"
 fi
 
+bash "$OPENWBBASEDIR/packages/legacy_run.sh" "modules.sungrow.device" "inverter" "${pv2ip}" "2">>"$MYLOGFILE" 2>&1
 
-bash "$OPENWBBASEDIR/packages/legacy_run.sh" "modules.sungrow.device" "inverter" "${pv2ip}" "2">>${MYLOGFILE} 2>&1
-
-pvwatt=$(<${RAMDISKDIR}/pvwatt)
-echo $pvwatt
+cat "$RAMDISKDIR/pv2watt"

--- a/modules/wr2_victron/main.sh
+++ b/modules/wr2_victron/main.sh
@@ -1,22 +1,15 @@
 #!/bin/bash
-OPENWBBASEDIR=$(cd `dirname $0`/../../ && pwd)
+OPENWBBASEDIR=$(cd "$(dirname "$0")/../../" && pwd)
 RAMDISKDIR="${OPENWBBASEDIR}/ramdisk"
-MODULEDIR=$(cd `dirname $0` && pwd)
-DMOD="PV"
-#DMOD="MAIN"
-Debug=$debug
-
-#For development only
-#Debug=1
+#DMOD="PV"
+DMOD="MAIN"
 
 if [ ${DMOD} == "MAIN" ]; then
-        MYLOGFILE="${RAMDISKDIR}/openWB.log"
+	MYLOGFILE="${RAMDISKDIR}/openWB.log"
 else
-        MYLOGFILE="${RAMDISKDIR}/nurpv.log"
+	MYLOGFILE="${RAMDISKDIR}/nurpv.log"
 fi
 
+bash "$OPENWBBASEDIR/packages/legacy_run.sh" "modules.victron.device" "inverter" "${pv2ip}" "${pv2id}" "1" "2">>"$MYLOGFILE" 2>&1
 
-bash "$OPENWBBASEDIR/packages/legacy_run.sh" "modules.victron.device" "inverter" "${pv2ip}" "${pv2id}" "1" "2">>${MYLOGFILE} 2>&1
-
-pvwatt=$(<${RAMDISKDIR}/pvwatt)
-echo $pvwatt
+cat "$RAMDISKDIR/pv2watt"


### PR DESCRIPTION
- some main.sh referenced "pvwatt" but should use "pv2watt"
- fix shellsheck warnings
- fix flake8 and pylint warnings