### PR TITLE
fix http module crash: initialization of device_config done after fir…

### DIFF
--- a/packages/modules/http/device.py
+++ b/packages/modules/http/device.py
@@ -39,11 +39,12 @@ class Device(AbstractDevice):
     def __init__(self, device_config: dict) -> None:
         self._components = {}  # type: Dict[str, http_component_classes]
         try:
+            self.device_config = device_config
             port = self.device_config["configuration"]["port"]
             self.domain = self.device_config["configuration"]["protocol"] + \
-                "://" + self.device_config["configuration"]["domain"] + \
-                ":" + port if port else ""
-            self.device_config = device_config
+                "://" + self.device_config["configuration"]["domain"]
+            if port is not None:
+                self.domain = self.domain + ":" + port
         except Exception:
             log.MainLogger().exception("Fehler im Modul "+device_config["name"])
 
@@ -106,7 +107,10 @@ def create_legacy_device_config(url: str):
     device_config = get_default_config()
     device_config["configuration"]["protocol"] = parsed_url.scheme
     device_config["configuration"]["domain"] = parsed_url.hostname
-    device_config["configuration"]["port"] = str(parsed_url.port)
+    if parsed_url.port is not None:
+        device_config["configuration"]["port"] = str(parsed_url.port)
+    else:
+        device_config["configuration"]["port"] = None
     return device_config
 
 


### PR DESCRIPTION
…st usage/access, wrong check for port on creating URL

Seit commit af6b1dc779e8eafaf5dfdd7e0b5e5bb77560aa44 (an http/device.py) crashed leider das HTTP Modul, da auf eine Variable/Member (device_config) zugegriffen wird, bevor diese initialisiert wurde:

`AttributeError: 'Device' object has no attribute 'device_config'
self.device_config["id"], component_config, self.domain)
File "/var/www/html/openWB/packages/modules/http/device.py", line 55, in add_component
device.add_component(component_config)
File "/var/www/html/openWB/packages/modules/http/device.py", line 97, in run_device_legacy
run_device_legacy(create_legacy_device_config(power_path), component_config)
File "/var/www/html/openWB/packages/modules/http/device.py", line 135, in read_legacy_counter
parser.set_defaults(RUN=lambda args: function(*[getattr(args, argument_name) for argument_name in arg_spec.args]))
File "/var/www/html/openWB/packages/helpermodules/cli/_run_using_positional_cli_args.py", line 19, in <lambda>
args.RUN(args)
File "/var/www/html/openWB/packages/helpermodules/cli/_run_using_positional_cli_args.py", line 34, in run_using_positional_cli_args
{"bat": read_legacy_bat, "counter": read_legacy_counter, "inverter": read_legacy_inverter}, argv
File "/var/www/html/openWB/packages/modules/http/device.py", line 150, in main
importlib.import_module(parsed[0]).main(parsed[1:])
File "/var/www/html/openWB/packages/legacy_run_server.py", line 109, in handle_message
self.__callback(read_all_bytes(connection))
File "/var/www/html/openWB/packages/legacy_run_server.py", line 87, in handle_connection
yield
File "/var/www/html/openWB/packages/legacy_run_server.py", line 48, in redirect_stdout_stderr_exceptions_to_log
Traceback (most recent call last):
2022-05-17 20:44:45: PID: 2512: legacy run server: Unhandled exception
AttributeError: 'Device' object has no attribute 'device_config'
port = self.device_config["configuration"]["port"]
File "/var/www/html/openWB/packages/modules/http/device.py", line 42, in __init__
Traceback (most recent call last):
2022-05-17 20:44:45: PID: 2512: root: Fehler im Modul HTTP`

Dies dürfte auch unter openWB V2.0 passieren, da hier der Code afaics genauso benutzt wird.

Darüber hinaus ist die Erweiterung um das "port" Attribut leider auch fehlerbehaftet und führt bei einer bestehenden V1.9 Konfiguration zu einer falsch generierten URL (http:/<host>:None/<path> anstatt Portangabe) und somit auch zu einem nicht funktionierendem HTTP Modul.
Dieser PR fixt beides.