### PR TITLE
Bugfix

### DIFF
--- a/processautolock.sh
+++ b/processautolock.sh
@@ -177,7 +177,7 @@ do
 		elif [ $timeOfDay = "$unlockTime" ] && [ $statusFlag != "3" ]; then
 			# charge point not waiting for lock and not already unlocked
 			# but unlock time is now, so enable charge point
-			mqttTopic="openWB/set/lp$chargePoint/ChargePointEnabled"
+			mqttTopic="openWB/set/lp/$chargePoint/ChargePointEnabled"
 			mosquitto_pub -r -t $mqttTopic -m 1
 			# and set flag "auto-unlock performed"
 			mqttTopic="openWB/set/lp/$chargePoint/AutolockStatus"

--- a/rfidtag.sh
+++ b/rfidtag.sh
@@ -115,7 +115,7 @@ rfid() {
 					for ((currentCp=1; currentCp<=InstalledChargePoints; currentCp++)); do
 						if [[ "${lpsPlugStat[$currentCp]}" -ne "1" ]]; then
 							openwbDebugLog "MAIN" 0 "Disabling CP #${currentCp} as it's still unplugged after timeout of RFID tag scan has been exceeded"
-							mosquitto_pub -r -q 2 -t "openWB/set/lp${currentCp}/ChargePointEnabled" -m "0"
+							mosquitto_pub -r -q 2 -t "openWB/set/lp/${currentCp}/ChargePointEnabled" -m "0"
 							eval lp${currentCp}enabled=0
 						fi
 					done
@@ -339,7 +339,7 @@ checkTagValidAndSetStartScanData() {
 			local tagScanInfo="$NowItIs,$lasttag,1"
 			echo "$tagScanInfo" > "ramdisk/tagScanInfoLp${chargePoint}"
 			mosquitto_pub -r -q 2 -t "openWB/lp/${chargePoint}/tagScanInfo" -m "$tagScanInfo"
-			mosquitto_pub -r -q 2 -t "openWB/set/lp${chargePoint}/ChargePointEnabled" -m "1"
+			mosquitto_pub -r -q 2 -t "openWB/set/lp/${chargePoint}/ChargePointEnabled" -m "1"
 
 			eval lp${chargePoint}enabled=1
 			openwbDebugLog "MAIN" 0 "Start waiting for ${MaximumSecondsAfterRfidScanToAssignCp} seconds for CP #${chargePoint} to get plugged in after RFID scan of '$lasttag' @ meter value $llkwh (justPlugged == ${pluggedLps[$chargePoint]})"

--- a/runs/rfid/rfidDaemon.py
+++ b/runs/rfid/rfidDaemon.py
@@ -103,7 +103,7 @@ def conditions():
                     if (str(tag) == str(Values["lastscannedtag"])):
                         log_debug(1, "Schalte Ladepunkt: " + str(Values["lastpluggedlp"]) + " frei")
                         write_to_ramdisk("lp" + str(Values["lastpluggedlp"]) + "enabled", "1")
-                        write_to_ramdisk("rfidlp" + str(Values["lastpluggedlp"]), "1")
+                        write_to_ramdisk("rfidlp" + str(Values["lastpluggedlp"]), str(Values["lastscannedtag"]))
                         log_debug(1, "Schreibe Tag: " + str(Values["lastscannedtag"]) + " zu Ladepunkt")
                         Values.update({'lastpluggedlp': "0"})
                         write_to_ramdisk("readtag", "0")

--- a/runs/rfid/rfidDaemon.py
+++ b/runs/rfid/rfidDaemon.py
@@ -9,6 +9,7 @@ logFilename = ramdiskPath + "/rfid.log"
 
 loglevel = 1
 counter = 0
+null_tag_value = "0"
 rfid_list = []
 Values = {
     'newplugstatlp1': str(0),
@@ -98,7 +99,7 @@ def conditions():
         log_debug(0, str(Values["lastpluggedlp"]) + "prüfe auf rfid scan")
         try:
             Values.update({'lastscannedtag': str(read_from_ramdisk("readtag").rstrip())})
-            if (Values["lastscannedtag"] != "0"):
+            if (Values["lastscannedtag"] != null_tag_value):
                 for tag in rfid_list:
                     if (str(tag) == str(Values["lastscannedtag"])):
                         log_debug(1, "Schalte Ladepunkt: " + str(Values["lastpluggedlp"]) + " frei")
@@ -106,7 +107,7 @@ def conditions():
                         write_to_ramdisk("rfidlp" + str(Values["lastpluggedlp"]), str(Values["lastscannedtag"]))
                         log_debug(1, "Schreibe Tag: " + str(Values["lastscannedtag"]) + " zu Ladepunkt")
                         Values.update({'lastpluggedlp': "0"})
-                        write_to_ramdisk("readtag", "0")
+                        write_to_ramdisk("readtag", null_tag_value)
         except Exception as e:
             log_debug(1, str(e))
             pass
@@ -121,7 +122,6 @@ def save_last_rfidtag():
 
 
 def clear_old_rfidtag():
-    null_tag_value = "0"
     null_tag = False
     null_tag = bool(str(read_from_ramdisk("readtag").rstrip()) == null_tag_value)
     if null_tag is False:


### PR DESCRIPTION
- fix missing "/" in topic `openWB/set/lp/X/ChargePointEnabled` (processautolock.sh, rfidtag.sh)
- fix rfid tag for accounting in mode 2
- move rfid tag for "empty" into global var (rfidDaemon.py)