### PR TITLE
Smartmq....

### DIFF
--- a/runs/initRamdisk.sh
+++ b/runs/initRamdisk.sh
@@ -611,7 +611,7 @@ initRamdisk(){
 	ra='^-?[0-9]+$'
 	smartmqtemp=$(timeout 1 mosquitto_sub -t openWB/config/get/SmartHome/smartmq)
 	if ! [[ $smartmqtemp =~ $ra ]] ; then
-		smartmqtemp="0"
+		smartmqtemp="1"
 	fi
 	echo $smartmqtemp > $RamdiskPath/smartmq
 

--- a/runs/smarthomemq.py
+++ b/runs/smarthomemq.py
@@ -227,6 +227,8 @@ def getdevicevalues():
     mqtt_all['openWB/SmartHome/Status/wattschalt'] = totalwatt
     mqtt_all['openWB/SmartHome/Status/wattnichtschalt'] = totalwattot
     mqtt_all['openWB/SmartHome/Status/wattnichtHaus'] = totalminhaus
+    mqtt_all['openWB/SmartHome/Status/uberschuss'] = uberschuss
+    mqtt_all['openWB/SmartHome/Status/uberschussoffset'] = uberschussoffset
     sendmq(mqtt_all)
 
 

--- a/web/settings/smarthomeconfig.php
+++ b/web/settings/smarthomeconfig.php
@@ -794,13 +794,14 @@ $numDevices = 9;
 
 						<div class="form-group">
 							<div class="form-row mb-1">
-								<label for="smartmq" class="col-md-4 col-form-label">Smartmq handler verwenden (ohne Config file, noch in Entwicklung)</label>
+								<label for="smartmq" class="col-md-4 col-form-label">Smartmq handler verwenden (ohne Config file)</label>
 								<div class="col">
 									<select name="smartmq" id="smartmq" class="form-control" data-default="0" data-topicprefix="openWB/config/get/SmartHome/">
 										<option value="0" data-option="0">Nein</option>
 										<option value="1" data-option="1">Ja</option>
 									</select>
 								</div>
+								<span class="text-danger">Smartmq bietet derweilen die gleichen und mehr Funktionen wie der Smarthomehandler an. Smartmq wird Mitte Juni 2022 den Smarthomehandler komplett ersetzen. Dann wird der obige Parameter fix auf Ja gesetzt und kann nicht mehr geändert werden.</span>
 							</div>
 						</div>
 


### PR DESCRIPTION
Setzt als Default Smartmq wenn von stable auf nightly gewechselt wird.
Updated Überschuss für Status Bild mittels mqtt
Bringt eine Warnung das Mitte Juni 2022 der jetzige Smarthomehandler ersetzt wird