### PR TITLE
Elwa Steuerung....

### DIFF
--- a/runs/usmarthome/smartbase.py
+++ b/runs/usmarthome/smartbase.py
@@ -596,6 +596,7 @@ class Sbase(Sbase0):
         self._c_ausverz_f = 'N'
         self._c_einverz = 0
         self._c_einverz_f = 'N'
+        self._dynregel = 0
 
     def __del__(self):
 
@@ -1174,13 +1175,22 @@ class Sbase(Sbase0):
                                 self.turndevicerelais(0, 0, 1)
                                 return
                             else:
-                                self.logClass(2, "(" + str(self.device_nummer)
-                                              + ") " + self.device_name +
-                                              " Mindesteinschaltdauer erreicht"
-                                              + ",Ausschaltschwelle 0 gesetzt")
-                                work_ausschaltverzoegerung = 0
-                                if (work_ausschaltschwelle < 0):
-                                    work_ausschaltschwelle = 0
+                                if (self._dynregel == 0):
+                                    self.logClass(2, "(" +
+                                                  str(self.device_nummer) +
+                                                  ") " + self.device_name +
+                                                  " Mindesteinschaltdauer " +
+                                                  "erreicht, " +
+                                                  "Ausschaltschwelle 0 " +
+                                                  "gesetzt")
+                                    work_ausschaltverzoegerung = 0
+                                    if (work_ausschaltschwelle < 0):
+                                        work_ausschaltschwelle = 0
+                                else:
+                                    self.logClass(2, "(" +
+                                                  str(self.device_nummer)
+                                                  + ") " + self.device_name +
+                                                  " Gerät mit dyn Regelung")
                         else:
                             self.logClass(2, "(" + str(self.device_nummer) +
                                           ") " + self.device_name +

--- a/runs/usmarthome/smartbase.py
+++ b/runs/usmarthome/smartbase.py
@@ -1207,14 +1207,22 @@ class Sbase(Sbase0):
                             self.turndevicerelais(0, 0, 1)
                             return
                         else:
-                            self.logClass(2, "(" + str(self.device_nummer) +
-                                          ") " + self.device_name +
-                                          " Mindesteinschaltdauer nicht" +
-                                          " bekannt,setze Ausschaltschwelle" +
-                                          " auf 0")
-                            work_ausschaltverzoegerung = 0
-                            if (work_ausschaltschwelle < 0):
-                                work_ausschaltschwelle = 0
+                            if (self._dynregel == 0):
+                                self.logClass(2, "(" +
+                                              str(self.device_nummer) +
+                                              ") " + self.device_name +
+                                              " Mindesteinschaltdauer " +
+                                              "nicht bekannt, " +
+                                              "Ausschaltschwelle 0 " +
+                                              "gesetzt")
+                                work_ausschaltverzoegerung = 0
+                                if (work_ausschaltschwelle < 0):
+                                    work_ausschaltschwelle = 0
+                            else:
+                                self.logClass(2, "(" +
+                                              str(self.device_nummer)
+                                              + ") " + self.device_name +
+                                              " Gerät mit dyn Regelung")
                 else:
                     self.logClass(2, "(" + str(self.device_nummer) + ") " +
                                   self.device_name +

--- a/runs/usmarthome/smartelwa.py
+++ b/runs/usmarthome/smartelwa.py
@@ -8,6 +8,7 @@ class Selwa(Sbase):
     def __init__(self):
         # setting
         super().__init__()
+        self._dynregel = 1
         print('__init__ Selwa executed')
 
     def getwatt(self, uberschuss, uberschussoffset):


### PR DESCRIPTION
Beim Einsatz von Elwa mit der Option bei Autoladen Ausschaltschwelle anpassen und einer laufenden Autoladung in Verbindung mit einer kleinen PV Anlage wird Elwa durch openWB laufen deaktiviert da durch PV Ladung der EVU Punkt auf 0 geregelt wird. Dadurch wird die (angepasste) Ausschaltschwelle berührt und openWB deaktiviert Elwa.  Mit dieser Korrektur wird die Ausschaltschwelle von Elwa nicht mehr angepasst, aber trotzdem sichergestellt das die aktuelle Leistungsaufnahme von Elwa als abschaltbare Smarthomedeviceleistung geführt wird  und somit von der PV Autoladung verwendet werden kann.
Damit das funktioniert muss die Ausschaltschwelle von Elwa auf Bezug gestellt werden (positive Zahl erfasst z.b. 500). Es sind alle Smarthomedevices mit dynamische Regelung betroffen. Das ganze wird mit Elwa getestet und dann für die anderen Smarthomedevices angepasst.