### PR TITLE
support for kostal piko hybrid systems

### DIFF
--- a/modules/bezug_kostalpiko/kostal_piko.py
+++ b/modules/bezug_kostalpiko/kostal_piko.py
@@ -31,6 +31,13 @@ def update(wrkostalpikoip: str, speichermodul: str):
     if pvwatt > 5:
         pvwatt = pvwatt*-1
 
+    # Bereinigen der WR-Leistung, um die Batterieentladeleistung, falls ein Hybrid-System vorhanden ist.
+    if speichermodul == "speicher_bydhv":
+        with open("/var/www/html/openWB/ramdisk/speicherleistung", "r") as f:
+            speicherleistung = float(f.read())
+        if speicherleistung < 0:
+            pvwatt -= speicherleistung
+
     # zur weiteren Verwendung im Webinterface
     with open("/var/www/html/openWB/ramdisk/pvwatt", "w") as f:
         f.write(str(pvwatt))


### PR DESCRIPTION
Ergänzung zu PR #2235: Wenn ein Hybrid-System vorhanden ist, muss noch die Batterieentladeleistung von der WR-Leistung subtrahiert werden. Bisher wurde in diesem Fall die DC-Ausgangsleistung des WR verwendet, was zu Ungenauigkeiten führt.