### PR TITLE
smartmq Kanalwahl für Shellies

### DIFF
--- a/modules/smarthome/shelly/off.py
+++ b/modules/smarthome/shelly/off.py
@@ -1,17 +1,20 @@
 #!/usr/bin/python3
 import sys
-import os
 import time
-import json
-import getopt
-import socket
-import struct
-import codecs
-import binascii
 import urllib.request
-named_tuple = time.localtime() # getstruct_time
+named_tuple = time.localtime()  # getstruct_time
 time_string = time.strftime("%m/%d/%Y, %H:%M:%S shelly off.py", named_tuple)
-devicenumber=str(sys.argv[1])
-ipadr=str(sys.argv[2])
-uberschuss=int(sys.argv[3])
-urllib.request.urlopen("http://"+str(ipadr)+"/relay/0?turn=off", timeout=3)
+devicenumber = str(sys.argv[1])
+ipadr = str(sys.argv[2])
+uberschuss = int(sys.argv[3])
+try:
+    chan = int(sys.argv[4])
+except Exception:
+    chan = 0
+if (chan == 0):
+    urllib.request.urlopen("http://"+str(ipadr)+"/relay/0?turn=off",
+                           timeout=3)
+else:
+    chan = chan - 1
+    urllib.request.urlopen("http://"+str(ipadr)+"/relay/" + str(chan) +
+                           "?turn=off", timeout=3)

--- a/modules/smarthome/shelly/on.py
+++ b/modules/smarthome/shelly/on.py
@@ -1,17 +1,20 @@
 #!/usr/bin/python3
 import sys
-import os
 import time
-import json
-import getopt
-import socket
-import struct
-import codecs
-import binascii
 import urllib.request
-named_tuple = time.localtime() # getstruct_time
+named_tuple = time.localtime()  # getstruct_time
 time_string = time.strftime("%m/%d/%Y, %H:%M:%S shelly on.py", named_tuple)
-devicenumber=str(sys.argv[1])
-ipadr=str(sys.argv[2])
-uberschuss=int(sys.argv[3])
-urllib.request.urlopen("http://"+str(ipadr)+"/relay/0?turn=on", timeout=3)
+devicenumber = str(sys.argv[1])
+ipadr = str(sys.argv[2])
+uberschuss = int(sys.argv[3])
+try:
+    chan = int(sys.argv[4])
+except Exception:
+    chan = 0
+if (chan == 0):
+    urllib.request.urlopen("http://"+str(ipadr)+"/relay/0?turn=on",
+                           timeout=3)
+else:
+    chan = chan - 1
+    urllib.request.urlopen("http://"+str(ipadr)+"/relay/" + str(chan) +
+                           "?turn=on", timeout=3)

--- a/modules/smarthome/shelly/watt.py
+++ b/modules/smarthome/shelly/watt.py
@@ -3,33 +3,44 @@ import sys
 import os
 import time
 import json
-import getopt
-import socket
-import struct
-import codecs
-import binascii
 import urllib.request
 
-def totalPowerFromShellyJson(answer):
-    if 'meters' in answer:
-        meters = answer['meters'] # shelly
-    else:
-        meters = answer['emeters'] # shellyEM & shelly3EM
-    total = 0
-    # shellyEM has one meter, shelly3EM has three meters:
-    for meter in meters:
-        total = total + meter['power']
+
+def totalPowerFromShellyJson(answer, chan):
+    if (chan == 0):
+        if 'meters' in answer:
+            meters = answer['meters']   # shelly
+        else:
+            meters = answer['emeters']  # shellyEM & shelly3EM
+        total = 0
+        # shellyEM has one meter, shelly3EM has three meters:
+        for meter in meters:
+            total = total + meter['power']
+        return int(total)
+    chan = chan - 1
+    try:
+        total = int(answer['meters'][chan]['power'])   # Abfrage shelly
+    except Exception:
+        total = int(answer['emeters'][chan]['power'])  # Abfrage shellyEM
     return int(total)
 
 
-named_tuple = time.localtime() # getstruct_time
+named_tuple = time.localtime()   # getstruct_time
 time_string = time.strftime("%m/%d/%Y, %H:%M:%S shelly watty.py", named_tuple)
-devicenumber=str(sys.argv[1])
-ipadr=str(sys.argv[2])
-uberschuss=int(sys.argv[3])
-
-# Setze Default-Werte, andernfalls wird der letzte Wert ewig fortgeschrieben. Insbesondere wichtig für aktuelle Leistung
-powerc = 0 # Zähler wird beim Neustart auf 0 gesetzt, darf daher nicht übergeben werden.
+devicenumber = str(sys.argv[1])
+ipadr = str(sys.argv[2])
+uberschuss = int(sys.argv[3])
+try:
+    chan = int(sys.argv[4])
+except Exception:
+    chan = 0
+# chan = 0 alle Meter, Kan 0
+# chan = 1 meter 1, Kan 0
+# chan = 2 meter 2, kan 1
+# Setze Default-Werte, andernfalls wird der letzte Wert ewig fortgeschrieben.
+# Insbesondere wichtig für aktuelle Leistung
+# Zähler wird beim Neustart auf 0 gesetzt, darf daher nicht übergeben werden.
+powerc = 0
 temp0 = '0.0'
 temp1 = '0.0'
 temp2 = '0.0'
@@ -40,76 +51,93 @@ gen = '1'
 # test dic
 g_dictionary = {"gen": 1}
 
-a_dictionary = {"switch:0":{"id": 0, "source": "init", "output": True, "apower": 55.000, "voltage": 218.794,"aenergy": {"total":4327.45,"minute_ts":1637430901},"temperature":{"tC":49.1, "tF":120.3}}}
+a_dictionary = {"switch:1": {"id": 0, "source": "init", "output": True,
+                             "apower": 93.000, "voltage": 218.794,
+                "aenergy": {"total": 4327.45, "minute_ts": 1637430901},
+                "temperature": {"tC": 49.1, "tF": 120.3}}}
 
 # test dic ende
 # lesen endpoint, gen bestimmem. gen 1 hat unter Umstaenden keinen Eintrag
-fname =   '/var/www/html/openWB/ramdisk/smarthome_device_ret' + str(devicenumber) + '_shelly_info'
-fnameg =   '/var/www/html/openWB/ramdisk/smarthome_device_ret' + str(devicenumber) + '_shelly_infog'
+fbase = '/var/www/html/openWB/ramdisk/smarthome_device_ret'
+fname = fbase + str(devicenumber) + '_shelly_info'
+fnameg = fbase + str(devicenumber) + '_shelly_infog'
 if os.path.isfile(fnameg):
-    f = open(fnameg, 'r')
-    gen=str(f.read())
-    f.close()
-else:   
-    answergen= json.loads(str(urllib.request.urlopen("http://"+str(ipadr)+"/shelly", timeout=3).read().decode("utf-8")))
-    #answergen.update(g_dictionary)
-    f = open(fname, 'w')
-    json.dump(answergen,f)
-    f.close()
-    if 'gen' in answergen:
-        gen = str(int(answergen['gen']))
-    f = open(fnameg, 'w')
-    f.write(str(gen))
-    f.close()
+    with open(fnameg, 'r') as f:
+        gen = str(f.read())
+else:
+    aread = urllib.request.urlopen("http://" + str(ipadr) + "/shelly",
+                                   timeout=3).read().decode("utf-8")
+    agen = json.loads(str(aread))
+    # agen.update(g_dictionary)
+    with open(fname, 'w') as f:
+        json.dump(agen, f)
+    if 'gen' in agen:
+        gen = str(int(agen['gen']))
+    with open(fnameg, 'w') as f:
+        f.write(str(gen))
 # Versuche Daten von Shelly abzurufen.
 try:
     if (gen == "1"):
-        answer = json.loads(str(urllib.request.urlopen("http://"+str(ipadr)+"/status", timeout=3).read().decode("utf-8")))
-        #answer.update(a_dictionary)  
+        aread = urllib.request.urlopen("http://"+str(ipadr)+"/status",
+                                       timeout=3).read().decode("utf-8")
+        answer = json.loads(str(aread))
+        # answer.update(a_dictionary)
         # fake new gen
-        #gen = '2'
+        # gen = '2'
     else:
-        answer = json.loads(str(urllib.request.urlopen("http://"+str(ipadr)+"/rpc/Shelly.GetStatus", timeout=3).read().decode("utf-8")))
-    f = open('/var/www/html/openWB/ramdisk/smarthome_device_ret' + str(devicenumber) + '_shelly', 'w')
-    f.write(str(answer))
-    f.close()
-except:
-    print("failed to connect to device on " +  ipadr + ", setting all values to 0")
-#answer.update(a_dictionary)
-# Versuche Werte aus der Antwort zu extrahieren.
+        aread = urllib.request.urlopen("http://"+str(ipadr) +
+                                       "/rpc/Shelly.GetStatus",
+                                       timeout=3).read().decode("utf-8")
+        answer = json.loads(str(aread))
+    with open('/var/www/html/openWB/ramdisk/smarthome_device_ret' +
+              str(devicenumber) + '_shelly', 'w') as f:
+        f.write(str(answer))
+except Exception:
+    print("failed to connect to device on " +
+          ipadr + ", setting all values to 0")
+#  answer.update(a_dictionary)
+#  Versuche Werte aus der Antwort zu extrahieren.
 try:
     if (gen == "1"):
-        aktpower = totalPowerFromShellyJson(answer)
+        aktpower = totalPowerFromShellyJson(answer, chan)
     else:
-        aktpower = int(answer['switch:0'] ['apower'])
-except:
+        if (chan > 0):
+            chan = chan - 1
+        sw = 'switch:' + str(chan)
+        aktpower = int(answer[sw]['apower'])
+except Exception:
     pass
 
 try:
     if (gen == "1"):
-        relais = int(answer['relays'][0]['ison'])
+        if (chan > 0):
+            chan = chan - 1
+        relais = int(answer['relays'][chan]['ison'])
     else:
-        relais = int(answer['switch:0'] ['output'])
-except:
+        if (chan > 0):
+            chan = chan - 1
+        sw = 'switch:' + str(chan)
+        relais = int(answer[sw]['output'])
+except Exception:
     pass
 
 try:
     temp0 = str(answer['ext_temperature']['0']['tC'])
-except:
+except Exception:
     pass
 
 try:
     temp1 = str(answer['ext_temperature']['1']['tC'])
-except:
+except Exception:
     pass
 
 try:
     temp2 = str(answer['ext_temperature']['2']['tC'])
-except:
+except Exception:
     pass
-
-answer = '{"power":' + str(aktpower) + ',"powerc":' + str(powerc) + ',"on":' + str(relais) + ',"temp0":' + str(temp0) + ',"temp1":' + str(temp1) + ',"temp2":' + str(temp2) + '} '
-
-f1 = open('/var/www/html/openWB/ramdisk/smarthome_device_ret' + str(devicenumber), 'w')
-json.dump(answer,f1)
-f1.close()
+answer = '{"power":' + str(aktpower) + ',"powerc":' + str(powerc)
+answer += ',"on":' + str(relais) + ',"temp0":' + str(temp0)
+answer += ',"temp1":' + str(temp1) + ',"temp2":' + str(temp2) + '}'
+with open('/var/www/html/openWB/ramdisk/smarthome_device_ret' +
+          str(devicenumber), 'w') as f1:
+    json.dump(answer, f1)

--- a/runs/mqttsub.py
+++ b/runs/mqttsub.py
@@ -137,6 +137,16 @@ def on_message(client, userdata, msg):
                 if ( 1 <= int(devicenumb) <= numberOfSupportedDevices and 0 <= int(msg.payload) <= 1):
                     writetoconfig(shconfigfile,'smarthomedevices','device_differentMeasurement_'+str(devicenumb),msg.payload.decode("utf-8"))
                     client.publish("openWB/config/get/SmartHome/Devices/"+str(devicenumb)+"/device_differentMeasurement", msg.payload.decode("utf-8"), qos=0, retain=True)
+            if (( "openWB/config/set/SmartHome/Device" in msg.topic) and ("device_chan" in msg.topic)):
+                devicenumb=re.sub(r'\D', '', msg.topic)
+                if ( 1 <= int(devicenumb) <= numberOfSupportedDevices and 0 <= int(msg.payload) <= 6):
+                    writetoconfig(shconfigfile,'smarthomedevices','device_chan_'+str(devicenumb),msg.payload.decode("utf-8"))
+                    client.publish("openWB/config/get/SmartHome/Devices/"+str(devicenumb)+"/device_chan", msg.payload.decode("utf-8"), qos=0, retain=True)
+            if (( "openWB/config/set/SmartHome/Device" in msg.topic) and ("device_measchan" in msg.topic)):
+                devicenumb=re.sub(r'\D', '', msg.topic)
+                if ( 1 <= int(devicenumb) <= numberOfSupportedDevices and 0 <= int(msg.payload) <= 6):
+                    writetoconfig(shconfigfile,'smarthomedevices','device_measchan_'+str(devicenumb),msg.payload.decode("utf-8"))
+                    client.publish("openWB/config/get/SmartHome/Devices/"+str(devicenumb)+"/device_measchan", msg.payload.decode("utf-8"), qos=0, retain=True)
             if (( "openWB/config/set/SmartHome/Device" in msg.topic) and ("device_ip" in msg.topic)):
                 devicenumb=re.sub(r'\D', '', msg.topic)
                 if ( 1 <= int(devicenumb) <= numberOfSupportedDevices and len(str(msg.payload.decode("utf-8"))) > 6 and bool(re.match(ipallowed, msg.payload.decode("utf-8")))):

--- a/runs/usmarthome/smartbase.py
+++ b/runs/usmarthome/smartbase.py
@@ -87,6 +87,7 @@ class Sbase(Sbase0):
         self._mydevicepb = 'none'
         self._oldrelais = '2'
         self._oldwatt = 0
+        self._device_chan = 0
         # mqtt per
         self._whimported_tmp = 0
         self.runningtime = 0
@@ -330,6 +331,8 @@ class Sbase(Sbase0):
                 self._device_onuntiltime = value
             elif (key == 'mode'):
                 self.device_manual = valueint
+            elif (key == 'device_chan'):
+                self._device_chan = valueint
             elif (key == 'device_manual_control'):
                 self.device_manual_control = valueint
             elif (key == 'device_deactivateper'):

--- a/runs/usmarthome/smartmeas.py
+++ b/runs/usmarthome/smartmeas.py
@@ -40,6 +40,8 @@ class Slbase(Sbase0):
         self._device_actor = 'none'
         self._device_username = 'none'
         self._device_password = 'none'
+        self._device_measchan = 0
+        self._device_chan = 0
 
     def updatepar(self, input_param):
         self._smart_param = input_param.copy()
@@ -87,6 +89,10 @@ class Slbase(Sbase0):
                 self._device_measureportsdm = value
             elif (key == 'device_measuresmaage'):
                 self._device_measuresmaage = valueint
+            elif (key == 'device_measchan'):
+                self._device_measchan = valueint
+            elif (key == 'device_chan'):
+                self._device_chan = valueint                
             elif (key == 'device_measuresmaser'):
                 self._device_measuresmaser = value
             elif (key == 'device_measureid'):
@@ -162,15 +168,16 @@ class Slshelly(Slbase):
         print('__init__ Slshelly excuted')
 
     def getwattread(self):
-        self._watt(self._device_ip)
+        self._watt(self._device_ip, self._device_chan)
 
     def sepwattread(self):
-        self._watt(self._device_measureip)
+        self._watt(self._device_measureip, self._device_measchan)
         return self.newwatt, self.newwattk
 
-    def _watt(self, ip):
+    def _watt(self, ip, chan):
         argumentList = ['python3', self._prefixpy + 'shelly/watt.py',
-                        str(self.device_nummer), str(ip), '0']
+                        str(self.device_nummer), str(ip), '0',
+                        str(chan)]
         try:
             proc = subprocess.Popen(argumentList)
             proc.communicate()

--- a/runs/usmarthome/smartshelly.py
+++ b/runs/usmarthome/smartshelly.py
@@ -44,7 +44,8 @@ class Sshelly(Sbase):
             pname = "/off.py"
 
         argumentList = ['python3', self._prefixpy + 'shelly' + pname,
-                        str(self.device_nummer), str(self._device_ip), '0']
+                        str(self.device_nummer), str(self._device_ip), '0',
+                        str(self._device_chan)]
         try:
             self.proc = subprocess.Popen(argumentList)
             self.proc.communicate()

--- a/web/settings/smarthomeconfig.php
+++ b/web/settings/smarthomeconfig.php
@@ -161,6 +161,21 @@ $numDevices = 9;
 									</div>
 								</div>
 							</div>
+							<div class="device<?php echo $devicenum; ?>-option device<?php echo $devicenum; ?>-option-shelly hide">
+								<hr class="border-secondary">
+								<div class="form-row mb-1">
+									<label for="device_chanDevices<?php echo $devicenum; ?>" class="col-md-4 col-form-label">Kanal/Meter Auswahl</label>
+									<select class="form-control" name="device_chan" id="device_chanDevices<?php echo $devicenum; ?>" data-default="0" data-topicprefix="openWB/config/get/SmartHome/" data-topicsubgroup="Devices/<?php echo $devicenum; ?>/">
+										<option value="0" data-option="0" selected="selected">Kanal 0 / alle Meter summiert</option>
+										<option value="1" data-option="1">Kanal 0 / Meter 1</option>
+										<option value="2" data-option="2">Kanal 1 / Meter 2</option>
+										<option value="3" data-option="3">Kanal 2 / Meter 3</option>
+										<option value="4" data-option="4">Kanal 3 / Meter 4</option>
+										<option value="5" data-option="5">Kanal 4 / Meter 5</option>
+										<option value="6" data-option="6">Kanal 5 / Meter 6</option>
+									</select>
+								</div>
+							</div>
 							<div class="device<?php echo $devicenum; ?>-option device<?php echo $devicenum; ?>-option-none hide">
 								<hr class="border-secondary">
 								<div class="form-row mb-1">
@@ -671,6 +686,21 @@ $numDevices = 9;
 									<label for="device_measureipDevices<?php echo $devicenum; ?>" class="col-md-4 col-form-label">IP Adresse</label>
 									<div class="col">
 										<input id="device_measureipDevices<?php echo $devicenum; ?>" name="device_measureip" class="form-control" type="text" required="required" pattern="^((\d{1,2}|1\d\d|2[0-4]\d|25[0-5])\.){3}(\d{1,2}|1\d\d|2[0-4]\d|25[0-5])$" data-default="192.168.1.1" value="192.168.1.1" inputmode="text"  data-topicprefix="openWB/config/get/SmartHome/" data-topicsubgroup="Devices/<?php echo $devicenum; ?>/">
+									</div>
+								</div>
+								<div class="form-row mb-1 deviceMeasureTypeDevices<?php echo $devicenum; ?>-option deviceMeasureTypeDevices<?php echo $devicenum; ?>-option-shelly hide">
+									<div class="form-row mb-1">
+								  <hr class="border-secondary">
+										<label for="device_measchanDevices<?php echo $devicenum; ?>" class="col-md-4 col-form-label">Meter Auswahl</label>
+										<select class="form-control" name="device_measchan" id="device_measchanDevices<?php echo $devicenum; ?>" data-default="0" data-topicprefix="openWB/config/get/SmartHome/" data-topicsubgroup="Devices/<?php echo $devicenum; ?>/">
+											<option value="0" data-option="0" selected="selected">alle Meter summiert</option>
+											<option value="1" data-option="1">Meter 1</option>
+											<option value="2" data-option="2">Meter 2</option>
+											<option value="3" data-option="3">Meter 3</option>
+											<option value="4" data-option="4">Meter 4</option>
+											<option value="5" data-option="5">Meter 5</option>
+											<option value="6" data-option="6">Meter 6</option>
+										</select>
 									</div>
 								</div>
 								<div class="form-row mb-1 deviceMeasureTypeDevices<?php echo $devicenum; ?>-option deviceMeasureTypeDevices<?php echo $devicenum; ?>-option-sdm630 hide; ?>-option deviceMeasureTypeDevices<?php echo $devicenum; ?>-option-sdm120 hide; ?>-option deviceMeasureTypeDevices<?php echo $devicenum; ?>-option-we514 deviceMeasureTypeDevices<?php echo $devicenum; ?>-option-fronius hide">

--- a/web/settings/topicsToSubscribe_smarthomeconfig.js
+++ b/web/settings/topicsToSubscribe_smarthomeconfig.js
@@ -68,6 +68,8 @@ var topicsToSubscribe = [
 	["openWB/config/get/SmartHome/Devices/+/device_deactivateper", 0],
 	["openWB/config/get/SmartHome/Devices/+/device_pbtype", 0],
 	["openWB/config/get/SmartHome/Devices/+/device_pbip", 0],
+	["openWB/config/get/SmartHome/Devices/+/device_measchan", 0],
+	["openWB/config/get/SmartHome/Devices/+/device_chan", 0],
 	["openWB/config/get/SmartHome/Devices/+/device_measuresmaage", 0]
 
 ];


### PR DESCRIPTION
Neu wird die Kanalwahl für Shellies unterstützt. Im Gui kann ausgewählt werden:
a) Auf welchem Kanal das on/off Kommando geschickt wird.
b) Welcher Meter ausgelesen werden soll
Zusätzlich gibt es aus Kompatibilitätsgründen das bisherige Verhalten (alle Meter addieren, On / Off auf Kanal 0 senden) als Auswahloption.
Programme an flake8 angepasst