### PR TITLE
smartmq

### DIFF
--- a/runs/mqttsub.py
+++ b/runs/mqttsub.py
@@ -407,6 +407,13 @@ def on_message(client, userdata, msg):
                     client.publish("openWB/config/get/SmartHome/Devices/"+str(devicenumb)+"/device_standbyPower", msg.payload.decode("utf-8"), qos=0, retain=True)
                 else:
                     print( "invalid payload for topic '" + msg.topic + "': " + msg.payload.decode("utf-8"))
+            if (( "openWB/config/set/SmartHome/Device" in msg.topic) and ("device_nonewatt" in msg.topic)):
+                devicenumb=re.sub(r'\D', '', msg.topic)
+                if ( 1 <= int(devicenumb) <= numberOfSupportedDevices and 0 <= int(msg.payload) <= 10000 ):
+                    writetoconfig(shconfigfile,'smarthomedevices','device_nonewatt_'+str(devicenumb), msg.payload.decode("utf-8"))
+                    client.publish("openWB/config/get/SmartHome/Devices/"+str(devicenumb)+"/device_nonewatt", msg.payload.decode("utf-8"), qos=0, retain=True)
+                else:
+                    print( "invalid payload for topic '" + msg.topic + "': " + msg.payload.decode("utf-8"))
             if (( "openWB/config/set/SmartHome/Device" in msg.topic) and ("device_standbyDuration" in msg.topic)):
                 devicenumb=re.sub(r'\D', '', msg.topic)
                 if ( 1 <= int(devicenumb) <= numberOfSupportedDevices and 0 <= int(msg.payload) <= 86400 ):

--- a/runs/usmarthome/smartbase.py
+++ b/runs/usmarthome/smartbase.py
@@ -12,27 +12,26 @@ class Sbase0:
     _prefixpy = _basePath+'/modules/smarthome/'
 
     def logClass(self, level, msg):
-        if (int(level) >= 2):
+        if (int(level) >= 0):
             local_time = datetime.now(timezone.utc).astimezone()
-            file = open('/var/www/html/openWB/ramdisk/smarthome.log',
-                        'a', encoding='utf8')
-            if (int(level) == 0):
-                file.write(local_time.strftime(format="%Y-%m-%d %H:%M:%S")
-                           + '-: ' + str(msg) + '\n')
-            if (int(level) == 1):
-                file.write(local_time.strftime(format="%Y-%m-%d %H:%M:%S")
-                           + '-: ' + str(msg) + '\n')
-            if (int(level) == 2):
-                file.write(local_time.strftime(format="%Y-%m-%d %H:%M:%S")
-                           + '-: ' + str(msg) + '\n')
-            file.close
+            with open(self._basePath+'/ramdisk/smarthome.log', 'a',
+                      encoding='utf8', buffering=1) as file:
+                if (int(level) == 0):
+                    file.write(local_time.strftime(format="%Y-%m-%d %H:%M:%S")
+                               + '-: ' + str(msg) + '\n')
+                if (int(level) == 1):
+                    file.write(local_time.strftime(format="%Y-%m-%d %H:%M:%S")
+                               + '-: ' + str(msg) + '\n')
+                if (int(level) == 2):
+                    file.write(local_time.strftime(format="%Y-%m-%d %H:%M:%S")
+                               + '-: ' + str(msg) + '\n')
 
     def readret(self):
         with open(self._basePath+'/ramdisk/smarthome_device_ret' +
                   str(self.device_nummer), 'r') as f1:
             answer = json.loads(json.load(f1))
         return answer
-        
+
 
 class Slbase(Sbase0):
     def __init__(self):
@@ -60,6 +59,7 @@ class Slbase(Sbase0):
         self._device_measuresmaser = '123'
         self._device_measuresmaage = 15
         self._device_leistungurl = 'none'
+        self._device_stateurl = 'none'
         self._device_measureurl = 'none'
         self._device_measureurlc = 'none'
         self._device_measurejsonurl = 'none'
@@ -146,6 +146,8 @@ class Slbase(Sbase0):
                 self._device_username = value
             elif (key == 'device_password'):
                 self._device_password = value
+            elif (key == 'device_stateurl'):
+                self._device_stateurl = value
             else:
                 self.logClass(2, "(" + str(self.device_nummer) + ") "
                               + __class__.__name__ + " überlesen " + key +
@@ -153,7 +155,6 @@ class Slbase(Sbase0):
 
     def __del__(self):
         print('__del__ Slbase executed ')
-
 
 
 class Slmqtt(Slbase):
@@ -176,11 +177,7 @@ class Slmqtt(Slbase):
         try:
             proc = subprocess.Popen(argumentList)
             proc.communicate()
-            f1 = open(self._basePath+'/ramdisk/smarthome_device_ret' +
-                      str(self.device_nummer), 'r')
-            answerj = json.load(f1)
-            f1.close()
-            answer = json.loads(answerj)
+            answer = self.readret()
             self.newwatt = int(answer['power'])
             self.newwattk = int(answer['powerc'])
             self.relais = int(answer['on'])
@@ -207,28 +204,31 @@ class Slshelly(Slbase):
                         str(self.device_nummer), str(ip), '0']
         try:
             proc = subprocess.Popen(argumentList)
-            proc.communicate()    
-            answer = self.readret()    
+            proc.communicate()
+            answer = self.readret()
             self.newwatt = int(answer['power'])
             self.newwattk = int(answer['powerc'])
             self.relais = int(answer['on'])
             if (self.device_temperatur_configured > 0):
                 self.temp0 = str(answer['temp0'])
-                f = open(self._basePath+'/ramdisk/device' + str(self.device_nummer) + '_temp0', 'w')
+                f = open(self._basePath+'/ramdisk/device' +
+                         str(self.device_nummer) + '_temp0', 'w')
                 f.write(str(self.temp0))
                 f.close()
             else:
                 self.temp0 = '300'
             if (self.device_temperatur_configured > 1):
                 self.temp1 = str(answer['temp1'])
-                f = open(self._basePath+'/ramdisk/device' + str(self.device_nummer) + '_temp1', 'w')
+                f = open(self._basePath+'/ramdisk/device' +
+                         str(self.device_nummer) + '_temp1', 'w')
                 f.write(str(self.temp1))
                 f.close()
             else:
                 self.temp1 = '300'
             if (self.device_temperatur_configured > 2):
                 self.temp2 = str(answer['temp2'])
-                f = open(self._basePath+'/ramdisk/device' + str(self.device_nummer) + '_temp2', 'w')
+                f = open(self._basePath+'/ramdisk/device' +
+                         str(self.device_nummer) + '_temp2', 'w')
                 f.write(str(self.temp2))
                 f.close()
             else:
@@ -265,11 +265,7 @@ class Slavm(Slbase):
         try:
             proc = subprocess.Popen(argumentList)
             proc.communicate()
-            f1 = open(self._basePath+'/ramdisk/smarthome_device_ret' +
-                      str(self.device_nummer), 'r')
-            answerj = json.load(f1)
-            f1.close()
-            answer = json.loads(answerj)
+            answer = self.readret()
             self.newwatt = int(answer['power'])
             self.newwattk = int(answer['powerc'])
             self.relais = int(answer['on'])
@@ -297,11 +293,7 @@ class Sltasmota(Slbase):
         try:
             proc = subprocess.Popen(argumentList)
             proc.communicate()
-            f1 = open(self._basePath+'/ramdisk/smarthome_device_ret' +
-                      str(self.device_nummer), 'r')
-            answerj = json.load(f1)
-            f1.close()
-            answer = json.loads(answerj)
+            answer = self.readret()
             self.newwatt = int(answer['power'])
             self.newwattk = int(answer['powerc'])
             self.relais = int(answer['on'])
@@ -317,24 +309,25 @@ class Slhttp(Slbase):
         print('__init__ Slhttp excuted')
 
     def getwattread(self):
-        self._watt(self._device_leistungurl, 'none')
+        self._watt(self._device_leistungurl, 'none',
+                   self._device_stateurl)
 
     def sepwattread(self):
-        self._watt(self._device_measureurl, self._device_measureurlc)
+        self._watt(self._device_measureurl, self._device_measureurlc,
+                   'none')
         return self.newwatt, self.newwattk
 
-    def _watt(self, url, urlc):
+    def _watt(self, url, urlc, urls):
         argumentList = ['python3', self._prefixpy + 'http/watt.py',
-                        str(self.device_nummer), '0', str(self.devuberschuss),
-                        url, urlc]
+                        str(self.device_nummer), '0',
+                        str(self.devuberschuss), url, urlc,
+                        '0', '0', urls]
+        proc = subprocess.Popen(argumentList)
+        proc.communicate()
         try:
             proc = subprocess.Popen(argumentList)
             proc.communicate()
-            f1 = open(self._basePath+'/ramdisk/smarthome_device_ret' +
-                      str(self.device_nummer), 'r')
-            answerj = json.load(f1)
-            f1.close()
-            answer = json.loads(answerj)
+            answer = self.readret()
             self.newwatt = int(answer['power'])
             self.newwattk = int(answer['powerc'])
             self.relais = int(answer['on'])
@@ -368,7 +361,8 @@ class Slmystrom(Slbase):
             self.relais = int(answer['on'])
             if (self.device_temperatur_configured > 0):
                 self.temp0 = str(answer['temp0'])
-                f = open(self._basePath+'/ramdisk/device' + str(self.device_nummer) + '_temp0', 'w')
+                f = open(self._basePath+'/ramdisk/device' +
+                         str(self.device_nummer) + '_temp0', 'w')
                 f.write(str(self.temp0))
                 f.close()
             else:
@@ -392,11 +386,7 @@ class Slsmaem(Slbase):
         try:
             proc = subprocess.Popen(argumentList)
             proc.communicate()
-            f1 = open(self._basePath+'/ramdisk/smarthome_device_ret' +
-                      str(self.device_nummer), 'r')
-            answerj = json.load(f1)
-            f1.close()
-            answer = json.loads(answerj)
+            answer = self.readret()
             self.newwatt = int(answer['power'])
             self.newwattk = int(answer['powerc'])
         except Exception as e1:
@@ -419,11 +409,7 @@ class Slwe514(Slbase):
         try:
             proc = subprocess.Popen(argumentList)
             proc.communicate()
-            f1 = open(self._basePath+'/ramdisk/smarthome_device_ret' +
-                      str(self.device_nummer), 'r')
-            answerj = json.load(f1)
-            f1.close()
-            answer = json.loads(answerj)
+            answer = self.readret()
             self.newwatt = int(answer['power'])
             self.newwattk = int(answer['powerc'])
         except Exception as e1:
@@ -448,11 +434,7 @@ class Sljson(Slbase):
         try:
             proc = subprocess.Popen(argumentList)
             proc.communicate()
-            f1 = open(self._basePath+'/ramdisk/smarthome_device_ret' +
-                      str(self.device_nummer), 'r')
-            answerj = json.load(f1)
-            f1.close()
-            answer = json.loads(answerj)
+            answer = self.readret()
             self.newwatt = int(answer['power'])
             self.newwattk = int(answer['powerc'])
         except Exception as e1:
@@ -474,11 +456,7 @@ class Slfronius(Slbase):
         try:
             proc = subprocess.Popen(argumentList)
             proc.communicate()
-            f1 = open(self._basePath+'/ramdisk/smarthome_device_ret' +
-                      str(self.device_nummer), 'r')
-            answerj = json.load(f1)
-            f1.close()
-            answer = json.loads(answerj)
+            answer = self.readret()
             self.newwatt = int(answer['power'])
             self.newwattk = int(answer['powerc'])
         except Exception as e1:
@@ -502,15 +480,7 @@ class Slsdm630(Slbase):
         try:
             proc = subprocess.Popen(argumentList)
             proc.communicate()
-            # with open(self._basePath+'/ramdisk/smarthome_device_ret' +
-            #          str(self.device_nummer), 'r') as f1:
-            #    answer = json.loads(json.load(f1))
             answer = self.readret()
-            #f1 = open(self._basePath+'/ramdisk/smarthome_device_ret' +
-            #          str(self.device_nummer), 'r')
-            #answerj = json.load(f1)
-            #f1.close()
-            #answer = json.loads(answerj)
             self.newwatt = int(answer['power'])
             self.newwattk = int(answer['powerc'])
         except Exception as e1:
@@ -534,11 +504,7 @@ class Slsdm120(Slbase):
         try:
             proc = subprocess.Popen(argumentList)
             proc.communicate()
-            f1 = open(self._basePath+'/ramdisk/smarthome_device_ret' +
-                      str(self.device_nummer), 'r')
-            answerj = json.load(f1)
-            f1.close()
-            answer = json.loads(answerj)
+            answer = self.readret()
             self.newwatt = int(answer['power'])
             self.newwattk = int(answer['powerc'])
         except Exception as e1:
@@ -605,7 +571,7 @@ class Sbase(Sbase0):
         self._device_endtime = '00:00'
         self._device_ontime = '00:00'
         self._device_onuntiltime = '00:00'
-
+        self._device_nonewatt = 0
         self.device_manual_control = 0
 
         self._oldrelais = '2'
@@ -633,7 +599,6 @@ class Sbase(Sbase0):
         self._c_ausverz_f = 'N'
         self._c_einverz = 0
         self._c_einverz_f = 'N'
-
 
     def __del__(self):
 
@@ -669,7 +634,8 @@ class Sbase(Sbase0):
         (self.newwatt, self.newwattk) = self.sepwatt(self.newwatt,
                                                      self.newwattk)
         # bei reiner Leistungsmessung relais nur nach Watt setzten
-        if (self.newwatt > 1) and (self.device_type == 'none'):
+        if ((self.newwatt > self._device_nonewatt)
+           and (self.device_type == 'none')):
             self.relais = 1
         # bei laufender Anlauferkennung deivce nicht aktiv setzten
         if (self.relais == 1) and (self.devstatus != 20):
@@ -817,6 +783,8 @@ class Sbase(Sbase0):
                 self._device_einschaltverzoegerung = valueint * 60
             elif (key == 'device_ausschaltverzoegerung'):
                 self._device_ausschaltverzoegerung = valueint * 60
+            elif (key == 'device_nonewatt'):
+                self._device_nonewatt = valueint
             elif (key == 'device_type'):
                 self.device_type = value
             elif (key == 'device_configured'):

--- a/web/settings/smarthomeconfig.php
+++ b/web/settings/smarthomeconfig.php
@@ -157,6 +157,16 @@ $numDevices = 9;
 									</div>
 								</div>
 							</div>
+							<div class="device<?php echo $devicenum; ?>-option device<?php echo $devicenum; ?>-option-none hide">
+								<hr class="border-secondary">
+								<div class="form-row mb-1">
+									<label for="device_nonewattDevices<?php echo $devicenum; ?>" class="col-md-4 col-form-label">Separate Leistungsaufnahme in Watt</label>
+									<div class="col">
+										<input id="device_nonewattDevices<?php echo $devicenum; ?>" name="device_nonewatt" class="form-control naturalNumber" type="number" inputmode="decimal" required min="0" max="10000" data-default="0" value="0" data-topicprefix="openWB/config/get/SmartHome/" data-topicsubgroup="Devices/<?php echo $devicenum; ?>/">
+										<span class="form-text small">Wenn separate Leistungsaufnahme in Watt kleiner/gleich ist, wird das Gerät als ausgeschaltet (rot) gezeigt, anderenfalls grün .</span>
+									</div>
+								</div>
+							</div>
 							<div class="device<?php echo $devicenum; ?>-option device<?php echo $devicenum; ?>-option-shelly device<?php echo $devicenum; ?>-option-tasmota device<?php echo $devicenum; ?>-option-acthor device<?php echo $devicenum; ?>-option-elwa device<?php echo $devicenum; ?>-option-idm device<?php echo $devicenum; ?>-option-stiebel device<?php echo $devicenum; ?>-option-avm device<?php echo $devicenum; ?>-option-mystrom device<?php echo $devicenum; ?>-option-viessmann device<?php echo $devicenum; ?>-option-pyt hide">
 								<hr class="border-secondary">
 								<div class="form-row mb-1">
@@ -215,7 +225,7 @@ $numDevices = 9;
 											<input id="device_stateurlDevices<?php echo $devicenum; ?>" name="device_stateurl" class="form-control" type="text" data-default="" value="" data-topicprefix="openWB/config/get/SmartHome/" data-topicsubgroup="Devices/<?php echo $devicenum; ?>/">
 											<span class="form-text small">
 												Die hier angegebene URL wird aufgerufen, um den aktuellen Status (1 = an, 0 = aus) des Geräts zu erhalten. <br>
-												Der Parameter ist optional und kann somit auch leer gelassen werden. In diesem Fall wird der Parameter mit "none" vorbelegt und 
+												Der Parameter ist optional und kann somit auch leer gelassen werden. In diesem Fall wird der Parameter mit "none" vorbelegt und
                                                                                                 die Erkennung, ob das Gerät angeschaltet ist, wird weiterhin über die Leistung ermittelt. <br>
 											</span>
 										</div>
@@ -232,7 +242,7 @@ $numDevices = 9;
 												<option value="M1" data-option="M1">Acthor M1</option>
 												<option value="M3" data-option="M3">Acthor M3</option>
 												<option value="9s" data-option="9s">Acthor 9s</option>
-												<option value="9s18" data-option="9s18">Acthor 9s Dual 18k</option>												
+												<option value="9s18" data-option="9s18">Acthor 9s Dual 18k</option>
 											</select>
 											<span class="form-text small">
 												Hier ist das installierte Modell auszuwählen.

--- a/web/settings/topicsToSubscribe_smarthomeconfig.js
+++ b/web/settings/topicsToSubscribe_smarthomeconfig.js
@@ -63,6 +63,7 @@ var topicsToSubscribe = [
 	["openWB/config/get/SmartHome/Devices/+/device_measuresmaser", 0],
 	["openWB/config/get/SmartHome/Devices/+/device_onTime", 0],
 	["openWB/config/get/SmartHome/Devices/+/device_onuntilTime", 0],
+  ["openWB/config/get/SmartHome/Devices/+/device_nonewatt", 0],
 	["openWB/config/get/SmartHome/Devices/+/device_measuresmaage", 0]
 
 ];


### PR DESCRIPTION
- Weitere fileopen auf neuen Syntax umgestellt
- PR#1743 nachgezogen
Bei Kein Gerät kann die Schwelle, wann separate Leistungsmessung als an oder aus angezeigt wird parametrisiert werden