### PR TITLE
soc_vwid: change level for idle log entries from 0 to 2

### DIFF
--- a/modules/soc_vwid/main.sh
+++ b/modules/soc_vwid/main.sh
@@ -89,14 +89,14 @@ getAndWriteSoc(){
 soctimer=$(<$soctimerfile)
 if (( ladeleistung > 500 )); then
 	if (( soctimer < intervallladen )); then
-		openwbDebugLog ${DMOD} 0 "Lp$CHARGEPOINT: Charging, but nothing to do yet. Incrementing timer."
+		openwbDebugLog ${DMOD} 2 "Lp$CHARGEPOINT: Charging, but nothing to do yet. Incrementing timer."
 		incrementTimer
 	else
 		getAndWriteSoc
 	fi
 else
 	if (( soctimer < intervall )); then
-		openwbDebugLog ${DMOD} 0 "Lp$CHARGEPOINT: Nothing to do yet. Incrementing timer."
+		openwbDebugLog ${DMOD} 2 "Lp$CHARGEPOINT: Nothing to do yet. Incrementing timer."
 		incrementTimer
 
 	else


### PR DESCRIPTION
Avoid recording normally useless idle messages in EV-SOC log.
This will show a much longer history of SOC request cycles.
In debug level 2 idle log entries will still be recorded.