### PR TITLE
Zeitkorrektur Langzeitlogging

### DIFF
--- a/regel.sh
+++ b/regel.sh
@@ -140,7 +140,7 @@ fi
 #ladelog ausfuehren
 ./ladelog.sh &
 graphtimer=$(<ramdisk/graphtimer)
-if (( graphtimer < 4 )); then
+if (( graphtimer < 5 )); then
 	graphtimer=$((graphtimer+1))
 	echo $graphtimer > ramdisk/graphtimer
 else


### PR DESCRIPTION
Es wird wieder alle 60 Sekunden ein Zeile in Logging gesetzt.
Die Langzeitansicht umfasst dann wieder 24 Stunden.
Vorher wurden alle 50 Sekunden einen Zeile geschrieben, daher auch mal 2 in einer Minute.
Die Anzeige umfasste dann nur 20 Stunden.