### PR TITLE
U1p3p switch in background

### DIFF
--- a/regel.sh
+++ b/regel.sh
@@ -233,13 +233,23 @@ fi
 evsedintest
 
 #u1p3p switch
-u1p3pswitch
+u1p3pswitch &
 
 #hooks - externe geraete
 hook
 
 #Graphing
 graphing
+
+# second check for blockall
+# may be set from our call to u1p3pswitch
+if (( u1p3paktiv == 1 )); then
+	blockall=$(<"${RAMDISKDIR}/blockall")
+	if (( blockall == 1 )); then
+		openwbDebugLog "MAIN" 1 "Phasen Umschaltung aktiv... beende"
+		exit 0
+	fi
+fi
 
 if (( cpunterbrechunglp1 == 1 )); then
 	if (( plugstat == 1 )) && (( lp1enabled == 1 )); then

--- a/u1p3p.sh
+++ b/u1p3p.sh
@@ -19,22 +19,26 @@ u1p3pswitch() {
 			if ((nachtladenstate == 1)) || ((nachtladen2state == 1)) || ((nachtladenstates1 == 1)) || ((nachtladen2states1 == 1)); then
 				if ((u1p3pstat != u1p3pnl)); then
 					openwbDebugLog "MAIN" 1 "Nachtladen derzeit $u1p3pstat Phasen, auf $u1p3pnl konfiguriert, aendere..."
+					echo 1 >"${RAMDISKDIR}/blockall"
 					if ((u1p3pnl == 3)); then
 						runs/u1p3pcheck.sh 3
 					else
 						runs/u1p3pcheck.sh 1
 					fi
+					echo 0 > "${RAMDISKDIR}/blockall"
 					openwbDebugLog "MAIN" 1 "auf $u1p3pnl Phasen geaendert"
 				fi
 			else
 				if ((lademodus == 0)); then
 					if ((u1p3pstat != u1p3psofort)); then
 						openwbDebugLog "MAIN" 1 "Sofortladen derzeit $u1p3pstat Phasen, auf $u1p3psofort konfiguriert, aendere..."
+						echo 1 >"${RAMDISKDIR}/blockall"
 						if ((u1p3psofort == 3)); then
 							runs/u1p3pcheck.sh 3
 						else
 							runs/u1p3pcheck.sh 1
 						fi
+						echo 0 > "${RAMDISKDIR}/blockall"
 						openwbDebugLog "MAIN" 1 "auf $u1p3psofort Phasen geaendert"
 					fi
 				fi
@@ -42,7 +46,9 @@ u1p3pswitch() {
 					if ((u1p3pstat != u1p3pminundpv)); then
 						if ((u1p3pminundpv == 4)); then
 							if ((u1p3pstat == 0)); then
+								echo 1 >"${RAMDISKDIR}/blockall"
 								runs/u1p3pcheck.sh 1
+								echo 0 >"${RAMDISKDIR}/blockall"
 							fi
 							if ((u1p3pstat == 3)); then
 								urcounter=$(<"${RAMDISKDIR}/urcounter")
@@ -53,18 +59,22 @@ u1p3pswitch() {
 									urcounter=$((urcounter + 10))
 									echo $urcounter >"${RAMDISKDIR}/urcounter"
 								else
-									runs/u1p3pcheck.sh 1
 									openwbDebugLog "MAIN" 1 "Min PV Laden derzeit $u1p3pstat Phasen, auf 1 Nur PV konfiguriert, aendere..."
-									echo 0 >/var/www/html/openWB/ramdisk/urcounter
+									echo 1 >"${RAMDISKDIR}/blockall"
+									runs/u1p3pcheck.sh 1
+									echo 0 >"${RAMDISKDIR}/blockall"
+									echo 0 >"${RAMDISKDIR}/urcounter"
 								fi
 							fi
 						else
 							openwbDebugLog "MAIN" 1 "Min PV Laden derzeit $u1p3pstat Phasen, auf $u1p3pminundpv konfiguriert, aendere..."
+							echo 1 > "${RAMDISKDIR}/blockall"
 							if ((u1p3pnurpv == 3)); then
 								runs/u1p3pcheck.sh 3
 							else
 								runs/u1p3pcheck.sh 1
 							fi
+							echo 0 >"${RAMDISKDIR}/blockall"
 							openwbDebugLog "MAIN" 1 "auf $u1p3pminundpv Phasen geaendert"
 						fi
 					fi
@@ -73,7 +83,9 @@ u1p3pswitch() {
 					if ((u1p3pstat != u1p3pnurpv)); then
 						if ((u1p3pnurpv == 4)); then
 							if ((u1p3pstat == 0)); then
+								echo 1 >"${RAMDISKDIR}/blockall"
 								runs/u1p3pcheck.sh 1
+								echo 0 >"${RAMDISKDIR}/blockall"
 							fi
 							if ((u1p3pstat == 3)); then
 								urcounter=$(<"${RAMDISKDIR}/urcounter")
@@ -84,18 +96,22 @@ u1p3pswitch() {
 									urcounter=$((urcounter + 10))
 									echo $urcounter >"${RAMDISKDIR}/urcounter"
 								else
-									runs/u1p3pcheck.sh 1
 									openwbDebugLog "MAIN" 1 "Nur PV Laden derzeit $u1p3pstat Phasen, auf 1 Nur PV konfiguriert, aendere..."
-									echo 0 >/var/www/html/openWB/ramdisk/urcounter
+									echo 1 >"${RAMDISKDIR}/blockall"
+									runs/u1p3pcheck.sh 1
+									echo 0 >"${RAMDISKDIR}/blockall"
+									echo 0 >"${RAMDISKDIR}/urcounter"
 								fi
 							fi
 						else
 							openwbDebugLog "MAIN" 1 "Nur PV Laden derzeit $u1p3pstat Phasen, auf $u1p3pnurpv konfiguriert, aendere..."
+							echo 1 >"${RAMDISKDIR}/blockall"
 							if ((u1p3pnurpv == 3)); then
 								runs/u1p3pcheck.sh 3
 							else
 								runs/u1p3pcheck.sh 1
 							fi
+							echo 0 >"${RAMDISKDIR}/blockall"
 							openwbDebugLog "MAIN" 1 "auf $u1p3pnurpv Phasen geaendert"
 						fi
 					fi
@@ -103,22 +119,26 @@ u1p3pswitch() {
 				if ((lademodus == 4)); then
 					if ((u1p3pstat != u1p3pstandby)); then
 						openwbDebugLog "MAIN" 1 "Standby Laden derzeit $u1p3pstat Phasen, auf $u1p3pstandby konfiguriert, aendere..."
+						echo 1 >"${RAMDISKDIR}/blockall"
 						if ((u1p3pstandby == 3)); then
 							runs/u1p3pcheck.sh 3
 						else
 							runs/u1p3pcheck.sh 1
 						fi
+						echo 0 >"${RAMDISKDIR}/blockall"
 						openwbDebugLog "MAIN" 1 "auf $u1p3pstandby Phasen geaendert"
 					fi
 				fi
 				if ((lademodus == 3)); then
 					if ((u1p3pstat != u1p3pstandby)); then
 						openwbDebugLog "MAIN" 1 "Stop Laden derzeit $u1p3pstat Phasen, auf $u1p3pstandby konfiguriert, aendere..."
+						echo 1 >"${RAMDISKDIR}/blockall"
 						if ((u1p3pstandby == 3)); then
 							runs/u1p3pcheck.sh 3
 						else
 							runs/u1p3pcheck.sh 1
 						fi
+						echo 0 >"${RAMDISKDIR}/blockall"
 						openwbDebugLog "MAIN" 1 "auf $u1p3pstandby Phasen geaendert"
 					fi
 				fi

--- a/u1p3p.sh
+++ b/u1p3p.sh
@@ -3,11 +3,11 @@
 u1p3pswitch() {
 
 	if ((u1p3paktiv == 1)); then
-		u1p3pstat=$(<ramdisk/u1p3pstat)
-		nachtladenstate=$(<ramdisk/nachtladenstate)       # "Nachtladen" LP1
-		nachtladen2state=$(<ramdisk/nachtladen2state)     # "Morgensladen" LP1
-		nachtladenstates1=$(<ramdisk/nachtladenstates1)   # "Nachtladen" LP2
-		nachtladen2states1=$(<ramdisk/nachtladen2states1) # "Morgensladen" LP2
+		u1p3pstat=$(<"${RAMDISKDIR}/u1p3pstat")
+		nachtladenstate=$(<"${RAMDISKDIR}/nachtladenstate")       # "Nachtladen" LP1
+		nachtladen2state=$(<"${RAMDISKDIR}/nachtladen2state")     # "Morgensladen" LP1
+		nachtladenstates1=$(<"${RAMDISKDIR}/nachtladenstates1")   # "Nachtladen" LP2
+		nachtladen2states1=$(<"${RAMDISKDIR}/nachtladen2states1") # "Morgensladen" LP2
 		if [ -z "$u1p3schaltparam" ]; then
 			u1p3schaltparam=8
 		fi
@@ -45,13 +45,13 @@ u1p3pswitch() {
 								runs/u1p3pcheck.sh 1
 							fi
 							if ((u1p3pstat == 3)); then
-								urcounter=$(</var/www/html/openWB/ramdisk/urcounter)
-								if ((urcounter < urwaittime)); then
+								urcounter=$(<"${RAMDISKDIR}/urcounter")
+								if (( urcounter < urwaittime )); then
 									if ((urcounter < urwaittime - 60)); then
 										urcounter=$((urwaittime - 60))
 									fi
 									urcounter=$((urcounter + 10))
-									echo $urcounter >/var/www/html/openWB/ramdisk/urcounter
+									echo $urcounter >"${RAMDISKDIR}/urcounter"
 								else
 									runs/u1p3pcheck.sh 1
 									openwbDebugLog "MAIN" 1 "Min PV Laden derzeit $u1p3pstat Phasen, auf 1 Nur PV konfiguriert, aendere..."
@@ -76,13 +76,13 @@ u1p3pswitch() {
 								runs/u1p3pcheck.sh 1
 							fi
 							if ((u1p3pstat == 3)); then
-								urcounter=$(</var/www/html/openWB/ramdisk/urcounter)
+								urcounter=$(<"${RAMDISKDIR}/urcounter")
 								if ((urcounter < urwaittime)); then
 									if ((urcounter < urwaittime - 60)); then
 										urcounter=$((urwaittime - 60))
 									fi
 									urcounter=$((urcounter + 10))
-									echo $urcounter >/var/www/html/openWB/ramdisk/urcounter
+									echo $urcounter >"${RAMDISKDIR}/urcounter"
 								else
 									runs/u1p3pcheck.sh 1
 									openwbDebugLog "MAIN" 1 "Nur PV Laden derzeit $u1p3pstat Phasen, auf 1 Nur PV konfiguriert, aendere..."
@@ -127,7 +127,7 @@ u1p3pswitch() {
 			if ((nachtladenstate == 1)) || ((nachtladen2state == 1)) || ((nachtladenstates1 == 1)) || ((nachtladen2states1 == 1)); then
 				if ((u1p3pstat != u1p3pnl)); then
 					openwbDebugLog "MAIN" 1 "Nachtladen derzeit $u1p3pstat Phasen, auf $u1p3pnl konfiguriert, unterbreche Ladung und aendere..."
-					echo 1 >ramdisk/blockall
+					echo 1 >"${RAMDISKDIR}/blockall"
 					runs/u1p3pcheck.sh stop
 					sleep 5
 					if ((u1p3pnl == 3)); then
@@ -137,14 +137,14 @@ u1p3pswitch() {
 					fi
 					sleep 1
 					runs/u1p3pcheck.sh start
-					echo 0 >ramdisk/blockall
+					echo 0 >"${RAMDISKDIR}/blockall"
 					openwbDebugLog "MAIN" 1 "auf $u1p3pnl Phasen geaendert"
 				fi
 			else
 				if ((lademodus == 0)); then
 					if ((u1p3pstat != u1p3psofort)); then
 						openwbDebugLog "MAIN" 1 "Sofortladen derzeit $u1p3pstat Phasen, auf $u1p3psofort konfiguriert, unterbreche Ladung und aendere..."
-						echo 1 >ramdisk/blockall
+						echo 1 >"${RAMDISKDIR}/blockall"
 						runs/u1p3pcheck.sh stop
 						sleep 5
 						if ((u1p3psofort == 3)); then
@@ -154,14 +154,14 @@ u1p3pswitch() {
 						fi
 						sleep 1
 						runs/u1p3pcheck.sh start
-						echo 0 >ramdisk/blockall
+						echo 0 >"${RAMDISKDIR}/blockall"
 						openwbDebugLog "MAIN" 1 "auf $u1p3psofort Phasen geaendert"
 					fi
 				fi
 				if ((lademodus == 1)); then
 					if ((u1p3pstat != u1p3pminundpv)); then
 						if ((u1p3pminundpv == 4)); then
-							oldll=$(<ramdisk/llsoll)
+							oldll=$(<"${RAMDISKDIR}/llsoll")
 							if ((u1p3pstat == 1)); then
 								if [[ $schieflastaktiv == "1" ]]; then
 									maximalstromstaerke=$schieflastmaxa
@@ -169,85 +169,85 @@ u1p3pswitch() {
 								if ((ladeleistung < 100)); then
 									if ((uberschuss > ((3 * mindestuberschuss) + 1000))); then
 										openwbDebugLog "MAIN" 1 "Min PV Laden derzeit $u1p3pstat Phasen, auf MinPV Automatik konfiguriert, aendere auf 3 Phasen da viel Überschuss vorhanden..."
-										echo 1 >ramdisk/blockall
+										echo 1 >"${RAMDISKDIR}/blockall"
 										runs/u1p3pcheck.sh stop
 										sleep 8
 										runs/u1p3pcheck.sh 3
 										sleep 20
 										runs/u1p3pcheck.sh startslow
-										(sleep 25 && echo 0 >ramdisk/blockall) &
+										(sleep 25 && echo 0 >"${RAMDISKDIR}/blockall") &
 										openwbDebugLog "MAIN" 1 "auf 3 Phasen MinPV Automatik geaendert"
 									fi
 								fi
 								if ((oldll == maximalstromstaerke)); then
-									uhcounter=$(</var/www/html/openWB/ramdisk/uhcounter)
+									uhcounter=$(<"${RAMDISKDIR}/uhcounter")
 									if ((uhcounter < uhwaittime)); then
 										if ((maximalstromstaerke == 16)); then
 											if ((uberschuss > 500)); then
 												uhcounter=$((uhcounter + 10))
-												echo $uhcounter >/var/www/html/openWB/ramdisk/uhcounter
+												echo $uhcounter >"${RAMDISKDIR}/uhcounter"
 												openwbDebugLog "MAIN" 1 "Umschaltcounter Erhoehung auf $uhcounter erhoeht fuer Min PV Automatik Phasenumschaltung, genug uberschuss fuer 3 Phasen Ladung"
 											else
 												openwbDebugLog "MAIN" 1 "Umschaltcounter nicht erhöht fuer Min PV Automatik Phasenumschaltung, fehlender uberschuss fuer 3 Phasen Ladung"
 											fi
 										else
 											uhcounter=$((uhcounter + 10))
-											echo $uhcounter >/var/www/html/openWB/ramdisk/uhcounter
+											echo $uhcounter >"${RAMDISKDIR}/uhcounter"
 											openwbDebugLog "MAIN" 1 "Umschaltcounter Erhoehung auf $uhcounter erhoeht fuer Min PV Automatik Phasenumschaltung"
 										fi
 									else
 										openwbDebugLog "MAIN" 1 "Min PV Laden derzeit $u1p3pstat Phasen, auf MinPV Automatik konfiguriert, unterbreche Ladung und  aendere auf 3 Phasen..."
-										echo 1 >ramdisk/blockall
+										echo 1 >"${RAMDISKDIR}/blockall"
 										runs/u1p3pcheck.sh stop
 										sleep 8
 										runs/u1p3pcheck.sh 3
 										sleep 20
 										runs/u1p3pcheck.sh startslow
-										(sleep 25 && echo 0 >ramdisk/blockall) &
+										(sleep 25 && echo 0 >"${RAMDISKDIR}/blockall") &
 										openwbDebugLog "MAIN" 1 "auf 3 Phasen MinPV Automatik geaendert"
-										echo 0 >/var/www/html/openWB/ramdisk/uhcounter
+										echo 0 >"${RAMDISKDIR}/uhcounter"
 									fi
 								else
-									echo 0 >/var/www/html/openWB/ramdisk/uhcounter
+									echo 0 >"${RAMDISKDIR}/uhcounter"
 								fi
 							else
 								if ((ladeleistung < 100)); then
 									if ((uberschuss < (3 * mindestuberschuss))); then
-										echo 0 >/var/www/html/openWB/ramdisk/urcounter
-										echo 1 >ramdisk/blockall
+										echo 0 >"${RAMDISKDIR}/urcounter"
+										echo 1 >"${RAMDISKDIR}/blockall"
 										runs/u1p3pcheck.sh stop
 										sleep 8
 										runs/u1p3pcheck.sh 1
 										sleep 20
 										runs/u1p3pcheck.sh startslow
-										(sleep 25 && echo 0 >ramdisk/blockall) &
+										(sleep 25 && echo 0 >"${RAMDISKDIR}/blockall") &
 										openwbDebugLog "MAIN" 1 "auf 1 Phasen MinPV Automatik geaendert da geringerer Überschuss"
 									fi
 								fi
 								if ((oldll == minimalampv)) && ((ladeleistung > 100)); then
-									urcounter=$(</var/www/html/openWB/ramdisk/urcounter)
+									urcounter=$(<"${RAMDISKDIR}/urcounter")
 									if ((urcounter < urwaittime)); then
 										urcounter=$((urcounter + 10))
-										echo $urcounter >/var/www/html/openWB/ramdisk/urcounter
+										echo $urcounter >"${RAMDISKDIR}/urcounter"
 										openwbDebugLog "MAIN" 1 "Umschaltcounter Reduzierung auf $urcounter erhoeht fuer Min PV Automatik Phasenumschaltung"
 									else
-										echo 0 >/var/www/html/openWB/ramdisk/urcounter
-										echo 1 >ramdisk/blockall
+										echo 0 >"${RAMDISKDIR}/urcounter"
+										echo 1 >"${RAMDISKDIR}/blockall"
 										runs/u1p3pcheck.sh stop
 										sleep 8
 										runs/u1p3pcheck.sh 1
 										sleep 20
 										runs/u1p3pcheck.sh startslow
-										(sleep 25 && echo 0 >ramdisk/blockall) &
+										(sleep 25 && echo 0 >"${RAMDISKDIR}/blockall") &
 										openwbDebugLog "MAIN" 1 "auf 1 Phasen MinPV Automatik geaendert"
 									fi
 								else
-									echo 0 >/var/www/html/openWB/ramdisk/urcounter
+									echo 0 >"${RAMDISKDIR}/urcounter"
 								fi
 							fi
 						else
 							openwbDebugLog "MAIN" 1 "Min PV Laden derzeit $u1p3pstat Phasen, auf $u1p3pminundpv konfiguriert, unterbreche Ladung und  aendere..."
-							echo 1 >ramdisk/blockall
+							echo 1 >"${RAMDISKDIR}/blockall"
 							runs/u1p3pcheck.sh stop
 							sleep 5
 							if ((u1p3pminundpv == 3)); then
@@ -257,7 +257,7 @@ u1p3pswitch() {
 							fi
 							sleep 1
 							runs/u1p3pcheck.sh start
-							echo 0 >ramdisk/blockall
+							echo 0 >"${RAMDISKDIR}/blockall"
 							openwbDebugLog "MAIN" 1 "auf $u1p3pminundpv Phasen geaendert"
 						fi
 					fi
@@ -265,7 +265,7 @@ u1p3pswitch() {
 				if ((lademodus == 2)); then
 					if ((u1p3pstat != u1p3pnurpv)); then
 						if ((u1p3pnurpv == 4)); then
-							oldll=$(<ramdisk/llsoll)
+							oldll=$(<"${RAMDISKDIR}/llsoll")
 							if ((u1p3pstat == 1)); then
 								if [[ $schieflastaktiv == "1" ]]; then
 									maximalstromstaerke=$schieflastmaxa
@@ -273,75 +273,75 @@ u1p3pswitch() {
 								if ((ladeleistung < 100)); then
 									if ((uberschuss > ((3 * mindestuberschuss) + 1000))); then
 										openwbDebugLog "MAIN" 1 "Nur PV Laden derzeit $u1p3pstat Phasen, auf NurPV Automatik konfiguriert, aendere auf 3 Phasen da viel Überschuss vorhanden..."
-										echo 1 >ramdisk/blockall
+										echo 1 >"${RAMDISKDIR}/blockall"
 										runs/u1p3pcheck.sh stop
 										sleep 8
 										runs/u1p3pcheck.sh 3
 										sleep 20
 										runs/u1p3pcheck.sh startslow
-										(sleep 25 && echo 0 >ramdisk/blockall) &
+										(sleep 25 && echo 0 >"${RAMDISKDIR}/blockall") &
 										openwbDebugLog "MAIN" 1 "auf 3 Phasen NurPV Automatik geaendert"
 									fi
 								fi
 								if ((oldll == maximalstromstaerke)); then
-									uhcounter=$(</var/www/html/openWB/ramdisk/uhcounter)
+									uhcounter=$(<"${RAMDISKDIR}/uhcounter")
 									if ((uhcounter < uhwaittime)); then
 										uhcounter=$((uhcounter + 10))
-										echo $uhcounter >/var/www/html/openWB/ramdisk/uhcounter
+										echo $uhcounter >"${RAMDISKDIR}/uhcounter"
 										openwbDebugLog "MAIN" 1 "Umschaltcounter Erhoehung auf $uhcounter erhoeht fuer PV Automatik Phasenumschaltung"
 									else
 										openwbDebugLog "MAIN" 1 "Nur PV Laden derzeit $u1p3pstat Phasen, auf NurPV Automatik konfiguriert, unterbreche Ladung und  aendere auf 3 Phasen..."
-										echo 1 >ramdisk/blockall
+										echo 1 >"${RAMDISKDIR}/blockall"
 										runs/u1p3pcheck.sh stop
 										sleep 8
 										runs/u1p3pcheck.sh 3
 										sleep 20
 										runs/u1p3pcheck.sh startslow
-										(sleep 25 && echo 0 >ramdisk/blockall) &
+										(sleep 25 && echo 0 >"${RAMDISKDIR}/blockall") &
 										openwbDebugLog "MAIN" 1 "auf 3 Phasen NurPV Automatik geaendert"
-										echo 0 >/var/www/html/openWB/ramdisk/uhcounter
+										echo 0 >"${RAMDISKDIR}/uhcounter"
 									fi
 								else
-									echo 0 >/var/www/html/openWB/ramdisk/uhcounter
+									echo 0 >"${RAMDISKDIR}/uhcounter"
 								fi
 							else
 								if ((ladeleistung < 100)); then
 									if ((uberschuss < (3 * mindestuberschuss))); then
-										echo 0 >/var/www/html/openWB/ramdisk/urcounter
-										echo 1 >ramdisk/blockall
+										echo 0 >"${RAMDISKDIR}/urcounter"
+										echo 1 >"${RAMDISKDIR}/blockall"
 										runs/u1p3pcheck.sh stop
 										sleep 8
 										runs/u1p3pcheck.sh 1
 										sleep 20
 										runs/u1p3pcheck.sh startslow
-										(sleep 25 && echo 0 >ramdisk/blockall) &
+										(sleep 25 && echo 0 >"${RAMDISKDIR}/blockall") &
 										openwbDebugLog "MAIN" 1 "auf 1 Phasen NurPV Automatik geaendert da geringerer Überschuss"
 									fi
 								fi
 								if ((oldll == minimalapv)) && ((ladeleistung > 100)); then
-									urcounter=$(</var/www/html/openWB/ramdisk/urcounter)
-									if ((urcounter < urwaittime)); then
+									urcounter=$(<"${RAMDISKDIR}/urcounter")
+									if ((urcounter  < urwaittime)); then
 										urcounter=$((urcounter + 10))
-										echo $urcounter >/var/www/html/openWB/ramdisk/urcounter
+										echo $urcounter >"${RAMDISKDIR}/urcounter"
 										openwbDebugLog "MAIN" 1 "Umschaltcounter Reduzierung auf $urcounter erhoeht fuer PV Automatik Phasenumschaltung"
 									else
-										echo 0 >/var/www/html/openWB/ramdisk/urcounter
-										echo 1 >ramdisk/blockall
+										echo 0 >"${RAMDISKDIR}/urcounter"
+										echo 1 >"${RAMDISKDIR}/blockall"
 										runs/u1p3pcheck.sh stop
 										sleep 8
 										runs/u1p3pcheck.sh 1
 										sleep 20
 										runs/u1p3pcheck.sh startslow
-										(sleep 25 && echo 0 >ramdisk/blockall) &
+										(sleep 25 && echo 0 >"${RAMDISKDIR}/blockall") &
 										openwbDebugLog "MAIN" 1 "auf 1 Phasen NurPV Automatik geaendert"
 									fi
 								else
-									echo 0 >/var/www/html/openWB/ramdisk/urcounter
+									echo 0 >"${RAMDISKDIR}/urcounter"
 								fi
 							fi
 						else
 							openwbDebugLog "MAIN" 1 "Nur PV Laden derzeit $u1p3pstat Phasen, auf $u1p3pnurpv konfiguriert, unterbreche Ladung und  aendere..."
-							echo 1 >ramdisk/blockall
+							echo 1 >"${RAMDISKDIR}/blockall"
 							runs/u1p3pcheck.sh stop
 							sleep 5
 							if ((u1p3pnurpv == 3)); then
@@ -351,7 +351,7 @@ u1p3pswitch() {
 							fi
 							sleep 1
 							runs/u1p3pcheck.sh start
-							echo 0 >ramdisk/blockall
+							echo 0 >"${RAMDISKDIR}/blockall"
 							openwbDebugLog "MAIN" 1 "auf $u1p3pnurpv Phasen geaendert"
 						fi
 					fi
@@ -359,7 +359,7 @@ u1p3pswitch() {
 				if ((lademodus == 4)); then
 					if ((u1p3pstat != u1p3pstandby)); then
 						openwbDebugLog "MAIN" 1 "Standby Laden derzeit $u1p3pstat Phasen, auf $u1p3pstandby konfiguriert, unterbreche Ladung und aendere..."
-						echo 1 >ramdisk/blockall
+						echo 1 >"${RAMDISKDIR}/blockall"
 						runs/u1p3pcheck.sh stop
 						sleep 5
 						if ((u1p3pstandby == 3)); then
@@ -369,7 +369,7 @@ u1p3pswitch() {
 						fi
 						sleep 1
 						runs/u1p3pcheck.sh start
-						echo 0 >ramdisk/blockall
+						echo 0 >"${RAMDISKDIR}/blockall"
 						openwbDebugLog "MAIN" 1 "auf $u1p3pstandby Phasen geaendert"
 					fi
 				fi


### PR DESCRIPTION
- move call to phase switching to background
- add missing handling of `ramdisk/blockall` in u1p3p.sh
- fix shellcheck warnings and errors