### PR TITLE
Update kostal_piko.py to Output power

### DIFF
--- a/modules/bezug_kostalpiko/kostal_piko.py
+++ b/modules/bezug_kostalpiko/kostal_piko.py
@@ -17,7 +17,7 @@ def update(wrkostalpikoip: str, speichermodul: str):
     # Auslesen eines Kostal Piko WR über die integrierte API des WR mit angeschlossenem Eigenverbrauchssensor.
 
     params = (
-        ('dxsEntries', ['33556736', '251658753', '83887106', '83887362', '83887618']),
+        ('dxsEntries', ['67109120', '251658753', '83887106', '83887362', '83887618']),
     )
     pvwatttmp = requests.get('http://'+wrkostalpikoip+'/api/dxs.json', params=params, timeout=3).json()
     # aktuelle Ausgangsleistung am WR [W]


### PR DESCRIPTION
Ich habe gerade mal in den Code geschaut.
'dxsEntries', ['33556736', '251658753', '83887106', '83887362', '83887618']
Hier scheint mir der erste Wert falsch zu sein. Hier sollte '67109120' stehen. Das wäre dann der "GridAC" und somit zumindest meiner Meinung nach der richtige Wert. Es hilft ja nichts zu wissen, was die Panales liefern. Der Output des Wechselrichters ist für uns interessant, oder?

-Total DC input [W][double] --> http://192.168.178.21/api/dxs.json?dxsEntries=33556736
-Output power [W][double] --> http://192.168.178.21/api/dxs.json?dxsEntries=67109120