### PR TITLE
Einschalt und Ausschaltgruppe...

### DIFF
--- a/runs/mqttsub.py
+++ b/runs/mqttsub.py
@@ -188,7 +188,7 @@ def on_message(client, userdata, msg):
                     
             if (( "openWB/config/set/SmartHome/Device" in msg.topic) and ("device_deactivateper" in msg.topic)):
                 devicenumb=re.sub(r'\D', '', msg.topic)
-                if ( 1 <= int(devicenumb) <= numberOfSupportedDevices and 0 <= int(msg.payload) <= 2):
+                if ( 1 <= int(devicenumb) <= numberOfSupportedDevices and 0 <= int(msg.payload) <= 100):
                     writetoconfig(shconfigfile,'smarthomedevices','device_deactivateper_'+str(devicenumb), msg.payload.decode("utf-8"))
                     client.publish("openWB/config/get/SmartHome/Devices/"+str(devicenumb)+"/device_deactivateper", msg.payload.decode("utf-8"), qos=0, retain=True)
                                         

--- a/runs/smarthomemq.py
+++ b/runs/smarthomemq.py
@@ -183,6 +183,9 @@ def getdevicevalues():
     totalwatt = 0
     totalwattot = 0
     totalminhaus = 0
+    # dyn daten einschaltgruppe
+    Sbase.ausschaltwatt = 0
+    Sbase.einrelais = 0
     mqtt_all = {}
     for mydevice in mydevices:
         mydevice.getwatt(uberschuss, uberschussoffset)
@@ -223,6 +226,16 @@ def getdevicevalues():
              + str(totalwattot))
     logDebug(LOGLEVELDEBUG, "Total Watt nicht im Hausverbrauch: " +
              str(totalminhaus))
+    logDebug(LOGLEVELDEBUG, "Anzahl devices in Auschaltgruppe: " +
+             str(Sbase.ausdevices) + " akt: " + str(Sbase.ausschaltwatt) +
+             " Anzahl devices in Einschaltgruppe: " + str(Sbase.eindevices)
+             )
+    logDebug(LOGLEVELDEBUG, "Einschaltgruppe rel: " + str(Sbase.einrelais) +
+             " Summe Einschaltschwelle: " +
+             str(Sbase.einschwelle) + " max Einschaltverzögerung " +
+             str(Sbase.einverz) + " nur Einschaltgruppe prüfen bis: " +
+             str(Sbase.nureinschaltinsec)
+             )
     mqtt_all['openWB/SmartHome/Status/maxspeicherladung'] = maxspeicher
     mqtt_all['openWB/SmartHome/Status/wattschalt'] = totalwatt
     mqtt_all['openWB/SmartHome/Status/wattnichtschalt'] = totalwattot
@@ -263,6 +276,13 @@ def update_devices():
     global mqtt_cache
     client = mqtt.Client("openWB-SmartHome-bulkpublisher-" + str(os.getpid()))
     client.connect("localhost")
+    # statische daten einschaltgruppe
+    Sbase.ausdevices = 0
+    Sbase.eindevices = 0
+    Sbase.einverz = 0
+    Sbase.einschwelle = 0
+    # Nur einschaltgruppe in Sekunden
+    Sbase.nureinschaltinsec = 0
     for i in range(1, numberOfSupportedDevices+1):
         device_configured = 0
         device_type = 'none'
@@ -393,6 +413,8 @@ def resetmaxeinschaltdauerfunc():
                         mydevice.c_oldstampeinschaltdauer = 0
                         mydevice.c_oldstampeinschaltdauer_f = 'N'
             resetmaxeinschaltdauer = 1
+            # Nur einschaltgruppe in Sekunden für neuen Tag zurücksetzten
+            Sbase.nureinschaltinsec = 0
             sendmq(mqtt_reset)
     if (int(hour) == 1):
         resetmaxeinschaltdauer = 0

--- a/runs/usmarthome/smartbase.py
+++ b/runs/usmarthome/smartbase.py
@@ -1001,9 +1001,13 @@ class Sbase(Sbase0):
         localinsec = int((localhour * 60 * 60) + (localminute * 60))
         if (localinsec < Sbase.nureinschaltinsec) and (Sbase.eindevices > 0):
             self.logClass(2, "(" + str(self.device_nummer) + ") " +
-                          self.device_name + " Prüfe nur Einschaltgruppe " +
-                          "keine Regelung")
-            return
+                          self.device_name + " Prüfe nur Einschaltgruppe ")
+            if (self.gruppe == 'E'):
+                pass
+            else:
+                self.logClass(2, "(" + str(self.device_nummer) + ") " +
+                              self.device_name + " kein Regelung")
+                return
         # onnow = 0 -> normale Regelung
         # onnow = 1 -> Zeitpunkt erreciht, immer ein ohne Ueberschuss regelung
         onnow = 0

--- a/runs/usmarthome/smartbase.py
+++ b/runs/usmarthome/smartbase.py
@@ -511,6 +511,16 @@ class Slsdm120(Slbase):
 
 
 class Sbase(Sbase0):
+    # Instance variablen für ein und Auschaltgruppe
+    einschwelle = 0
+    einverz = 0
+    eindevices = 0
+    #
+    ausdevices = 0
+    ausschaltwatt = 0
+    einrelais = 0
+    nureinschaltinsec = 0
+
     def __init__(self):
         # setting
         print('__init__ Sbase executed')
@@ -597,6 +607,7 @@ class Sbase(Sbase0):
         self._c_einverz = 0
         self._c_einverz_f = 'N'
         self._dynregel = 0
+        self.gruppe = 'none'
 
     def __del__(self):
 
@@ -729,6 +740,11 @@ class Sbase(Sbase0):
         else:
             sendstatus = self.devstatus
         self.mqtt_param[pref + 'Status'] = sendstatus
+        if (self.gruppe == 'A'):
+            Sbase.ausschaltwatt = Sbase.ausschaltwatt + self._oldwatt
+        elif (self.gruppe == 'E'):
+            if (self.relais == 1):
+                Sbase.einrelais = 1
 
     def updatepar(self, input_param):
         self._smart_param = input_param.copy()
@@ -857,6 +873,18 @@ class Sbase(Sbase0):
         self.mqtt_param_del[pref + 'TemperatureSensor1'] = '300'
         self.mqtt_param_del[pref + 'TemperatureSensor2'] = '300'
         self.mqtt_param_del[pref + 'RunningTimeToday'] = '0'
+        if (self._device_deactivateper == 100):
+            self.gruppe = 'E'
+            Sbase.eindevices = Sbase.eindevices + 1
+            workein = self._device_einschaltschwelle
+            Sbase.einschwelle = Sbase.einschwelle + workein
+            workeinverz = self._device_einschaltverzoegerung + 30
+            Sbase.einverz = max(Sbase.einverz, workeinverz)
+        elif (self._device_deactivateper > 0):
+            self.gruppe = 'A'
+            Sbase.ausdevices = Sbase.ausdevices + 1
+        else:
+            self.gruppe = 'none'
         if (self.device_type == 'none'):
             self.device_canswitch = 0
         if (self._device_differentmeasurement == 1):
@@ -971,6 +999,11 @@ class Sbase(Sbase0):
         localhour = int(local_time.strftime(format="%H"))
         localminute = int(local_time.strftime(format="%M"))
         localinsec = int((localhour * 60 * 60) + (localminute * 60))
+        if (localinsec < Sbase.nureinschaltinsec) and (Sbase.eindevices > 0):
+            self.logClass(2, "(" + str(self.device_nummer) + ") " +
+                          self.device_name + " Prüfe nur Einschaltgruppe " +
+                          "keine Regelung")
+            return
         # onnow = 0 -> normale Regelung
         # onnow = 1 -> Zeitpunkt erreciht, immer ein ohne Ueberschuss regelung
         onnow = 0
@@ -1309,8 +1342,9 @@ class Sbase(Sbase0):
                               " Anlauferkennung nun aktiv, eingeschaltet ")
                 self.turndevicerelais(1, 0, 0)
                 return
-        # periodisch ausschalten
-        if (self.relais == 1) and (self._device_deactivateper > 0):
+        # periodisch hart ausschalten
+        if ((self.relais == 1) and (self.gruppe == 'A') and
+           (Sbase.eindevices == 0)):
             self.logClass(2, "(" + str(self.device_nummer) + ") " +
                           self.device_name +
                           " Soll periodisch ausgeschaltet werden " +
@@ -1325,6 +1359,39 @@ class Sbase(Sbase0):
                 self.turndevicerelais(0, 0, 1)
                 self._c_ausverz_f = 'N'
                 return
+        # periodisch prüfen ob ausschalten
+        if ((self.relais == 1) and (self.gruppe == 'A') and
+           (Sbase.eindevices > 0)):
+            self.logClass(2, "(" + str(self.device_nummer) + ") " +
+                          self.device_name +
+                          " Soll periodisch geprüft werden " +
+                          " (1 = volle Stunde / " +
+                          " 2 = volle Stunde + halbe Stunde) " +
+                          str(self._device_deactivateper))
+            if (((self._device_deactivateper == 2) and (localminute == 30)) or
+               (localminute == 00)):
+                self.logClass(2, "(" + str(self.device_nummer) +
+                              ") " + self.device_name +
+                              " akt Leistungsaufnahme Abschaltgruppe " +
+                              str(Sbase.ausschaltwatt) +
+                              " Summe benötigte Einschaltschwelle: " +
+                              str(Sbase.einschwelle) + " Überschuss " +
+                              str(self._uberschuss))
+                if (((Sbase.ausschaltwatt + self._uberschuss) >
+                   Sbase.einschwelle) and Sbase.einrelais == 0):
+                    self.logClass(2, "(" + str(self.device_nummer) +
+                                  ") " + self.device_name +
+                                  " erfolgreich, schalte aus ")
+                    self.turndevicerelais(0, 0, 1)
+                    self._c_ausverz_f = 'N'
+                    # rechne Zeit exclusive einschaltgruppe
+                    local_time = datetime.now(timezone.utc).astimezone()
+                    localh = int(local_time.strftime(format="%H"))
+                    localminute = int(local_time.strftime(format="%M"))
+                    localinsec = int((localh * 60 * 60) + (localminute * 60))
+                    Sbase.nureinschaltinsec = localinsec + Sbase.einverz
+                    return
+
         if ((self.devuberschuss > self._device_einschaltschwelle)
            or (onnow == 1)):
             self._c_ausverz_f = 'N'

--- a/web/settings/smarthomeconfig.php
+++ b/web/settings/smarthomeconfig.php
@@ -464,21 +464,28 @@ $numDevices = 9;
 									<hr class="border-secondary">
 									<div class="form-group">
 										<div class="form-row mb-1">
-											<label class="col-md-4 col-form-label">Periodisch ausschalten...</label>
+											<label class="col-md-4 col-form-label">Einschalt/Ausschaltgruppe...</label>
 											<div class="col">
 												<div class="btn-group btn-group-toggle btn-block" id="device_deactivateperDevices<?php echo $devicenum; ?>" name="device_deactivateper" data-toggle="buttons" data-default="0" value="0" data-topicprefix="openWB/config/get/SmartHome/" data-topicsubgroup="Devices/<?php echo $devicenum; ?>/">
 													<label class="btn btn-outline-info">
 														<input type="radio" name="device_deactivateperDevices<?php echo $devicenum; ?>" id="device_deactivateper<?php echo $devicenum; ?>0" data-option="0" value="0" checked="checked">nie
 													</label>
 													<label class="btn btn-outline-info">
-														<input type="radio" name="device_deactivateperDevices<?php echo $devicenum; ?>" id="device_deactivateper<?php echo $devicenum; ?>1" data-option="1" value="1">jede volle Stunde
+														<input type="radio" name="device_deactivateperDevices<?php echo $devicenum; ?>" id="device_deactivateper<?php echo $devicenum; ?>1" data-option="1" value="1">jede volle Stunde prüfen oder ausschalten
 													</label>
 												 	<label class="btn btn-outline-info">
-														<input type="radio" name="device_deactivateperDevices<?php echo $devicenum; ?>" id="device_deactivateper<?php echo $devicenum; ?>2" data-option="2" value="2">jede volle Stunde / jede halbe Stunde
+														<input type="radio" name="device_deactivateperDevices<?php echo $devicenum; ?>" id="device_deactivateper<?php echo $devicenum; ?>2" data-option="2" value="2">jede volle Stunde / jede halbe Stunde prüfen oder ausschalten
 													</label>
+												 	<label class="btn btn-outline-info">
+														<input type="radio" name="device_deactivateperDevices<?php echo $devicenum; ?>" id="device_deactivateper<?php echo $devicenum; ?>2" data-option="100" value="100">gehört zu Einschaltgruppe
+													</label>
+
+
+
 												</div>
-												<span class="form-text small">Diese Option (bei jeder vollen Stunde / jede halbe Stunde) sorgt dafür, dass dieses Gerät periodisch ausgestellt wird ohne Ausschaltschwelle / Ausschaltverzögerung zu berücksichtigen. Dann können andere Geräte mit dem freiwerden Überschuss eingeschaltet werden.
+												<span class="form-text small">Diese Option (bei jeder vollen Stunde / jede halbe Stunde) sorgt dafür, dass dieses Gerät periodisch ausgestellt wird ohne Ausschaltschwelle / Ausschaltverzögerung zu berücksichtigen (=Auschaltgruppe). Dann können andere Geräte mit dem freiwerden Überschuss eingeschaltet werden. Sofern andere Geräte zuätzlich in der Einschaltgrupppe definiert werden, werden die Geräte in der Auschaltgruppe nur dann abgestellt wenn genug Überschuss dann da ist um die ganze Einschaltgrupppe anzustellen.
 												</span>
+												<span class="text-danger">Diese Funktion ist in der Entwicklung.</span>
 											</div>
 										</div>
 									</div>


### PR DESCRIPTION
Neu kann im Smarthomemq eine Auschaltgruppe und eine Einschaltgruppe definiert werden.
Sofern andere Geräte zusätzlich in der Einschaltgrupppe definiert werden, werden die Geräte in der Ausschaltgruppe periodisch überprüft und nur dann abgestellt wenn genug Überschuss dann da ist um die ganze Einschaltgrupppe anzustellen.
Sofern keine Einschaltgruppe definiert ist, werden die Gerät in der Ausschaltgruppe (wie heute) periodisch abgestellt.
DAmit lässt sich eine Priorisierung der Smarthomegeräte erreichen.