### PR TITLE
solax gen4

### DIFF
--- a/modules/bezug_solax/main.sh
+++ b/modules/bezug_solax/main.sh
@@ -15,7 +15,7 @@ else
 	MYLOGFILE="${RAMDISKDIR}/evu.log"
 fi
 
-bash "$OPENWBBASEDIR/packages/legacy_run.sh" "modules.solax.device" "counter" "${solaxip}" >>${MYLOGFILE} 2>&1
+bash "$OPENWBBASEDIR/packages/legacy_run.sh" "modules.solax.device" "counter" "${solaxip}" "${pv1_ida}" >>${MYLOGFILE} 2>&1
 ret=$?
 
 openwbDebugLog ${DMOD} 2 "EVU RET: ${ret}"

--- a/modules/speicher_solax/main.sh
+++ b/modules/speicher_solax/main.sh
@@ -15,7 +15,7 @@ else
         MYLOGFILE="${RAMDISKDIR}/bat.log"
 fi
 
-bash "$OPENWBBASEDIR/packages/legacy_run.sh" "modules.solax.device" "bat" "${solaxip}" >>${MYLOGFILE} 2>&1
+bash "$OPENWBBASEDIR/packages/legacy_run.sh" "modules.solax.device" "bat" "${solaxip}" "${pv1_ida}" >>${MYLOGFILE} 2>&1
 ret=$?
 
 openwbDebugLog ${DMOD} 2 "BAT RET: ${ret}"

--- a/modules/wr2_solax/main.sh
+++ b/modules/wr2_solax/main.sh
@@ -12,6 +12,6 @@ fi
 
 openwbDebugLog ${DMOD} 2 "PV2 IP: ${pv2ip}"
 
-bash "$OPENWBBASEDIR/packages/legacy_run.sh" "modules.solax.device" "inverter" "${pv2ip}" "2">>"$MYLOGFILE" 2>&1
+bash "$OPENWBBASEDIR/packages/legacy_run.sh" "modules.solax.device" "inverter" "${pv2ip}" "0" "2">>${MYLOGFILE} 2>&1
 
 cat "$RAMDISKDIR/pv2watt"

--- a/modules/wr_solax/main.sh
+++ b/modules/wr_solax/main.sh
@@ -18,7 +18,7 @@ fi
 openwbDebugLog ${DMOD} 2 "PV IP: ${solaxip}"
 
 
-bash "$OPENWBBASEDIR/packages/legacy_run.sh" "modules.solax.device" "inverter" "${solaxip}" "1">>${MYLOGFILE} 2>&1
+bash "$OPENWBBASEDIR/packages/legacy_run.sh" "modules.solax.device" "inverter" "${solaxip}" "${pv1_ida}" "1">>${MYLOGFILE} 2>&1
 
 pvwatt=$(<${RAMDISKDIR}/pvwatt)
 echo $pvwatt

--- a/packages/modules/solax/bat.py
+++ b/packages/modules/solax/bat.py
@@ -18,8 +18,9 @@ def get_default_config() -> dict:
 
 
 class SolaxBat:
-    def __init__(self, device_id: int, component_config: dict, tcp_client: modbus.ModbusClient) -> None:
+    def __init__(self, device_id: int, component_config: dict, tcp_client: modbus.ModbusClient, modbus_id: int) -> None:
         self.__device_id = device_id
+        self.__modbus_id = modbus_id
         self.component_config = component_config
         self.__tcp_client = tcp_client
         self.__sim_count = simcount.SimCountFactory().get_sim_counter()()
@@ -30,8 +31,8 @@ class SolaxBat:
     def update(self) -> None:
         log.MainLogger().debug("Komponente "+self.component_config["name"]+" auslesen.")
         with self.__tcp_client:
-            power = self.__tcp_client.read_input_registers(22, ModbusDataType.INT_16)
-            soc = self.__tcp_client.read_input_registers(28, ModbusDataType.UINT_16)
+            power = self.__tcp_client.read_input_registers(22, ModbusDataType.INT_16, unit=self.__modbus_id)
+            soc = self.__tcp_client.read_input_registers(28, ModbusDataType.UINT_16, unit=self.__modbus_id)
 
         topic_str = "openWB/set/system/device/" + str(
             self.__device_id)+"/component/"+str(self.component_config["id"])+"/"

--- a/packages/modules/solax/counter.py
+++ b/packages/modules/solax/counter.py
@@ -27,7 +27,8 @@ class SolaxCounter:
     def update(self):
         log.MainLogger().debug("Komponente "+self.component_config["name"]+" auslesen.")
         with self.__tcp_client:
-            power = self.__tcp_client.read_input_registers(70, ModbusDataType.INT_32, wordorder=Endian.Little, unit=self.__modbus_id) * -1
+            power = self.__tcp_client.read_input_registers(70, ModbusDataType.INT_32, wordorder=Endian.Little,
+                                                           unit=self.__modbus_id) * -1
             frequency = self.__tcp_client.read_input_registers(7, ModbusDataType.UINT_16, unit=self.__modbus_id) / 100
             try:
                 powers = [-value for value in self.__tcp_client.read_input_registers(

--- a/packages/modules/solax/counter.py
+++ b/packages/modules/solax/counter.py
@@ -17,8 +17,9 @@ def get_default_config() -> dict:
 
 
 class SolaxCounter:
-    def __init__(self, device_id: int, component_config: dict, tcp_client: modbus.ModbusClient) -> None:
+    def __init__(self, device_id: int, component_config: dict, tcp_client: modbus.ModbusClient, modbus_id: int) -> None:
         self.component_config = component_config
+        self.__modbus_id = modbus_id
         self.__tcp_client = tcp_client
         self.__store = get_counter_value_store(component_config["id"])
         self.component_info = ComponentInfo.from_component_config(component_config)
@@ -26,17 +27,17 @@ class SolaxCounter:
     def update(self):
         log.MainLogger().debug("Komponente "+self.component_config["name"]+" auslesen.")
         with self.__tcp_client:
-            power = self.__tcp_client.read_input_registers(70, ModbusDataType.INT_32, wordorder=Endian.Little) * -1
-            frequency = self.__tcp_client.read_input_registers(7, ModbusDataType.UINT_16) / 100
+            power = self.__tcp_client.read_input_registers(70, ModbusDataType.INT_32, wordorder=Endian.Little, unit=self.__modbus_id) * -1
+            frequency = self.__tcp_client.read_input_registers(7, ModbusDataType.UINT_16, unit=self.__modbus_id) / 100
             try:
                 powers = [-value for value in self.__tcp_client.read_input_registers(
-                    130, [ModbusDataType.INT_32] * 3, wordorder=Endian.Little
+                    130, [ModbusDataType.INT_32] * 3, wordorder=Endian.Little, unit=self.__modbus_id
                 )]
             except Exception:
                 powers = None
             exported, imported = [value * 10
                                   for value in self.__tcp_client.read_input_registers(
-                                      72, [ModbusDataType.UINT_32] * 2, wordorder=Endian.Little
+                                      72, [ModbusDataType.UINT_32] * 2, wordorder=Endian.Little, unit=self.__modbus_id
                                   )]
 
         counter_state = CounterState(

--- a/packages/modules/solax/device.py
+++ b/packages/modules/solax/device.py
@@ -43,7 +43,8 @@ class Device(AbstractDevice):
         component_type = component_config["type"]
         if component_type in self.COMPONENT_TYPE_TO_CLASS:
             self._components["component"+str(component_config["id"])] = (self.COMPONENT_TYPE_TO_CLASS[component_type](
-                self.device_config["id"], component_config, self.client,self.device_config["configuration"]["modbus_id"]))
+                self.device_config["id"], component_config, self.client,
+                self.device_config["configuration"]["modbus_id"]))
         else:
             raise Exception(
                 "illegal component type " + component_type + ". Allowed values: " +

--- a/packages/modules/solax/device.py
+++ b/packages/modules/solax/device.py
@@ -17,7 +17,8 @@ def get_default_config() -> dict:
         "type": "solax",
         "id": 0,
         "configuration": {
-            "ip_address": "192.168.193.15"
+            "ip_address": "192.168.193.15",
+            "modbus_id": 0
         }
     }
 
@@ -42,7 +43,7 @@ class Device(AbstractDevice):
         component_type = component_config["type"]
         if component_type in self.COMPONENT_TYPE_TO_CLASS:
             self._components["component"+str(component_config["id"])] = (self.COMPONENT_TYPE_TO_CLASS[component_type](
-                self.device_config["id"], component_config, self.client))
+                self.device_config["id"], component_config, self.client,self.device_config["configuration"]["modbus_id"]))
         else:
             raise Exception(
                 "illegal component type " + component_type + ". Allowed values: " +
@@ -62,7 +63,7 @@ class Device(AbstractDevice):
                 ": Es konnten keine Werte gelesen werden, da noch keine Komponenten konfiguriert wurden.")
 
 
-def read_legacy(component_type: str, ip_address: str, num: Optional[int] = None) -> None:
+def read_legacy(component_type: str, ip_address: str, modbus_id: int, num: Optional[int] = None) -> None:
     COMPONENT_TYPE_TO_MODULE = {
         "bat": bat,
         "counter": counter,
@@ -70,6 +71,7 @@ def read_legacy(component_type: str, ip_address: str, num: Optional[int] = None)
     }
     device_config = get_default_config()
     device_config["configuration"]["ip_address"] = ip_address
+    device_config["configuration"]["modbus_id"] = modbus_id
     dev = Device(device_config)
     if component_type in COMPONENT_TYPE_TO_MODULE:
         component_config = COMPONENT_TYPE_TO_MODULE[component_type].get_default_config()
@@ -82,6 +84,7 @@ def read_legacy(component_type: str, ip_address: str, num: Optional[int] = None)
     dev.add_component(component_config)
 
     log.MainLogger().debug('Solax IP-Adresse: ' + str(ip_address))
+    log.MainLogger().debug('Solax ID: ' + str(modbus_id))
 
     dev.update()
 

--- a/packages/modules/solax/inverter.py
+++ b/packages/modules/solax/inverter.py
@@ -30,7 +30,8 @@ class SolaxInverter:
         with self.__tcp_client:
             power_temp = self.__tcp_client.read_input_registers(10, [ModbusDataType.UINT_16] * 2, unit=self.__modbus_id)
             power = sum(power_temp) * -1
-            counter = self.__tcp_client.read_input_registers(82, ModbusDataType.UINT_32, wordorder=Endian.Little, unit=self.__modbus_id) * 100
+            counter = self.__tcp_client.read_input_registers(82, ModbusDataType.UINT_32, wordorder=Endian.Little,
+                                                             unit=self.__modbus_id) * 100
 
         inverter_state = InverterState(
             power=power,

--- a/packages/modules/solax/inverter.py
+++ b/packages/modules/solax/inverter.py
@@ -18,8 +18,9 @@ def get_default_config() -> dict:
 
 
 class SolaxInverter:
-    def __init__(self, device_id: int, component_config: dict, tcp_client: modbus.ModbusClient) -> None:
+    def __init__(self, device_id: int, component_config: dict, tcp_client: modbus.ModbusClient, modbus_id: int) -> None:
         self.component_config = component_config
+        self.__modbus_id = modbus_id
         self.__tcp_client = tcp_client
         self.__store = get_inverter_value_store(component_config["id"])
         self.component_info = ComponentInfo.from_component_config(component_config)
@@ -27,9 +28,9 @@ class SolaxInverter:
     def update(self) -> None:
         log.MainLogger().debug("Komponente "+self.component_config["name"]+" auslesen.")
         with self.__tcp_client:
-            power_temp = self.__tcp_client.read_input_registers(10, [ModbusDataType.UINT_16] * 2)
+            power_temp = self.__tcp_client.read_input_registers(10, [ModbusDataType.UINT_16] * 2, unit=self.__modbus_id)
             power = sum(power_temp) * -1
-            counter = self.__tcp_client.read_input_registers(82, ModbusDataType.UINT_32, wordorder=Endian.Little) * 100
+            counter = self.__tcp_client.read_input_registers(82, ModbusDataType.UINT_32, wordorder=Endian.Little, unit=self.__modbus_id) * 100
 
         inverter_state = InverterState(
             power=power,

--- a/web/settings/modulconfigpv.php
+++ b/web/settings/modulconfigpv.php
@@ -716,16 +716,7 @@
 								<div class="col">
 									<input class="form-control" type="text" pattern="^((\d{1,2}|1\d\d|2[0-4]\d|25[0-5])\.){3}(\d{1,2}|1\d\d|2[0-4]\d|25[0-5])$" name="solaxip" id="solaxip" value="<?php echo $solaxipold ?>">
 									<span class="form-text small">
-										Gültige Werte: IPs. IP Adresse des Solax Wechselrichters.
-									</span>
-								</div>
-							</div>
-							<div class="form-row mb-1">
-								<label for="pv1_ida" class="col-md-4 col-form-label">ID </label>
-								<div class="col">
-									<input class="form-control" type="text" name="pv1_ida" id="pv1_ida" value="<?php echo $pv1_idaold ?>">
-									<span class="form-text small">
-										Gültige Werte Id als Zahl. Für Gen3 0 eintragen für Gen4 ID vom WR eintragen (meistens 1)
+										Gültige Werte: IPs. IP Adresse des Solax Wechselrichters. Für Gen3 0 bei ID eintragen für Gen4 ID vom WR eintragen (meistens > 2)
 									</span>
 								</div>
 							</div>
@@ -1022,6 +1013,7 @@
 								}
 								if($('#pvwattmodul').val() == 'wr_solax') {
 									showSection('#pvwrsolax');
+									showSection('#pvid');									
 								}
 								if($('#pvwattmodul').val() == 'wr_smartme') {
 									showSection('#pvsmartme');

--- a/web/settings/modulconfigpv.php
+++ b/web/settings/modulconfigpv.php
@@ -603,7 +603,7 @@
 										</label>
 									</div>
 									<span class="form-text small">
-										Diese Option nur aktivieren, wenn ein weiteres Solaredge SmartMeter verbaut ist, welches z.B. die Leistung einer vorhandenen Bestands-PV-Anlage erfasst, 
+										Diese Option nur aktivieren, wenn ein weiteres Solaredge SmartMeter verbaut ist, welches z.B. die Leistung einer vorhandenen Bestands-PV-Anlage erfasst,
 										so dass diese dem WR hinzuaddiert wird.
 										Dieses zusätzliche SmartMeter muss dann als "Zähler 2" / "Position 2" im WR-Konfiguratioonsmenü konfiguriert sein.
 									</span>
@@ -717,6 +717,15 @@
 									<input class="form-control" type="text" pattern="^((\d{1,2}|1\d\d|2[0-4]\d|25[0-5])\.){3}(\d{1,2}|1\d\d|2[0-4]\d|25[0-5])$" name="solaxip" id="solaxip" value="<?php echo $solaxipold ?>">
 									<span class="form-text small">
 										Gültige Werte: IPs. IP Adresse des Solax Wechselrichters.
+									</span>
+								</div>
+							</div>
+							<div class="form-row mb-1">
+								<label for="pv1_ida" class="col-md-4 col-form-label">ID </label>
+								<div class="col">
+									<input class="form-control" type="text" name="pv1_ida" id="pv1_ida" value="<?php echo $pv1_idaold ?>">
+									<span class="form-text small">
+										Gültige Werte Id als Zahl. Für Gen3 0 eintragen für Gen4 ID vom WR eintragen (meistens 1)
 									</span>
 								</div>
 							</div>
@@ -1346,7 +1355,7 @@
 								}
 								if($('#pv2wattmodul').val() == 'wr2_shelly') {
 									showSection('#pv2ipdiv');
-								}								
+								}
 							}
 							$(function() {
 								display_pv2wattmodul();


### PR DESCRIPTION
Solax gen4
Bestehnden Solax gen3 Treiber angepasst. Als zusätzliches Eingabefeld wird neu Modbus ID verlangt. Gen4 verlangt hier ein Wert, gen3 sollte mit 0 laufen