### PR TITLE
Go-e: Kein triggern der API wenn Soll-Max-Ampere (llsoll) Null ist

### DIFF
--- a/goecheck.sh
+++ b/goecheck.sh
@@ -20,7 +20,7 @@ goecheck(){
 			fwv=$(echo $output | jq -r '.fwv' | grep -Po "[1-9]\d{1,2}")
 			oldcurrent=$(echo $output | jq -r '.amp')
 			current=$(</var/www/html/openWB/ramdisk/llsoll)
-			if (( oldcurrent != $current )) ; then
+			if (( oldcurrent != $current )) && (( $current != 0 )); then
 				if (($fwv >= 40)) ; then
 					curl --silent --connect-timeout $goetimeoutlp1 -s http://$goeiplp1/mqtt?payload=amx=$current > /dev/null
 				else
@@ -48,7 +48,7 @@ goecheck(){
 				fwv=$(echo $output | jq -r '.fwv' | grep -Po "[1-9]\d{1,2}")
 				oldcurrent=$(echo $output | jq -r '.amp')
 				current=$(</var/www/html/openWB/ramdisk/llsolls1)
-				if (( oldcurrent != $current )) ; then
+				if (( oldcurrent != $current )) && (( $current != 0 )); then
 					if (($fwv >= 40)) ; then
 						curl --silent --connect-timeout $goetimeoutlp2 -s http://$goeiplp2/mqtt?payload=amx=$current > /dev/null
 					else


### PR DESCRIPTION
Passiert, sobald der Ladepunkt deaktiviert wird (bspw. wie bei mir automatisch nach Erreichen eines gewünschten SOC via PV-Laden) oder nicht mehr genügend Überschuss vorhanden ist. Dann geht der Soll-Ampere-Stand (llsoll) auf 0. Dadurch passt er nicht mit dem Minimum bei go-e einzustellendem 6 Ampere zusammen => es wird der Soll-Ampere mit 0 gesendet und go-e setzt seinen minimal Ampere-Wert (6A). Das wiederholt sich dann bei jedem Zyklus => go-E blinkt ständig.
Siehe auch:
https://openwb.de/forum/viewtopic.php?p=60707#p60707
