### PR TITLE
logging/validierung von mqtt  parameter

### DIFF
--- a/runs/smarthomemq.py
+++ b/runs/smarthomemq.py
@@ -4,6 +4,7 @@ import time
 import re
 import os
 import logging
+from usmarthome.global0 import log, log_config
 from usmarthome.smartbase import Sbase
 from usmarthome.smartavm import Savm
 from usmarthome.smartacthor import Sacthor

--- a/runs/smarthomemq.py
+++ b/runs/smarthomemq.py
@@ -26,16 +26,12 @@ numberOfSupportedDevices = 9  # limit number of smarthome devices
 
 
 def initlog():
-    global log_config
-    global log
     formatter = logging.Formatter('%(asctime)s %(levelname)s %(message)s')
-    log_config = logging.getLogger("smartcon")
     log_config.setLevel(logging.DEBUG)
     fh = logging.FileHandler(bp+'/ramdisk/smartcon.log', encoding='utf8')
     fh.setLevel(logging.DEBUG)
     fh.setFormatter(formatter)
     log_config.addHandler(fh)
-    log = logging.getLogger("smarthome")
     log.setLevel(logging.DEBUG)
     fh = logging.FileHandler(bp+'/ramdisk/smarthome.log', encoding='utf8')
     fh.setLevel(logging.DEBUG)
@@ -49,7 +45,6 @@ def on_connect(client, userdata, flags, rc):
 
 
 def on_message(client, userdata, msg):
-    global log_config
     # wenn exception hier wird mit nächster msg weitergemacht
     # macht paho unter phyton 3 immer so
     global parammqtt
@@ -77,7 +72,6 @@ def on_message(client, userdata, msg):
 
 def checkbootdone():
     global resetmaxeinschaltdauer
-    global log
     resetmaxeinschaltdauer = 0
     try:
         with open(bp+'/ramdisk/bootinprogress', 'r') as value:
@@ -119,7 +113,6 @@ def loadregelvars():
     global numberOfSupportedDevices
     global maxspeicher
     global mydevices
-    global log
     try:
         with open(bp+'/ramdisk/speichervorhanden', 'r') as value:
             speichervorhanden = int(value.read())
@@ -194,7 +187,6 @@ def getdevicevalues():
     global mydevices
     global uberschuss
     global uberschussoffset
-    global log
     totalwatt = 0
     totalwattot = 0
     totalminhaus = 0
@@ -263,7 +255,6 @@ def getdevicevalues():
 
 def sendmq(mqtt_input):
     global mqtt_cache
-    global log
     client = mqtt.Client("openWB-SmartHome-bulkpublisher-" + str(os.getpid()))
     client.connect("localhost")
     for key, value in mqtt_input.items():
@@ -290,7 +281,6 @@ def update_devices():
     global parammqtt
     global mydevices
     global mqtt_cache
-    global log
     client = mqtt.Client("openWB-SmartHome-bulkpublisher-" + str(os.getpid()))
     client.connect("localhost")
     # statische daten einschaltgruppe
@@ -389,8 +379,6 @@ def update_devices():
 def readmq():
     global parammqtt
     global mydevices
-    global log_config
-    global log
     log_config.info("Config reRead start")
     log.info("Config reRead start")
     parammqtt = []
@@ -415,7 +403,6 @@ def resetmaxeinschaltdauerfunc():
     global resetmaxeinschaltdauer
     global numberOfSupportedDevices
     global mydevices
-    global log
     mqtt_reset = {}
     hour = time.strftime("%H")
     if (int(hour) == 0):

--- a/runs/usmarthome/global0.py
+++ b/runs/usmarthome/global0.py
@@ -1,0 +1,3 @@
+import logging
+log = logging.getLogger("smarthome")
+log_config = logging.getLogger("smartcon")

--- a/runs/usmarthome/smartacthor.py
+++ b/runs/usmarthome/smartacthor.py
@@ -1,7 +1,6 @@
 #!/usr/bin/python3
 from usmarthome.smartbase import Sbase
 import subprocess
-import json
 
 
 class Sacthor(Sbase):
@@ -27,9 +26,9 @@ class Sacthor(Sbase):
             elif (key == 'device_acthorpower'):
                 self._device_acthorpower = value
             else:
-                self.logClass(2, "(" + str(self.device_nummer) + ") " +
-                              __class__.__name__ + " überlesen " + key +
-                              " " + value)
+                self.log.warning("(" + str(self.device_nummer) + ") " +
+                                 __class__.__name__ + " überlesen " + key +
+                                 " " + value)
 
     def getwatt(self, uberschuss, uberschussoffset):
         self.prewatt(uberschuss, uberschussoffset)
@@ -40,15 +39,15 @@ class Sacthor(Sbase):
         try:
             self.proc = subprocess.Popen(argumentList)
             self.proc.communicate()
-            self.answer = self.readret()            
+            self.answer = self.readret()
             self.newwatt = int(self.answer['power'])
             self.newwattk = int(self.answer['powerc'])
             self.relais = int(self.answer['on'])
         except Exception as e1:
-            self.logClass(2, "(" + str(self.device_nummer) +
-                          ") Leistungsmessung %s %d %s Fehlermeldung: %s "
-                          % ('Acthor ', self.device_nummer,
-                             str(self._device_ip), str(e1)))
+            self.log.warning("(" + str(self.device_nummer) +
+                             ") Leistungsmessung %s %d %s Fehlermeldung: %s "
+                             % ('Acthor ', self.device_nummer,
+                                str(self._device_ip), str(e1)))
         self.postwatt()
 
     def turndevicerelais(self, zustand, ueberschussberechnung, updatecnt):
@@ -64,7 +63,7 @@ class Sacthor(Sbase):
             self.proc = subprocess.Popen(argumentList)
             self.proc.communicate()
         except Exception as e1:
-            self.logClass(2, "(" + str(self.device_nummer) +
-                          ") on / off  %s %d %s Fehlermeldung: %s "
-                          % ('Acthor ', self.device_nummer,
-                             str(self._device_ip), str(e1)))
+            self.log.warning("(" + str(self.device_nummer) +
+                             ") on / off  %s %d %s Fehlermeldung: %s "
+                             % ('Acthor ', self.device_nummer,
+                                str(self._device_ip), str(e1)))

--- a/runs/usmarthome/smartacthor.py
+++ b/runs/usmarthome/smartacthor.py
@@ -1,5 +1,6 @@
 #!/usr/bin/python3
 from usmarthome.smartbase import Sbase
+from usmarthome.global0 import log
 import subprocess
 
 
@@ -26,9 +27,9 @@ class Sacthor(Sbase):
             elif (key == 'device_acthorpower'):
                 self._device_acthorpower = value
             else:
-                self.log.warning("(" + str(self.device_nummer) + ") " +
-                                 __class__.__name__ + " überlesen " + key +
-                                 " " + value)
+                log.warning("(" + str(self.device_nummer) + ") " +
+                            __class__.__name__ + " überlesen " + key +
+                            " " + value)
 
     def getwatt(self, uberschuss, uberschussoffset):
         self.prewatt(uberschuss, uberschussoffset)
@@ -44,10 +45,10 @@ class Sacthor(Sbase):
             self.newwattk = int(self.answer['powerc'])
             self.relais = int(self.answer['on'])
         except Exception as e1:
-            self.log.warning("(" + str(self.device_nummer) +
-                             ") Leistungsmessung %s %d %s Fehlermeldung: %s "
-                             % ('Acthor ', self.device_nummer,
-                                str(self._device_ip), str(e1)))
+            log.warning("(" + str(self.device_nummer) +
+                        ") Leistungsmessung %s %d %s Fehlermeldung: %s "
+                        % ('Acthor ', self.device_nummer,
+                           str(self._device_ip), str(e1)))
         self.postwatt()
 
     def turndevicerelais(self, zustand, ueberschussberechnung, updatecnt):
@@ -63,7 +64,7 @@ class Sacthor(Sbase):
             self.proc = subprocess.Popen(argumentList)
             self.proc.communicate()
         except Exception as e1:
-            self.log.warning("(" + str(self.device_nummer) +
-                             ") on / off  %s %d %s Fehlermeldung: %s "
-                             % ('Acthor ', self.device_nummer,
-                                str(self._device_ip), str(e1)))
+            log.warning("(" + str(self.device_nummer) +
+                        ") on / off  %s %d %s Fehlermeldung: %s "
+                        % ('Acthor ', self.device_nummer,
+                           str(self._device_ip), str(e1)))

--- a/runs/usmarthome/smartavm.py
+++ b/runs/usmarthome/smartavm.py
@@ -37,18 +37,18 @@ class Savm(Sbase):
             elif (key == 'device_password'):
                 self._device_password = value
             else:
-                self.logClass(2, "(" + str(self.device_nummer) + ") " +
+                self.log.info("(" + str(self.device_nummer) + ") " +
                               __class__.__name__ + " überlesen " + key +
                               " " + value)
 
         if (self._old_measuretype0 == 'none'):
             self._mydevicemeasure0 = Slavm()
             self._old_measuretype0 = 'avm'
-            self.logClass(2, "(" + str(self.device_nummer) +
+            self.log.info("(" + str(self.device_nummer) +
                           ") Integrierte Leistungsmessung. Neues Measure" +
                           " device erzeugt " + self.device_type)
         else:
-            self.logClass(2, "(" + str(self.device_nummer) +
+            self.log.info("(" + str(self.device_nummer) +
                           ") Integrierte Leistungsmessung. Nur Parameter" +
                           " update " + self.device_type)
         self._mydevicemeasure0.updatepar(input_param)
@@ -71,7 +71,7 @@ class Savm(Sbase):
             self.proc = subprocess.Popen(argumentList)
             self.proc.communicate()
         except Exception as e1:
-            self.logClass(2, "(" + str(self.device_nummer) +
-                          ") on / off %s %d %s Fehlermeldung: %s "
-                          % ('avm', self.device_nummer,
-                             str(self._device_ip), str(e1)))
+            self.log.warning("(" + str(self.device_nummer) +
+                             ") on / off %s %d %s Fehlermeldung: %s "
+                             % ('avm', self.device_nummer,
+                                str(self._device_ip), str(e1)))

--- a/runs/usmarthome/smartavm.py
+++ b/runs/usmarthome/smartavm.py
@@ -1,5 +1,6 @@
 #!/usr/bin/python3
 from usmarthome.smartbase import Sbase, Slavm
+from usmarthome.global0 import log
 import subprocess
 
 
@@ -37,20 +38,20 @@ class Savm(Sbase):
             elif (key == 'device_password'):
                 self._device_password = value
             else:
-                self.log.info("(" + str(self.device_nummer) + ") " +
-                              __class__.__name__ + " überlesen " + key +
-                              " " + value)
+                log.info("(" + str(self.device_nummer) + ") " +
+                         __class__.__name__ + " überlesen " + key +
+                         " " + value)
 
         if (self._old_measuretype0 == 'none'):
             self._mydevicemeasure0 = Slavm()
             self._old_measuretype0 = 'avm'
-            self.log.info("(" + str(self.device_nummer) +
-                          ") Integrierte Leistungsmessung. Neues Measure" +
-                          " device erzeugt " + self.device_type)
+            log.info("(" + str(self.device_nummer) +
+                     ") Integrierte Leistungsmessung. Neues Measure" +
+                     " device erzeugt " + self.device_type)
         else:
-            self.log.info("(" + str(self.device_nummer) +
-                          ") Integrierte Leistungsmessung. Nur Parameter" +
-                          " update " + self.device_type)
+            log.info("(" + str(self.device_nummer) +
+                     ") Integrierte Leistungsmessung. Nur Parameter" +
+                     " update " + self.device_type)
         self._mydevicemeasure0.updatepar(input_param)
 
     def turndevicerelais(self, zustand, ueberschussberechnung, updatecnt):
@@ -71,7 +72,7 @@ class Savm(Sbase):
             self.proc = subprocess.Popen(argumentList)
             self.proc.communicate()
         except Exception as e1:
-            self.log.warning("(" + str(self.device_nummer) +
-                             ") on / off %s %d %s Fehlermeldung: %s "
-                             % ('avm', self.device_nummer,
-                                str(self._device_ip), str(e1)))
+            log.warning("(" + str(self.device_nummer) +
+                        ") on / off %s %d %s Fehlermeldung: %s "
+                        % ('avm', self.device_nummer,
+                           str(self._device_ip), str(e1)))

--- a/runs/usmarthome/smartbase.py
+++ b/runs/usmarthome/smartbase.py
@@ -1,6 +1,7 @@
 #!/usr/bin/python3
 import time
 import os
+from usmarthome.global0 import log
 from usmarthome.smartbase0 import Sbase0
 from usmarthome.smartmeas import Slsdm630, Slsdm120, Slwe514, Slfronius
 from usmarthome.smartmeas import Sljson, Slsmaem, Slshelly, Sltasmota, Slmqtt
@@ -170,16 +171,16 @@ class Sbase(Sbase0):
                           self._device_mineinschaltdauer) + 30
             timesince = int(time.time()) - int(self.c_mantime)
             if (manverz < timesince):
-                self.log.info("(" + str(self.device_nummer) + ") von Manuell "
-                              + "auf Automatisch gestellt oder startup,"
-                              + " Uebergangsfrist abgelaufen" +
-                              self.c_mantime_f)
+                log.info("(" + str(self.device_nummer) + ") von Manuell "
+                         + "auf Automatisch gestellt oder startup,"
+                         + " Uebergangsfrist abgelaufen" +
+                         self.c_mantime_f)
                 self.c_mantime_f = 'N'
             else:
-                self.log.info("(" + str(self.device_nummer) + ") von Manuell" +
-                              " auf Automatisch gestellt oder startup," +
-                              " Übergangsfrist laueft noch " + str(manverz) +
-                              " > " + str(timesince))
+                log.info("(" + str(self.device_nummer) + ") von Manuell" +
+                         " auf Automatisch gestellt oder startup," +
+                         " Übergangsfrist laueft noch " + str(manverz) +
+                         " > " + str(timesince))
                 self.abschalt = 0
         self._oldwatt = self.newwatt
         with open(self._basePath+'/ramdisk/device' + str(self.device_nummer) +
@@ -347,33 +348,33 @@ class Sbase(Sbase0):
             elif (key == 'WHImported_temp'):
                 if (self._first_run == 1):
                     self._whimported_tmp = valueint
-                    self.log.info("(" + str(self.device_nummer) +
-                                  ") aus mqtt übernommen " + key +
-                                  " " + value)
+                    log.info("(" + str(self.device_nummer) +
+                             ") aus mqtt übernommen " + key +
+                             " " + value)
             elif (key == 'RunningTimeToday'):
                 if (self._first_run == 1):
                     self.runningtime = valueint
-                    self.log.info("(" + str(self.device_nummer) +
-                                  ") aus mqtt übernommen " + key +
-                                  " " + value)
+                    log.info("(" + str(self.device_nummer) +
+                             ") aus mqtt übernommen " + key +
+                             " " + value)
             elif (key == 'oncountnor'):
                 if (self._first_run == 1):
                     self.oncountnor = value
-                    self.log.info("(" + str(self.device_nummer) +
-                                  ") aus mqtt übernommen " + key +
-                                  " " + value)
+                    log.info("(" + str(self.device_nummer) +
+                             ") aus mqtt übernommen " + key +
+                             " " + value)
             elif (key == 'OnCntStandby'):
                 if (self._first_run == 1):
                     self.oncntstandby = value
                     # status normal setzen
                     self.devstatus = 10
-                    self.log.info("(" + str(self.device_nummer) +
-                                  ") aus mqtt übernommen " + key +
-                                  " " + value)
+                    log.info("(" + str(self.device_nummer) +
+                             ") aus mqtt übernommen " + key +
+                             " " + value)
             else:
-                self.log.info("(" + str(self.device_nummer) + ") "
-                              + __class__.__name__ + " überlesen " + key +
-                              " " + value)
+                log.info("(" + str(self.device_nummer) + ") "
+                         + __class__.__name__ + " überlesen " + key +
+                         " " + value)
         self._first_run = 0
         pref = 'openWB/SmartHome/Devices/' + str(self.device_nummer) + '/'
         self.mqtt_param_del[pref + 'RelayStatus'] = '0'
@@ -403,33 +404,33 @@ class Sbase(Sbase0):
             if (self._old_pbtype == 'none'):
                 self._mydevicepb = Sbshelly()
                 self._old_pbtype = 'shelly'
-                self.log.info("(" + str(self.device_nummer) +
-                              ") control Button. Neues Button" +
-                              " device erzeugt Shelly")
+                log.info("(" + str(self.device_nummer) +
+                         ") control Button. Neues Button" +
+                         " device erzeugt Shelly")
             else:
-                self.log.info("(" + str(self.device_nummer) +
-                              ") Control Button. Nur Parameter " +
-                              " update ")
+                log.info("(" + str(self.device_nummer) +
+                         ") Control Button. Nur Parameter " +
+                         " update ")
             self._mydevicepb.updatepar(input_param)
         if ((self._device_pbtype == 'none') and
            (self._old_pbtype == 'shelly')):
             del self._mydevicepb
             self._old_pbtype = 'none'
-            self.log.info("(" + str(self.device_nummer) +
-                          ") Control Button gelöscht")
+            log.info("(" + str(self.device_nummer) +
+                     ") Control Button gelöscht")
         if (self._device_differentmeasurement == 1):
             if (self._oldmeasuretype1 == self._device_measuretype):
-                self.log.info("(" + str(self.device_nummer) +
-                              ") Separate Messung. Nur Parameter" +
-                              " update " + self._device_measuretype)
+                log.info("(" + str(self.device_nummer) +
+                         ") Separate Messung. Nur Parameter" +
+                         " update " + self._device_measuretype)
                 self._mydevicemeasure.updatepar(self._smart_param)
             else:
                 if (self._oldmeasuretype1 == 'empty'):
                     pass
                 else:
-                    self.log.info("(" + str(self.device_nummer) +
-                                  ") Separate Messung. Altes Measure"
-                                  + "device gelöscht " + self._oldmeasuretype1)
+                    log.info("(" + str(self.device_nummer) +
+                             ") Separate Messung. Altes Measure"
+                             + "device gelöscht " + self._oldmeasuretype1)
                     del self._mydevicemeasure
                 if (self._device_measuretype == 'sdm630'):
                     self._mydevicemeasure = Slsdm630()
@@ -456,20 +457,20 @@ class Sbase(Sbase0):
                 elif (self._device_measuretype == 'mystrom'):
                     self._mydevicemeasure = Slmystrom()
                 else:
-                    self.log.info("(" + str(self.device_nummer) +
-                                  ") Measuretype nicht untertützt " +
-                                  self._device_measuretype)
+                    log.info("(" + str(self.device_nummer) +
+                             ") Measuretype nicht untertützt " +
+                             self._device_measuretype)
                 self._mydevicemeasure.updatepar(self._smart_param)
                 self._oldmeasuretype1 = self._device_measuretype
-                self.log.info("(" + str(self.device_nummer) +
-                              ") Separate Messung. Neues Measure" +
-                              "device erzeugt " + self._device_measuretype)
+                log.info("(" + str(self.device_nummer) +
+                         ") Separate Messung. Neues Measure" +
+                         "device erzeugt " + self._device_measuretype)
         if ((self._device_differentmeasurement == 0) and
            (self._oldmeasuretype1 != 'empty')):
-            self.log.info("(" + str(self.device_nummer) +
-                          ") Separate Messung ausgeschaltet."
-                          " Altes Measure" +
-                          "device gelöscht " + self._oldmeasuretype1)
+            log.info("(" + str(self.device_nummer) +
+                     ") Separate Messung ausgeschaltet."
+                     " Altes Measure" +
+                     "device gelöscht " + self._oldmeasuretype1)
             del self._mydevicemeasure
             self._oldmeasuretype1 = 'empty'
         with open(self._basePath+'/ramdisk/smarthome_device_minhaus_' +
@@ -493,10 +494,10 @@ class Sbase(Sbase0):
                 self.oncountnor = str(int(self.oncountnor) + 1)
             else:
                 self.oncntstandby = str(int(self.oncntstandby) + 1)
-            self.log.info("(" + str(self.device_nummer) +
-                          ") angeschaltet. Überschussberechnung (1 = mit " +
-                          " Speicher, 2 = mit Offset) " +
-                          str(self.ueberschussberechnung))
+            log.info("(" + str(self.device_nummer) +
+                     ") angeschaltet. Überschussberechnung (1 = mit " +
+                     " Speicher, 2 = mit Offset) " +
+                     str(self.ueberschussberechnung))
             if updatecnt == 1:
                 self._c_eintime_f = 'Y'
                 self._c_eintime = int(time.time())
@@ -533,13 +534,13 @@ class Sbase(Sbase0):
         localminute = int(local_time.strftime(format="%M"))
         localinsec = int((localhour * 60 * 60) + (localminute * 60))
         if (localinsec < Sbase.nureinschaltinsec) and (Sbase.eindevices > 0):
-            self.log.info("(" + str(self.device_nummer) + ") " +
-                          self.device_name + " Prüfe nur Einschaltgruppe ")
+            log.info("(" + str(self.device_nummer) + ") " +
+                     self.device_name + " Prüfe nur Einschaltgruppe ")
             if (self.gruppe == 'E'):
                 pass
             else:
-                self.log.info("(" + str(self.device_nummer) + ") " +
-                              self.device_name + " kein Regelung")
+                log.info("(" + str(self.device_nummer) + ") " +
+                         self.device_name + " kein Regelung")
                 return
         # onnow = 0 -> normale Regelung
         # onnow = 1 -> Zeitpunkt erreciht, immer ein ohne Ueberschuss regelung
@@ -547,35 +548,35 @@ class Sbase(Sbase0):
         if (self._device_ontime != '00:00'):
             onhour = int(str("0") + str(self._device_ontime).partition(':')[0])
             onminute = int(str(self._device_ontime)[-2:])
-            self.log.info("(" + str(self.device_nummer) + ") " +
-                          self.device_name + " Immer an nach definiert " +
-                          str(onhour) + ":" + str('%.2d' % onminute) +
-                          " aktuelle Zeit " + str(localhour) + ":" +
-                          str('%.2d' % localminute))
+            log.info("(" + str(self.device_nummer) + ") " +
+                     self.device_name + " Immer an nach definiert " +
+                     str(onhour) + ":" + str('%.2d' % onminute) +
+                     " aktuelle Zeit " + str(localhour) + ":" +
+                     str('%.2d' % localminute))
             if ((onhour > localhour) or ((onhour == localhour)
                and (onminute >= localminute))):
                 pass
             else:
-                self.log.info("(" + str(self.device_nummer) + ") " +
-                              self.device_name +
-                              " schalte ein wegen Immer an nach")
+                log.info("(" + str(self.device_nummer) + ") " +
+                         self.device_name +
+                         " schalte ein wegen Immer an nach")
                 onnow = 1
         if (self._device_onuntiltime != '00:00'):
             onuntilh = int(str("0")
                            + str(self._device_onuntiltime).partition(':')[0])
             onuntilminute = int(str(self._device_onuntiltime)[-2:])
-            self.log.info("(" + str(self.device_nummer) + ") " +
-                          self.device_name + " Immer an vor definiert " +
-                          str(onuntilh) + ":" + str('%.2d' % onuntilminute)
-                          + " aktuelle Zeit " + str(localhour) + ":" +
-                          str('%.2d' % localminute))
+            log.info("(" + str(self.device_nummer) + ") " +
+                     self.device_name + " Immer an vor definiert " +
+                     str(onuntilh) + ":" + str('%.2d' % onuntilminute)
+                     + " aktuelle Zeit " + str(localhour) + ":" +
+                     str('%.2d' % localminute))
             if ((onuntilh < localhour) or ((onuntilh == localhour)
                and (onuntilminute <= localminute))):
                 pass
             else:
-                self.log.info("(" + str(self.device_nummer) + ") " +
-                              self.device_name +
-                              " schalte ein wegen Immer an vor")
+                log.info("(" + str(self.device_nummer) + ") " +
+                         self.device_name +
+                         " schalte ein wegen Immer an vor")
                 onnow = 1
         if ((self._device_finishtime != '00:00')
            and (self.oncountnor == str("0"))):
@@ -584,51 +585,51 @@ class Sbase(Sbase0):
             finishminute = int(str(self._device_finishtime)[-2:])
             startspatsec = int((finishhour * 60 * 60) + (finishminute * 60) -
                                self._device_mineinschaltdauer)
-            self.log.info("(" + str(self.device_nummer) + ") " +
-                          self.device_name +
-                          " finishtime definiert " +
-                          str(finishhour) + ":" + str('%.2d' % finishminute)
-                          + " aktuelle Zeit " + str(localhour) + ":" +
-                          str('%.2d' % localminute) +
-                          " Anzahl Starts heute 0 Mineinschaltdauer (Sec)"
-                          + str(self._device_mineinschaltdauer))
+            log.info("(" + str(self.device_nummer) + ") " +
+                     self.device_name +
+                     " finishtime definiert " +
+                     str(finishhour) + ":" + str('%.2d' % finishminute)
+                     + " aktuelle Zeit " + str(localhour) + ":" +
+                     str('%.2d' % localminute) +
+                     " Anzahl Starts heute 0 Mineinschaltdauer (Sec)"
+                     + str(self._device_mineinschaltdauer))
             if (((finishhour > localhour) or ((finishhour == localhour)
                and (finishminute >= localminute)))
                and (startspatsec <= localinsec)):
-                self.log.info("(" + str(self.device_nummer) + ") " +
-                              self.device_name +
-                              " schalte ein wegen finishtime, spaetester" +
-                              "start in sec " + str(startspatsec) +
-                              " aktuelle sec " + str(localinsec))
+                log.info("(" + str(self.device_nummer) + ") " +
+                         self.device_name +
+                         " schalte ein wegen finishtime, spaetester" +
+                         "start in sec " + str(startspatsec) +
+                         " aktuelle sec " + str(localinsec))
                 self.turndevicerelais(1, 0, 1)
                 self.devstatus = 30
                 return
         if self.devstatus == 30:
-            self.log.info("(" + str(self.device_nummer) + ") " +
-                          self.device_name +
-                          " finishtime laueft, pruefe Mindestlaufzeit")
+            log.info("(" + str(self.device_nummer) + ") " +
+                     self.device_name +
+                     " finishtime laueft, pruefe Mindestlaufzeit")
             if (self._c_eintime_f == 'Y'):
                 timesta = int(time.time()) - int(self._c_eintime)
                 if (self._device_mineinschaltdauer < timesta):
-                    self.log.info("(" + str(self.device_nummer) + ") " +
-                                  self.device_name +
-                                  " Mindesteinschaltdauer erreicht," +
-                                  " finishtime erreicht")
+                    log.info("(" + str(self.device_nummer) + ") " +
+                             self.device_name +
+                             " Mindesteinschaltdauer erreicht," +
+                             " finishtime erreicht")
                     self.devstatus = 10
                     return
                 else:
-                    self.log.info("(" + str(self.device_nummer) + ") " +
-                                  self.device_name +
-                                  " finishtime laueft, Mindesteinschaltdauer" +
-                                  "nicht erreicht, " +
-                                  str(self._device_mineinschaltdauer) +
-                                  " > " + str(timesta))
+                    log.info("(" + str(self.device_nummer) + ") " +
+                             self.device_name +
+                             " finishtime laueft, Mindesteinschaltdauer" +
+                             "nicht erreicht, " +
+                             str(self._device_mineinschaltdauer) +
+                             " > " + str(timesta))
                     return
             else:
-                self.log.info("(" + str(self.device_nummer) + ") " +
-                              self.device_name +
-                              " Mindesteinschaltdauer nicht bekannt," +
-                              " finishtime erreicht")
+                log.info("(" + str(self.device_nummer) + ") " +
+                         self.device_name +
+                         " Mindesteinschaltdauer nicht bekannt," +
+                         " finishtime erreicht")
                 self.devstatus = 10
                 return
         # here startup device_self._device_startupdetection
@@ -636,9 +637,9 @@ class Sbase(Sbase0):
            and (self.devstatus == 20)):
             self.devstatus = 10
             self.turndevicerelais(0, 0, 1)
-            self.log.info("(" + str(self.device_nummer) + ") " +
-                          self.device_name +
-                          " Anlauferkennung nun abgeschaltet ")
+            log.info("(" + str(self.device_nummer) + ") " +
+                     self.device_name +
+                     " Anlauferkennung nun abgeschaltet ")
             return
         # remove condition that device has to be off
         if ((self._device_startupdetection == 1)
@@ -646,9 +647,9 @@ class Sbase(Sbase0):
            and (self.oncountnor == str("0"))
            and (self.devstatus != 20)):
             self.devstatus = 20
-            self.log.info("(" + str(self.device_nummer) + ") " +
-                          self.device_name +
-                          " Anlauferkennung nun aktiv, eingeschaltet ")
+            log.info("(" + str(self.device_nummer) + ") " +
+                     self.device_name +
+                     " Anlauferkennung nun aktiv, eingeschaltet ")
             self.turndevicerelais(1, 0, 0)
             return
         if (self.devstatus == 20):
@@ -656,157 +657,157 @@ class Sbase(Sbase0):
                 if (self._c_anlaufz_f == 'Y'):
                     timesince = int(time.time()) - int((self._c_anlaufz))
                     if (self._device_standbyduration < timesince):
-                        self.log.info("(" + str(self.device_nummer) + ") " +
-                                      self.device_name +
-                                      " standbycheck abgelaufen " +
-                                      str(self._device_standbyduration) +
-                                      " ,sec pruefe Einschaltschwelle " +
-                                      str(self._device_standbypower))
+                        log.info("(" + str(self.device_nummer) + ") " +
+                                 self.device_name +
+                                 " standbycheck abgelaufen " +
+                                 str(self._device_standbyduration) +
+                                 " ,sec pruefe Einschaltschwelle " +
+                                 str(self._device_standbypower))
                         self.devstatus = 10
                         self._c_anlaufz_f = 'N'
                         if ((self.devuberschuss >
                            self._device_einschaltschwelle) or (onnow == 1)):
                             self._c_ausverz_f = 'N'
                             self._c_einverz_f = 'N'
-                            self.log.info("(" + str(self.device_nummer) +
-                                          ") " + self.device_name +
-                                          " Überschuss " +
-                                          str(self.devuberschuss) +
-                                          " größer Einschaltschwelle oder" +
-                                          " Immer an zeit erreicht, schalte " +
-                                          "ein (ohne Einschaltverzoegerung) " +
-                                          str(self._device_einschaltschwelle))
+                            log.info("(" + str(self.device_nummer) +
+                                     ") " + self.device_name +
+                                     " Überschuss " +
+                                     str(self.devuberschuss) +
+                                     " größer Einschaltschwelle oder" +
+                                     " Immer an zeit erreicht, schalte " +
+                                     "ein (ohne Einschaltverzoegerung) " +
+                                     str(self._device_einschaltschwelle))
                             self.turndevicerelais(1,
                                                   self.ueberschussberechnung,
                                                   1)
                         else:
-                            self.log.info("(" + str(self.device_nummer) +
-                                          ") " + self.device_name +
-                                          " Überschuss " +
-                                          str(self.devuberschuss) +
-                                          " kleiner Einschaltschwelle," +
-                                          " schalte aus " +
-                                          str(self._device_einschaltschwelle))
+                            log.info("(" + str(self.device_nummer) +
+                                     ") " + self.device_name +
+                                     " Überschuss " +
+                                     str(self.devuberschuss) +
+                                     " kleiner Einschaltschwelle," +
+                                     " schalte aus " +
+                                     str(self._device_einschaltschwelle))
                             self.turndevicerelais(0, 0, 1)
                         return
                     else:
-                        self.log.info("(" + str(self.device_nummer) + ") " +
-                                      self.device_name +
-                                      " standbycheck noch nicht erreicht " +
-                                      str(self._device_standbyduration) + " > "
-                                      + str(timesince))
+                        log.info("(" + str(self.device_nummer) + ") " +
+                                 self.device_name +
+                                 " standbycheck noch nicht erreicht " +
+                                 str(self._device_standbyduration) + " > "
+                                 + str(timesince))
                 else:
                     self._c_anlaufz_f = 'Y'
                     self._c_anlaufz = int(time.time())
-                    self.log.info("(" + str(self.device_nummer) + ") " +
-                                  self.device_name + " standbycheck gestartet "
-                                  + str(self.newwatt) + " > " +
-                                  str(self._device_standbypower))
+                    log.info("(" + str(self.device_nummer) + ") " +
+                             self.device_name + " standbycheck gestartet "
+                             + str(self.newwatt) + " > " +
+                             str(self._device_standbypower))
             else:
                 self._c_anlaufz_f = 'N'
-                self.log.info("(" + str(self.device_nummer) + ") " +
-                              self.device_name +
-                              " unter standbyschwelle , timer geloescht")
+                log.info("(" + str(self.device_nummer) + ") " +
+                         self.device_name +
+                         " unter standbyschwelle , timer geloescht")
         if (self._device_maxeinschaltdauer > self.runningtime):
-            self.log.info("(" + str(self.device_nummer) + ") " +
-                          self.device_name +
-                          " Maximale Einschaltdauer nicht erreicht")
+            log.info("(" + str(self.device_nummer) + ") " +
+                     self.device_name +
+                     " Maximale Einschaltdauer nicht erreicht")
         else:
             if (self.relais == 1):
-                self.log.info("(" + str(self.device_nummer) + ") " +
-                              self.device_name +
-                              " Maximale Einschaltdauer erreicht schalte ab")
+                log.info("(" + str(self.device_nummer) + ") " +
+                         self.device_name +
+                         " Maximale Einschaltdauer erreicht schalte ab")
                 self.turndevicerelais(0, 0, 1)
             else:
-                self.log.info("(" + str(self.device_nummer) + ")" +
-                              self.device_name +
-                              " Maximale Einschaltdauer erreicht" +
-                              " bereits abgeschaltet")
+                log.info("(" + str(self.device_nummer) + ")" +
+                         self.device_name +
+                         " Maximale Einschaltdauer erreicht" +
+                         " bereits abgeschaltet")
             return
         # Auto ladung
         if self._device_deactivatewhileevcharging > 0:
             if (self.relais == 1):
-                self.log.info("(" + str(self.device_nummer) + ") " +
-                              self.device_name +
-                              " Soll reduziert/abgeschaltet werden" +
-                              " bei Ladung, pruefe " + str(testcharge))
+                log.info("(" + str(self.device_nummer) + ") " +
+                         self.device_name +
+                         " Soll reduziert/abgeschaltet werden" +
+                         " bei Ladung, pruefe " + str(testcharge))
                 if chargestatus == 1:
-                    self.log.info("(" + str(self.device_nummer) + ") " +
-                                  self.device_name +
-                                  " Ladung läuft, pruefe Mindestlaufzeit")
+                    log.info("(" + str(self.device_nummer) + ") " +
+                             self.device_name +
+                             " Ladung läuft, pruefe Mindestlaufzeit")
                     if (self._c_eintime_f == 'Y'):
                         timesta = int(time.time()) - int(self._c_eintime)
                         if (self._device_mineinschaltdauer < timesta):
                             if self._device_deactivatewhileevcharging == 2:
-                                self.log.info("(" + str(self.device_nummer)
-                                              + ") " + self.device_name +
-                                              " Mindesteinschaltdauer" +
-                                              "  erreicht, schalte aus")
+                                log.info("(" + str(self.device_nummer)
+                                         + ") " + self.device_name +
+                                         " Mindesteinschaltdauer" +
+                                         "  erreicht, schalte aus")
                                 self.turndevicerelais(0, 0, 1)
                                 return
                             else:
                                 if (self._dynregel == 0):
-                                    self.log.info("(" +
-                                                  str(self.device_nummer) +
-                                                  ") " + self.device_name +
-                                                  " Mindesteinschaltdauer " +
-                                                  "erreicht, " +
-                                                  "Ausschaltschwelle 0 " +
-                                                  "gesetzt")
+                                    log.info("(" +
+                                             str(self.device_nummer) +
+                                             ") " + self.device_name +
+                                             " Mindesteinschaltdauer " +
+                                             "erreicht, " +
+                                             "Ausschaltschwelle 0 " +
+                                             "gesetzt")
                                     work_ausschaltverzoegerung = 0
                                     if (work_ausschaltschwelle < 0):
                                         work_ausschaltschwelle = 0
                                 else:
-                                    self.log.info("(" +
-                                                  str(self.device_nummer)
-                                                  + ") " + self.device_name +
-                                                  " Gerät mit dyn Regelung")
+                                    log.info("(" +
+                                             str(self.device_nummer)
+                                             + ") " + self.device_name +
+                                             " Gerät mit dyn Regelung")
                         else:
-                            self.log.info("(" + str(self.device_nummer) +
-                                          ") " + self.device_name +
-                                          " Mindesteinschaltdauer nicht" +
-                                          " erreicht, " +
-                                          str(self._device_mineinschaltdauer) +
-                                          " > " + str(timesta))
+                            log.info("(" + str(self.device_nummer) +
+                                     ") " + self.device_name +
+                                     " Mindesteinschaltdauer nicht" +
+                                     " erreicht, " +
+                                     str(self._device_mineinschaltdauer) +
+                                     " > " + str(timesta))
                     else:
                         if self._device_deactivatewhileevcharging == 2:
-                            self.log.info("(" + str(self.device_nummer) +
-                                          ") " + self.device_name +
-                                          " Mindesteinschaltdauer nicht" +
-                                          " bekannt,schalte aus")
+                            log.info("(" + str(self.device_nummer) +
+                                     ") " + self.device_name +
+                                     " Mindesteinschaltdauer nicht" +
+                                     " bekannt,schalte aus")
                             self.turndevicerelais(0, 0, 1)
                             return
                         else:
                             if (self._dynregel == 0):
-                                self.log.info("(" +
-                                              str(self.device_nummer) +
-                                              ") " + self.device_name +
-                                              " Mindesteinschaltdauer " +
-                                              "nicht bekannt, " +
-                                              "Ausschaltschwelle 0 " +
-                                              "gesetzt")
+                                log.info("(" +
+                                         str(self.device_nummer) +
+                                         ") " + self.device_name +
+                                         " Mindesteinschaltdauer " +
+                                         "nicht bekannt, " +
+                                         "Ausschaltschwelle 0 " +
+                                         "gesetzt")
                                 work_ausschaltverzoegerung = 0
                                 if (work_ausschaltschwelle < 0):
                                     work_ausschaltschwelle = 0
                             else:
-                                self.log.info("(" +
-                                              str(self.device_nummer)
-                                              + ") " + self.device_name +
-                                              " Gerät mit dyn Regelung")
+                                log.info("(" +
+                                         str(self.device_nummer)
+                                         + ") " + self.device_name +
+                                         " Gerät mit dyn Regelung")
                 else:
-                    self.log.info("(" + str(self.device_nummer) + ") " +
-                                  self.device_name +
-                                  " Ladung läuft nicht, pruefe weiter")
+                    log.info("(" + str(self.device_nummer) + ") " +
+                             self.device_name +
+                             " Ladung läuft nicht, pruefe weiter")
             else:
                 if self._device_deactivatewhileevcharging == 2:
-                    self.log.info("(" + str(self.device_nummer) + ") " +
-                                  self.device_name +
-                                  " Soll nicht eingeschaltet werden bei" +
-                                  " Ladung, pruefe " + str(testcharge))
+                    log.info("(" + str(self.device_nummer) + ") " +
+                             self.device_name +
+                             " Soll nicht eingeschaltet werden bei" +
+                             " Ladung, pruefe " + str(testcharge))
                     if chargestatus == 1:
-                        self.log.info("(" + str(self.device_nummer) + ") "
-                                      + self.device_name + " Ladung läuft, " +
-                                      "wird nicht eingeschaltet")
+                        log.info("(" + str(self.device_nummer) + ") "
+                                 + self.device_name + " Ladung läuft, " +
+                                 "wird nicht eingeschaltet")
                         return
         # Auto ladung ende
         # Art vom ueberschussberechnung pruefen
@@ -829,21 +830,21 @@ class Sbase(Sbase0):
                 newueberschussberechnung = 1
         if (self.ueberschussberechnung != newueberschussberechnung):
             self.ueberschussberechnung = newueberschussberechnung
-            self.log.info("(" + str(self.device_nummer) + ") " +
-                          self.device_name + " SoC " + str(speichersoc) +
-                          " Einschalt SoC " +
-                          str(self._device_speichersocbeforestart) +
-                          " Ueberschuss " + str(self.devuberschuss))
-            self.log.info("(" + str(self.device_nummer) + ") " +
-                          self.device_name +
-                          " Ueberschussberechnung anders (1 = mit Speicher," +
-                          " 2 = mit Offset) " +
-                          str(self.ueberschussberechnung))
+            log.info("(" + str(self.device_nummer) + ") " +
+                     self.device_name + " SoC " + str(speichersoc) +
+                     " Einschalt SoC " +
+                     str(self._device_speichersocbeforestart) +
+                     " Ueberschuss " + str(self.devuberschuss))
+            log.info("(" + str(self.device_nummer) + ") " +
+                     self.device_name +
+                     " Ueberschussberechnung anders (1 = mit Speicher," +
+                     " 2 = mit Offset) " +
+                     str(self.ueberschussberechnung))
         if (self.devstatus == 20):
-            self.log.info("(" + str(self.device_nummer) + ") " +
-                          self.device_name +
-                          " Anlauferkennung immer noch aktiv, keine Ueberprüf"
-                          + "ung auf Einschalt oder Ausschaltschwelle ")
+            log.info("(" + str(self.device_nummer) + ") " +
+                     self.device_name +
+                     " Anlauferkennung immer noch aktiv, keine Ueberprüf"
+                     + "ung auf Einschalt oder Ausschaltschwelle ")
             return
         # Device mit Anlauferkennung (mehrfach pro tag)
         # welches im PV Modus ist ?
@@ -853,73 +854,73 @@ class Sbase(Sbase0):
             if (self._c_eintime_f == 'Y'):
                 timesta = int(time.time()) - int(self._c_eintime)
                 if (self._device_mineinschaltdauer < timesta):
-                    self.log.info("(" + str(self.device_nummer) + ") "
-                                  + self.device_name +
-                                  " Mindesteinschaltdauer erreicht," +
-                                  " restarte Anlauferkennung ")
+                    log.info("(" + str(self.device_nummer) + ") "
+                             + self.device_name +
+                             " Mindesteinschaltdauer erreicht," +
+                             " restarte Anlauferkennung ")
                     self._c_eintime_f = 'N'
                     self.devstatus = 20
                     self.oncntstandby = str("0")
                     self.oncountnor = str("0")
-                    self.log.info("(" + str(self.device_nummer) + ") " +
-                                  self.device_name +
-                                  " Anlauferkennung nun aktiv, eingeschaltet ")
+                    log.info("(" + str(self.device_nummer) + ") " +
+                             self.device_name +
+                             " Anlauferkennung nun aktiv, eingeschaltet ")
                     self.turndevicerelais(1, 0, 0)
                     return
             else:
-                self.log.info("(" + str(self.device_nummer) + ") " +
-                              self.device_name +
-                              " Mindesteinschaltdauer nicht bekannt" +
-                              " restarte Anlauferkennung ")
+                log.info("(" + str(self.device_nummer) + ") " +
+                         self.device_name +
+                         " Mindesteinschaltdauer nicht bekannt" +
+                         " restarte Anlauferkennung ")
                 self.devstatus = 20
                 self.oncntstandby = str("0")
                 self.oncountnor = str("0")
-                self.log.info("(" + str(self.device_nummer) + ") " +
-                              self.device_name +
-                              " Anlauferkennung nun aktiv, eingeschaltet ")
+                log.info("(" + str(self.device_nummer) + ") " +
+                         self.device_name +
+                         " Anlauferkennung nun aktiv, eingeschaltet ")
                 self.turndevicerelais(1, 0, 0)
                 return
         # periodisch hart ausschalten
         if ((self.relais == 1) and (self.gruppe == 'A') and
            (Sbase.eindevices == 0)):
-            self.log.info("(" + str(self.device_nummer) + ") " +
-                          self.device_name +
-                          " Soll periodisch ausgeschaltet werden " +
-                          " (1 = volle Stunde / " +
-                          " 2 = volle Stunde + halbe Stunde) pruefe " +
-                          str(self._device_deactivateper))
+            log.info("(" + str(self.device_nummer) + ") " +
+                     self.device_name +
+                     " Soll periodisch ausgeschaltet werden " +
+                     " (1 = volle Stunde / " +
+                     " 2 = volle Stunde + halbe Stunde) pruefe " +
+                     str(self._device_deactivateper))
             if (((self._device_deactivateper == 2) and (localminute == 30)) or
                (localminute == 00)):
-                self.log.info("(" + str(self.device_nummer) +
-                              ") " + self.device_name +
-                              " erfolgreich, schalte aus ")
+                log.info("(" + str(self.device_nummer) +
+                         ") " + self.device_name +
+                         " erfolgreich, schalte aus ")
                 self.turndevicerelais(0, 0, 1)
                 self._c_ausverz_f = 'N'
                 return
         # periodisch prüfen ob ausschalten
         if ((self.relais == 1) and (self.gruppe == 'A') and
            (Sbase.eindevices > 0)):
-            self.log.info("(" + str(self.device_nummer) + ") " +
-                          self.device_name +
-                          " Soll periodisch geprüft werden " +
-                          " (1 = volle Stunde / " +
-                          " 2 = volle Stunde + halbe Stunde) " +
-                          str(self._device_deactivateper))
+            log.info("(" + str(self.device_nummer) + ") " +
+                     self.device_name +
+                     " Soll periodisch geprüft werden " +
+                     " (1 = volle Stunde / " +
+                     " 2 = volle Stunde + halbe Stunde) " +
+                     str(self._device_deactivateper))
             if (((self._device_deactivateper == 2) and (localminute == 30)) or
                (localminute == 00)):
-                self.log.info("(" + str(self.device_nummer) +
-                              ") " + self.device_name +
-                              " akt Leistungsaufnahme Abschaltgruppe " +
-                              str(Sbase.ausschaltwatt) +
-                              " Summe benötigte Einschaltschwelle: " +
-                              str(Sbase.einschwelle) + " Überschuss " +
-                              str(self._uberschuss))
+                log.info("(" + str(self.device_nummer) +
+                         ") " + self.device_name +
+                         " akt Leistungsaufnahme Abschaltgruppe " +
+                         str(Sbase.ausschaltwatt) +
+                         " Summe benötigte Einschaltschwelle: " +
+                         str(Sbase.einschwelle) + " Überschuss " +
+                         str(self._uberschuss))
                 if (((Sbase.ausschaltwatt + self._uberschuss) >
                    Sbase.einschwelle) and Sbase.einrelais == 0 and
                    Sbase.eindevstatus == 10):
-                    self.log.info("(" + str(self.device_nummer) +
-                                  ") " + self.device_name +
-                                  " erfolgreich, schalte aus ")
+                    log.info("(" + str(self.device_nummer) +
+                             ") " + self.device_name +
+                             " erfolgreich, schalte aus ")
                     self.turndevicerelais(0, 0, 1)
                     self._c_ausverz_f = 'N'
                     # rechne Zeit exclusive einschaltgruppe
@@ -933,103 +934,103 @@ class Sbase(Sbase0):
         if ((self.devuberschuss > self._device_einschaltschwelle)
            or (onnow == 1)):
             self._c_ausverz_f = 'N'
-            self.log.info("(" + str(self.device_nummer) + ") " +
-                          str(self.device_name) + " Überschuss " +
-                          str(self.devuberschuss) + " größer Einschaltschwelle"
-                          + " oder Immer an zeit erreicht " +
-                          str(self._device_einschaltschwelle))
+            log.info("(" + str(self.device_nummer) + ") " +
+                     str(self.device_name) + " Überschuss " +
+                     str(self.devuberschuss) + " größer Einschaltschwelle"
+                     + " oder Immer an zeit erreicht " +
+                     str(self._device_einschaltschwelle))
             if (self.relais == 0):
-                self.log.info("(" + str(self.device_nummer) + ") " +
-                              self.device_name + " SoC " + str(speichersoc) +
-                              " Einschalt SoC " +
-                              str(self._device_speichersocbeforestart) +
-                              " Ueberschuss " + str(self.devuberschuss))
-                self.log.info("(" + str(self.device_nummer) + ") " +
-                              self.device_name + " Ueberschussberechnung (1 ="
-                              + " mit Speicher, 2 = mit Offset) " +
-                              str(self.ueberschussberechnung))
+                log.info("(" + str(self.device_nummer) + ") " +
+                         self.device_name + " SoC " + str(speichersoc) +
+                         " Einschalt SoC " +
+                         str(self._device_speichersocbeforestart) +
+                         " Ueberschuss " + str(self.devuberschuss))
+                log.info("(" + str(self.device_nummer) + ") " +
+                         self.device_name + " Ueberschussberechnung (1 ="
+                         + " mit Speicher, 2 = mit Offset) " +
+                         str(self.ueberschussberechnung))
                 if (self._device_starttime != '00:00'):
                     starthour = int(str("0") +
                                     str(self._device_starttime).
                                     partition(':')[0])
                     startminute = int(str(self._device_starttime)[-2:])
-                    self.log.info("(" + str(self.device_nummer) + ") " +
-                                  self.device_name +
-                                  " Fruehster Start um definiert " +
-                                  str(starthour) + ":" +
-                                  str('%.2d' % startminute) +
-                                  " aktuelle Zeit " + str(localhour) + ":" +
-                                  str('%.2d' % localminute))
+                    log.info("(" + str(self.device_nummer) + ") " +
+                             self.device_name +
+                             " Fruehster Start um definiert " +
+                             str(starthour) + ":" +
+                             str('%.2d' % startminute) +
+                             " aktuelle Zeit " + str(localhour) + ":" +
+                             str('%.2d' % localminute))
                     if ((starthour > localhour) or ((starthour == localhour)
                        and (startminute >= localminute))):
-                        self.log.info("(" + str(self.device_nummer) + ") " +
-                                      self.device_name +
-                                      " Fruehster Start noch nicht erreicht ")
+                        log.info("(" + str(self.device_nummer) + ") " +
+                                 self.device_name +
+                                 " Fruehster Start noch nicht erreicht ")
                         return
                 if (self._device_endtime != '00:00'):
                     endhour = int(str("0") +
                                   str(self._device_endtime).partition(':')[0])
                     endminute = int(str(self._device_endtime)[-2:])
-                    self.log.info("(" + str(self.device_nummer) + ") " +
-                                  self.device_name +
-                                  " Spaetester Start um definiert " +
-                                  str(endhour) + ":" + str('%.2d' % endminute)
-                                  + " aktuelle Zeit " + str(localhour) + ":"
-                                  + str('%.2d' % localminute))
+                    log.info("(" + str(self.device_nummer) + ") " +
+                             self.device_name +
+                             " Spaetester Start um definiert " +
+                             str(endhour) + ":" + str('%.2d' % endminute)
+                             + " aktuelle Zeit " + str(localhour) + ":"
+                             + str('%.2d' % localminute))
                     if ((endhour > localhour) or ((endhour == localhour)
                        and (endminute >= localminute))):
                         pass
                     else:
-                        self.log.info("(" + str(self.device_nummer) + ") " +
-                                      self.device_name +
-                                      " Spaetester Start vorbei ")
+                        log.info("(" + str(self.device_nummer) + ") " +
+                                 self.device_name +
+                                 " Spaetester Start vorbei ")
                         return
                 if (self._c_einverz_f == 'Y'):
                     timesince = int(time.time()) - int(self._c_einverz)
                     if (self._device_einschaltverzoegerung < timesince):
-                        self.log.info("(" + str(self.device_nummer) + ") "
-                                      + self.device_name +
-                                      " Einschaltverzögerung erreicht, " +
-                                      "schalte ein " +
-                                      str(self._device_einschaltschwelle))
+                        log.info("(" + str(self.device_nummer) + ") "
+                                 + self.device_name +
+                                 " Einschaltverzögerung erreicht, " +
+                                 "schalte ein " +
+                                 str(self._device_einschaltschwelle))
                         self.turndevicerelais(1, self.ueberschussberechnung, 1)
                         self._c_einverz_f = 'N'
                     else:
-                        self.log.info("(" + str(self.device_nummer) + ") " +
-                                      self.device_name +
-                                      " Einschaltverzögerung nicht erreicht. "
-                                      + str(self._device_einschaltverzoegerung)
-                                      + " > " + str(timesince))
+                        log.info("(" + str(self.device_nummer) + ") " +
+                                 self.device_name +
+                                 " Einschaltverzögerung nicht erreicht. "
+                                 + str(self._device_einschaltverzoegerung)
+                                 + " > " + str(timesince))
                 else:
                     self._c_einverz_f = 'Y'
                     self._c_einverz = int(time.time())
-                    self.log.info("(" + str(self.device_nummer) + ") " +
-                                  self.device_name +
-                                  " Einschaltverzögerung gestartet")
+                    log.info("(" + str(self.device_nummer) + ") " +
+                             self.device_name +
+                             " Einschaltverzögerung gestartet")
             else:
-                self.log.info("(" + str(self.device_nummer) + ") " +
-                              self.device_name +
-                              " Einschaltverzögerung erreicht, bereits ein")
+                log.info("(" + str(self.device_nummer) + ") " +
+                         self.device_name +
+                         " Einschaltverzögerung erreicht, bereits ein")
                 self._c_einverz_f = 'N'
         else:
             self._c_einverz_f = 'N'
             if (self.devuberschuss < work_ausschaltschwelle):
                 if (speichersoc > self._device_speichersocbeforestop):
-                    self.log.info("(" + str(self.device_nummer) + ") " +
-                                  self.device_name +
-                                  " SoC höher als Abschalt SoC," +
-                                  " lasse Gerät weiterlaufen")
+                    log.info("(" + str(self.device_nummer) + ") " +
+                             self.device_name +
+                             " SoC höher als Abschalt SoC," +
+                             " lasse Gerät weiterlaufen")
                     return
                 else:
-                    self.log.info("(" + str(self.device_nummer) + ") " +
-                                  self.device_name +
-                                  " SoC niedriger als Abschalt SoC," +
-                                  " prüfe weiter")
-                self.log.info("(" + str(self.device_nummer) + ") " +
-                              self.device_name + " Überschuss " +
-                              str(self.devuberschuss) +
-                              " kleiner Ausschaltschwelle " +
-                              str(work_ausschaltschwelle))
+                    log.info("(" + str(self.device_nummer) + ") " +
+                             self.device_name +
+                             " SoC niedriger als Abschalt SoC," +
+                             " prüfe weiter")
+                log.info("(" + str(self.device_nummer) + ") " +
+                         self.device_name + " Überschuss " +
+                         str(self.devuberschuss) +
+                         " kleiner Ausschaltschwelle " +
+                         str(work_ausschaltschwelle))
                 if (self.relais == 1):
                     if (self._c_ausverz_f == 'Y'):
                         timesince = int(time.time()) - int(self._c_ausverz)
@@ -1038,55 +1039,55 @@ class Sbase(Sbase0):
                                 timesta = int((time.time()) -
                                               int(self._c_eintime))
                                 if (self._device_mineinschaltdauer < timesta):
-                                    self.log.info("(" +
-                                                  str(self.device_nummer) +
-                                                  ") " + self.device_name +
-                                                  " Ausschaltverzögerung &" +
-                                                  " Mindesteinschaltdauer " +
-                                                  "erreicht, schalte aus " +
-                                                  str(work_ausschaltschwelle))
+                                    log.info("(" +
+                                             str(self.device_nummer) +
+                                             ") " + self.device_name +
+                                             " Ausschaltverzögerung &" +
+                                             " Mindesteinschaltdauer " +
+                                             "erreicht, schalte aus " +
+                                             str(work_ausschaltschwelle))
                                     self.turndevicerelais(0, 0, 1)
                                     self._c_ausverz_f = 'N'
                                 else:
                                     s1 = str(self._device_mineinschaltdauer)
-                                    self.log.info("(" +
-                                                  str(self.device_nummer) +
-                                                  ") " + self.device_name +
-                                                  " Ausschaltverzögerung errei"
-                                                  + "cht, Mindesteinschalt" +
-                                                  "dauer nicht erreicht, " +
-                                                  s1 + " > " + str(timesta))
+                                    log.info("(" +
+                                             str(self.device_nummer) +
+                                             ") " + self.device_name +
+                                             " Ausschaltverzögerung errei"
+                                             + "cht, Mindesteinschalt" +
+                                             "dauer nicht erreicht, " +
+                                             s1 + " > " + str(timesta))
                             else:
-                                self.log.info("(" + str(self.device_nummer)
-                                              + ") " + self.device_name +
-                                              " Mindesteinschaltdauer nicht" +
-                                              " bekannt, schalte aus")
+                                log.info("(" + str(self.device_nummer)
+                                         + ") " + self.device_name +
+                                         " Mindesteinschaltdauer nicht" +
+                                         " bekannt, schalte aus")
                                 self.turndevicerelais(0, 0, 1)
                         else:
-                            self.log.info("(" + str(self.device_nummer) +
-                                          ") " + self.device_name +
-                                          " Ausschaltverzögerung nicht" +
-                                          " erreicht. " +
-                                          str(work_ausschaltverzoegerung) +
-                                          " > " + str(timesince))
+                            log.info("(" + str(self.device_nummer) +
+                                     ") " + self.device_name +
+                                     " Ausschaltverzögerung nicht" +
+                                     " erreicht. " +
+                                     str(work_ausschaltverzoegerung) +
+                                     " > " + str(timesince))
                     else:
-                        self.log.info("(" + str(self.device_nummer) + ") " +
-                                      self.device_name +
-                                      " Ausschaltverzögerung gestartet ")
+                        log.info("(" + str(self.device_nummer) + ") " +
+                                 self.device_name +
+                                 " Ausschaltverzögerung gestartet ")
                         self._c_ausverz_f = 'Y'
                         self._c_ausverz = int(time.time())
 
                 else:
-                    self.log.info("(" + str(self.device_nummer) + ") " +
-                                  self.device_name +
-                                  " Ausschaltverzögerung erreicht,bereits aus")
+                    log.info("(" + str(self.device_nummer) + ") " +
+                             self.device_name +
+                             " Ausschaltverzögerung erreicht,bereits aus")
                     self._c_ausverz_f = 'N'
             else:
-                self.log.info("(" + str(self.device_nummer) + ") " +
-                              self.device_name + " Überschuss kleiner als" +
-                              " Einschaltschwelle und größer als " +
-                              "Ausschaltschwelle. Ueberschuss " +
-                              str(self.devuberschuss))
+                log.info("(" + str(self.device_nummer) + ") " +
+                         self.device_name + " Überschuss kleiner als" +
+                         " Einschaltschwelle und größer als " +
+                         "Ausschaltschwelle. Ueberschuss " +
+                         str(self.devuberschuss))
                 self._c_einverz_f = 'N'
                 self._c_ausverz_f = 'N'
 
@@ -1194,13 +1195,13 @@ class Sbase(Sbase0):
             return
         self.newdevice_manual = newmanual
         self.newdevice_manual_control = newmanual_control
-        self.log.info("(" + str(self.device_nummer) + ") " +
-                      self.device_name +
-                      " Umschaltung manual modus alt/neu " +
-                      str(self.device_manual) + "/" +
-                      str(self.newdevice_manual) +
-                      " on off alt/neu " + str(self.device_manual_control) +
-                      "/" + str(self.newdevice_manual_control))
+        log.info("(" + str(self.device_nummer) + ") " +
+                 self.device_name +
+                 " Umschaltung manual modus alt/neu " +
+                 str(self.device_manual) + "/" +
+                 str(self.newdevice_manual) +
+                 " on off alt/neu " + str(self.device_manual_control) +
+                 "/" + str(self.newdevice_manual_control))
         if (self.newdevice_manual == self.device_manual):
             #  Änderung bezüglich on off
             self.btchange = 2

--- a/runs/usmarthome/smartbase.py
+++ b/runs/usmarthome/smartbase.py
@@ -23,6 +23,7 @@ class Sbase(Sbase0):
 
     def __init__(self):
         # setting
+        super().__init__()
         print('__init__ Sbase executed')
         self.mqtt_param = {}
         self.mqtt_param_del = {}
@@ -169,15 +170,13 @@ class Sbase(Sbase0):
                           self._device_mineinschaltdauer) + 30
             timesince = int(time.time()) - int(self.c_mantime)
             if (manverz < timesince):
-                self.logClass(2,
-                              "(" + str(self.device_nummer) + ") von Manuell "
+                self.log.info("(" + str(self.device_nummer) + ") von Manuell "
                               + "auf Automatisch gestellt oder startup,"
                               + " Uebergangsfrist abgelaufen" +
                               self.c_mantime_f)
                 self.c_mantime_f = 'N'
             else:
-                self.logClass(2,
-                              "(" + str(self.device_nummer) + ") von Manuell" +
+                self.log.info("(" + str(self.device_nummer) + ") von Manuell" +
                               " auf Automatisch gestellt oder startup," +
                               " Übergangsfrist laueft noch " + str(manverz) +
                               " > " + str(timesince))
@@ -348,19 +347,19 @@ class Sbase(Sbase0):
             elif (key == 'WHImported_temp'):
                 if (self._first_run == 1):
                     self._whimported_tmp = valueint
-                    self.logClass(2, "(" + str(self.device_nummer) +
+                    self.log.info("(" + str(self.device_nummer) +
                                   ") aus mqtt übernommen " + key +
                                   " " + value)
             elif (key == 'RunningTimeToday'):
                 if (self._first_run == 1):
                     self.runningtime = valueint
-                    self.logClass(2, "(" + str(self.device_nummer) +
+                    self.log.info("(" + str(self.device_nummer) +
                                   ") aus mqtt übernommen " + key +
                                   " " + value)
             elif (key == 'oncountnor'):
                 if (self._first_run == 1):
                     self.oncountnor = value
-                    self.logClass(2, "(" + str(self.device_nummer) +
+                    self.log.info("(" + str(self.device_nummer) +
                                   ") aus mqtt übernommen " + key +
                                   " " + value)
             elif (key == 'OnCntStandby'):
@@ -368,11 +367,11 @@ class Sbase(Sbase0):
                     self.oncntstandby = value
                     # status normal setzen
                     self.devstatus = 10
-                    self.logClass(2, "(" + str(self.device_nummer) +
+                    self.log.info("(" + str(self.device_nummer) +
                                   ") aus mqtt übernommen " + key +
                                   " " + value)
             else:
-                self.logClass(2, "(" + str(self.device_nummer) + ") "
+                self.log.info("(" + str(self.device_nummer) + ") "
                               + __class__.__name__ + " überlesen " + key +
                               " " + value)
         self._first_run = 0
@@ -404,11 +403,11 @@ class Sbase(Sbase0):
             if (self._old_pbtype == 'none'):
                 self._mydevicepb = Sbshelly()
                 self._old_pbtype = 'shelly'
-                self.logClass(2, "(" + str(self.device_nummer) +
+                self.log.info("(" + str(self.device_nummer) +
                               ") control Button. Neues Button" +
                               " device erzeugt Shelly")
             else:
-                self.logClass(2, "(" + str(self.device_nummer) +
+                self.log.info("(" + str(self.device_nummer) +
                               ") Control Button. Nur Parameter " +
                               " update ")
             self._mydevicepb.updatepar(input_param)
@@ -416,11 +415,11 @@ class Sbase(Sbase0):
            (self._old_pbtype == 'shelly')):
             del self._mydevicepb
             self._old_pbtype = 'none'
-            self.logClass(2, "(" + str(self.device_nummer) +
+            self.log.info("(" + str(self.device_nummer) +
                           ") Control Button gelöscht")
         if (self._device_differentmeasurement == 1):
             if (self._oldmeasuretype1 == self._device_measuretype):
-                self.logClass(2, "(" + str(self.device_nummer) +
+                self.log.info("(" + str(self.device_nummer) +
                               ") Separate Messung. Nur Parameter" +
                               " update " + self._device_measuretype)
                 self._mydevicemeasure.updatepar(self._smart_param)
@@ -428,7 +427,7 @@ class Sbase(Sbase0):
                 if (self._oldmeasuretype1 == 'empty'):
                     pass
                 else:
-                    self.logClass(2, "(" + str(self.device_nummer) +
+                    self.log.info("(" + str(self.device_nummer) +
                                   ") Separate Messung. Altes Measure"
                                   + "device gelöscht " + self._oldmeasuretype1)
                     del self._mydevicemeasure
@@ -457,17 +456,17 @@ class Sbase(Sbase0):
                 elif (self._device_measuretype == 'mystrom'):
                     self._mydevicemeasure = Slmystrom()
                 else:
-                    self.logClass(2, "(" + str(self.device_nummer) +
+                    self.log.info("(" + str(self.device_nummer) +
                                   ") Measuretype nicht untertützt " +
                                   self._device_measuretype)
                 self._mydevicemeasure.updatepar(self._smart_param)
                 self._oldmeasuretype1 = self._device_measuretype
-                self.logClass(2, "(" + str(self.device_nummer) +
+                self.log.info("(" + str(self.device_nummer) +
                               ") Separate Messung. Neues Measure" +
                               "device erzeugt " + self._device_measuretype)
         if ((self._device_differentmeasurement == 0) and
            (self._oldmeasuretype1 != 'empty')):
-            self.logClass(2, "(" + str(self.device_nummer) +
+            self.log.info("(" + str(self.device_nummer) +
                           ") Separate Messung ausgeschaltet."
                           " Altes Measure" +
                           "device gelöscht " + self._oldmeasuretype1)
@@ -494,7 +493,7 @@ class Sbase(Sbase0):
                 self.oncountnor = str(int(self.oncountnor) + 1)
             else:
                 self.oncntstandby = str(int(self.oncntstandby) + 1)
-            self.logClass(2, "(" + str(self.device_nummer) +
+            self.log.info("(" + str(self.device_nummer) +
                           ") angeschaltet. Überschussberechnung (1 = mit " +
                           " Speicher, 2 = mit Offset) " +
                           str(self.ueberschussberechnung))
@@ -534,12 +533,12 @@ class Sbase(Sbase0):
         localminute = int(local_time.strftime(format="%M"))
         localinsec = int((localhour * 60 * 60) + (localminute * 60))
         if (localinsec < Sbase.nureinschaltinsec) and (Sbase.eindevices > 0):
-            self.logClass(2, "(" + str(self.device_nummer) + ") " +
+            self.log.info("(" + str(self.device_nummer) + ") " +
                           self.device_name + " Prüfe nur Einschaltgruppe ")
             if (self.gruppe == 'E'):
                 pass
             else:
-                self.logClass(2, "(" + str(self.device_nummer) + ") " +
+                self.log.info("(" + str(self.device_nummer) + ") " +
                               self.device_name + " kein Regelung")
                 return
         # onnow = 0 -> normale Regelung
@@ -548,7 +547,7 @@ class Sbase(Sbase0):
         if (self._device_ontime != '00:00'):
             onhour = int(str("0") + str(self._device_ontime).partition(':')[0])
             onminute = int(str(self._device_ontime)[-2:])
-            self.logClass(2, "(" + str(self.device_nummer) + ") " +
+            self.log.info("(" + str(self.device_nummer) + ") " +
                           self.device_name + " Immer an nach definiert " +
                           str(onhour) + ":" + str('%.2d' % onminute) +
                           " aktuelle Zeit " + str(localhour) + ":" +
@@ -557,7 +556,7 @@ class Sbase(Sbase0):
                and (onminute >= localminute))):
                 pass
             else:
-                self.logClass(2, "(" + str(self.device_nummer) + ") " +
+                self.log.info("(" + str(self.device_nummer) + ") " +
                               self.device_name +
                               " schalte ein wegen Immer an nach")
                 onnow = 1
@@ -565,7 +564,7 @@ class Sbase(Sbase0):
             onuntilh = int(str("0")
                            + str(self._device_onuntiltime).partition(':')[0])
             onuntilminute = int(str(self._device_onuntiltime)[-2:])
-            self.logClass(2, "(" + str(self.device_nummer) + ") " +
+            self.log.info("(" + str(self.device_nummer) + ") " +
                           self.device_name + " Immer an vor definiert " +
                           str(onuntilh) + ":" + str('%.2d' % onuntilminute)
                           + " aktuelle Zeit " + str(localhour) + ":" +
@@ -574,7 +573,7 @@ class Sbase(Sbase0):
                and (onuntilminute <= localminute))):
                 pass
             else:
-                self.logClass(2, "(" + str(self.device_nummer) + ") " +
+                self.log.info("(" + str(self.device_nummer) + ") " +
                               self.device_name +
                               " schalte ein wegen Immer an vor")
                 onnow = 1
@@ -585,7 +584,7 @@ class Sbase(Sbase0):
             finishminute = int(str(self._device_finishtime)[-2:])
             startspatsec = int((finishhour * 60 * 60) + (finishminute * 60) -
                                self._device_mineinschaltdauer)
-            self.logClass(2, "(" + str(self.device_nummer) + ") " +
+            self.log.info("(" + str(self.device_nummer) + ") " +
                           self.device_name +
                           " finishtime definiert " +
                           str(finishhour) + ":" + str('%.2d' % finishminute)
@@ -596,7 +595,7 @@ class Sbase(Sbase0):
             if (((finishhour > localhour) or ((finishhour == localhour)
                and (finishminute >= localminute)))
                and (startspatsec <= localinsec)):
-                self.logClass(2, "(" + str(self.device_nummer) + ") " +
+                self.log.info("(" + str(self.device_nummer) + ") " +
                               self.device_name +
                               " schalte ein wegen finishtime, spaetester" +
                               "start in sec " + str(startspatsec) +
@@ -605,20 +604,20 @@ class Sbase(Sbase0):
                 self.devstatus = 30
                 return
         if self.devstatus == 30:
-            self.logClass(2, "(" + str(self.device_nummer) + ") " +
+            self.log.info("(" + str(self.device_nummer) + ") " +
                           self.device_name +
                           " finishtime laueft, pruefe Mindestlaufzeit")
             if (self._c_eintime_f == 'Y'):
                 timesta = int(time.time()) - int(self._c_eintime)
                 if (self._device_mineinschaltdauer < timesta):
-                    self.logClass(2, "(" + str(self.device_nummer) + ") " +
+                    self.log.info("(" + str(self.device_nummer) + ") " +
                                   self.device_name +
                                   " Mindesteinschaltdauer erreicht," +
                                   " finishtime erreicht")
                     self.devstatus = 10
                     return
                 else:
-                    self.logClass(2, "(" + str(self.device_nummer) + ") " +
+                    self.log.info("(" + str(self.device_nummer) + ") " +
                                   self.device_name +
                                   " finishtime laueft, Mindesteinschaltdauer" +
                                   "nicht erreicht, " +
@@ -626,7 +625,7 @@ class Sbase(Sbase0):
                                   " > " + str(timesta))
                     return
             else:
-                self.logClass(2, "(" + str(self.device_nummer) + ") " +
+                self.log.info("(" + str(self.device_nummer) + ") " +
                               self.device_name +
                               " Mindesteinschaltdauer nicht bekannt," +
                               " finishtime erreicht")
@@ -637,7 +636,7 @@ class Sbase(Sbase0):
            and (self.devstatus == 20)):
             self.devstatus = 10
             self.turndevicerelais(0, 0, 1)
-            self.logClass(2, "(" + str(self.device_nummer) + ") " +
+            self.log.info("(" + str(self.device_nummer) + ") " +
                           self.device_name +
                           " Anlauferkennung nun abgeschaltet ")
             return
@@ -647,7 +646,7 @@ class Sbase(Sbase0):
            and (self.oncountnor == str("0"))
            and (self.devstatus != 20)):
             self.devstatus = 20
-            self.logClass(2, "(" + str(self.device_nummer) + ") " +
+            self.log.info("(" + str(self.device_nummer) + ") " +
                           self.device_name +
                           " Anlauferkennung nun aktiv, eingeschaltet ")
             self.turndevicerelais(1, 0, 0)
@@ -657,7 +656,7 @@ class Sbase(Sbase0):
                 if (self._c_anlaufz_f == 'Y'):
                     timesince = int(time.time()) - int((self._c_anlaufz))
                     if (self._device_standbyduration < timesince):
-                        self.logClass(2, "(" + str(self.device_nummer) + ") " +
+                        self.log.info("(" + str(self.device_nummer) + ") " +
                                       self.device_name +
                                       " standbycheck abgelaufen " +
                                       str(self._device_standbyduration) +
@@ -669,7 +668,7 @@ class Sbase(Sbase0):
                            self._device_einschaltschwelle) or (onnow == 1)):
                             self._c_ausverz_f = 'N'
                             self._c_einverz_f = 'N'
-                            self.logClass(2, "(" + str(self.device_nummer) +
+                            self.log.info("(" + str(self.device_nummer) +
                                           ") " + self.device_name +
                                           " Überschuss " +
                                           str(self.devuberschuss) +
@@ -681,7 +680,7 @@ class Sbase(Sbase0):
                                                   self.ueberschussberechnung,
                                                   1)
                         else:
-                            self.logClass(2, "(" + str(self.device_nummer) +
+                            self.log.info("(" + str(self.device_nummer) +
                                           ") " + self.device_name +
                                           " Überschuss " +
                                           str(self.devuberschuss) +
@@ -691,7 +690,7 @@ class Sbase(Sbase0):
                             self.turndevicerelais(0, 0, 1)
                         return
                     else:
-                        self.logClass(2, "(" + str(self.device_nummer) + ") " +
+                        self.log.info("(" + str(self.device_nummer) + ") " +
                                       self.device_name +
                                       " standbycheck noch nicht erreicht " +
                                       str(self._device_standbyduration) + " > "
@@ -699,27 +698,27 @@ class Sbase(Sbase0):
                 else:
                     self._c_anlaufz_f = 'Y'
                     self._c_anlaufz = int(time.time())
-                    self.logClass(2, "(" + str(self.device_nummer) + ") " +
+                    self.log.info("(" + str(self.device_nummer) + ") " +
                                   self.device_name + " standbycheck gestartet "
                                   + str(self.newwatt) + " > " +
                                   str(self._device_standbypower))
             else:
                 self._c_anlaufz_f = 'N'
-                self.logClass(2, "(" + str(self.device_nummer) + ") " +
+                self.log.info("(" + str(self.device_nummer) + ") " +
                               self.device_name +
                               " unter standbyschwelle , timer geloescht")
         if (self._device_maxeinschaltdauer > self.runningtime):
-            self.logClass(2, "(" + str(self.device_nummer) + ") " +
+            self.log.info("(" + str(self.device_nummer) + ") " +
                           self.device_name +
                           " Maximale Einschaltdauer nicht erreicht")
         else:
             if (self.relais == 1):
-                self.logClass(2, "(" + str(self.device_nummer) + ") " +
+                self.log.info("(" + str(self.device_nummer) + ") " +
                               self.device_name +
                               " Maximale Einschaltdauer erreicht schalte ab")
                 self.turndevicerelais(0, 0, 1)
             else:
-                self.logClass(2, "(" + str(self.device_nummer) + ")" +
+                self.log.info("(" + str(self.device_nummer) + ")" +
                               self.device_name +
                               " Maximale Einschaltdauer erreicht" +
                               " bereits abgeschaltet")
@@ -727,19 +726,19 @@ class Sbase(Sbase0):
         # Auto ladung
         if self._device_deactivatewhileevcharging > 0:
             if (self.relais == 1):
-                self.logClass(2, "(" + str(self.device_nummer) + ") " +
+                self.log.info("(" + str(self.device_nummer) + ") " +
                               self.device_name +
                               " Soll reduziert/abgeschaltet werden" +
                               " bei Ladung, pruefe " + str(testcharge))
                 if chargestatus == 1:
-                    self.logClass(2, "(" + str(self.device_nummer) + ") " +
+                    self.log.info("(" + str(self.device_nummer) + ") " +
                                   self.device_name +
                                   " Ladung läuft, pruefe Mindestlaufzeit")
                     if (self._c_eintime_f == 'Y'):
                         timesta = int(time.time()) - int(self._c_eintime)
                         if (self._device_mineinschaltdauer < timesta):
                             if self._device_deactivatewhileevcharging == 2:
-                                self.logClass(2, "(" + str(self.device_nummer)
+                                self.log.info("(" + str(self.device_nummer)
                                               + ") " + self.device_name +
                                               " Mindesteinschaltdauer" +
                                               "  erreicht, schalte aus")
@@ -747,7 +746,7 @@ class Sbase(Sbase0):
                                 return
                             else:
                                 if (self._dynregel == 0):
-                                    self.logClass(2, "(" +
+                                    self.log.info("(" +
                                                   str(self.device_nummer) +
                                                   ") " + self.device_name +
                                                   " Mindesteinschaltdauer " +
@@ -758,12 +757,12 @@ class Sbase(Sbase0):
                                     if (work_ausschaltschwelle < 0):
                                         work_ausschaltschwelle = 0
                                 else:
-                                    self.logClass(2, "(" +
+                                    self.log.info("(" +
                                                   str(self.device_nummer)
                                                   + ") " + self.device_name +
                                                   " Gerät mit dyn Regelung")
                         else:
-                            self.logClass(2, "(" + str(self.device_nummer) +
+                            self.log.info("(" + str(self.device_nummer) +
                                           ") " + self.device_name +
                                           " Mindesteinschaltdauer nicht" +
                                           " erreicht, " +
@@ -771,7 +770,7 @@ class Sbase(Sbase0):
                                           " > " + str(timesta))
                     else:
                         if self._device_deactivatewhileevcharging == 2:
-                            self.logClass(2, "(" + str(self.device_nummer) +
+                            self.log.info("(" + str(self.device_nummer) +
                                           ") " + self.device_name +
                                           " Mindesteinschaltdauer nicht" +
                                           " bekannt,schalte aus")
@@ -779,7 +778,7 @@ class Sbase(Sbase0):
                             return
                         else:
                             if (self._dynregel == 0):
-                                self.logClass(2, "(" +
+                                self.log.info("(" +
                                               str(self.device_nummer) +
                                               ") " + self.device_name +
                                               " Mindesteinschaltdauer " +
@@ -790,22 +789,22 @@ class Sbase(Sbase0):
                                 if (work_ausschaltschwelle < 0):
                                     work_ausschaltschwelle = 0
                             else:
-                                self.logClass(2, "(" +
+                                self.log.info("(" +
                                               str(self.device_nummer)
                                               + ") " + self.device_name +
                                               " Gerät mit dyn Regelung")
                 else:
-                    self.logClass(2, "(" + str(self.device_nummer) + ") " +
+                    self.log.info("(" + str(self.device_nummer) + ") " +
                                   self.device_name +
                                   " Ladung läuft nicht, pruefe weiter")
             else:
                 if self._device_deactivatewhileevcharging == 2:
-                    self.logClass(2, "(" + str(self.device_nummer) + ") " +
+                    self.log.info("(" + str(self.device_nummer) + ") " +
                                   self.device_name +
                                   " Soll nicht eingeschaltet werden bei" +
                                   " Ladung, pruefe " + str(testcharge))
                     if chargestatus == 1:
-                        self.logClass(2, "(" + str(self.device_nummer) + ") "
+                        self.log.info("(" + str(self.device_nummer) + ") "
                                       + self.device_name + " Ladung läuft, " +
                                       "wird nicht eingeschaltet")
                         return
@@ -830,18 +829,18 @@ class Sbase(Sbase0):
                 newueberschussberechnung = 1
         if (self.ueberschussberechnung != newueberschussberechnung):
             self.ueberschussberechnung = newueberschussberechnung
-            self.logClass(2, "(" + str(self.device_nummer) + ") " +
+            self.log.info("(" + str(self.device_nummer) + ") " +
                           self.device_name + " SoC " + str(speichersoc) +
                           " Einschalt SoC " +
                           str(self._device_speichersocbeforestart) +
                           " Ueberschuss " + str(self.devuberschuss))
-            self.logClass(2, "(" + str(self.device_nummer) + ") " +
+            self.log.info("(" + str(self.device_nummer) + ") " +
                           self.device_name +
                           " Ueberschussberechnung anders (1 = mit Speicher," +
                           " 2 = mit Offset) " +
                           str(self.ueberschussberechnung))
         if (self.devstatus == 20):
-            self.logClass(2, "(" + str(self.device_nummer) + ") " +
+            self.log.info("(" + str(self.device_nummer) + ") " +
                           self.device_name +
                           " Anlauferkennung immer noch aktiv, keine Ueberprüf"
                           + "ung auf Einschalt oder Ausschaltschwelle ")
@@ -854,7 +853,7 @@ class Sbase(Sbase0):
             if (self._c_eintime_f == 'Y'):
                 timesta = int(time.time()) - int(self._c_eintime)
                 if (self._device_mineinschaltdauer < timesta):
-                    self.logClass(2, "(" + str(self.device_nummer) + ") "
+                    self.log.info("(" + str(self.device_nummer) + ") "
                                   + self.device_name +
                                   " Mindesteinschaltdauer erreicht," +
                                   " restarte Anlauferkennung ")
@@ -862,20 +861,20 @@ class Sbase(Sbase0):
                     self.devstatus = 20
                     self.oncntstandby = str("0")
                     self.oncountnor = str("0")
-                    self.logClass(2, "(" + str(self.device_nummer) + ") " +
+                    self.log.info("(" + str(self.device_nummer) + ") " +
                                   self.device_name +
                                   " Anlauferkennung nun aktiv, eingeschaltet ")
                     self.turndevicerelais(1, 0, 0)
                     return
             else:
-                self.logClass(2, "(" + str(self.device_nummer) + ") " +
+                self.log.info("(" + str(self.device_nummer) + ") " +
                               self.device_name +
                               " Mindesteinschaltdauer nicht bekannt" +
                               " restarte Anlauferkennung ")
                 self.devstatus = 20
                 self.oncntstandby = str("0")
                 self.oncountnor = str("0")
-                self.logClass(2, "(" + str(self.device_nummer) + ") " +
+                self.log.info("(" + str(self.device_nummer) + ") " +
                               self.device_name +
                               " Anlauferkennung nun aktiv, eingeschaltet ")
                 self.turndevicerelais(1, 0, 0)
@@ -883,7 +882,7 @@ class Sbase(Sbase0):
         # periodisch hart ausschalten
         if ((self.relais == 1) and (self.gruppe == 'A') and
            (Sbase.eindevices == 0)):
-            self.logClass(2, "(" + str(self.device_nummer) + ") " +
+            self.log.info("(" + str(self.device_nummer) + ") " +
                           self.device_name +
                           " Soll periodisch ausgeschaltet werden " +
                           " (1 = volle Stunde / " +
@@ -891,7 +890,7 @@ class Sbase(Sbase0):
                           str(self._device_deactivateper))
             if (((self._device_deactivateper == 2) and (localminute == 30)) or
                (localminute == 00)):
-                self.logClass(2, "(" + str(self.device_nummer) +
+                self.log.info("(" + str(self.device_nummer) +
                               ") " + self.device_name +
                               " erfolgreich, schalte aus ")
                 self.turndevicerelais(0, 0, 1)
@@ -900,7 +899,7 @@ class Sbase(Sbase0):
         # periodisch prüfen ob ausschalten
         if ((self.relais == 1) and (self.gruppe == 'A') and
            (Sbase.eindevices > 0)):
-            self.logClass(2, "(" + str(self.device_nummer) + ") " +
+            self.log.info("(" + str(self.device_nummer) + ") " +
                           self.device_name +
                           " Soll periodisch geprüft werden " +
                           " (1 = volle Stunde / " +
@@ -908,7 +907,7 @@ class Sbase(Sbase0):
                           str(self._device_deactivateper))
             if (((self._device_deactivateper == 2) and (localminute == 30)) or
                (localminute == 00)):
-                self.logClass(2, "(" + str(self.device_nummer) +
+                self.log.info("(" + str(self.device_nummer) +
                               ") " + self.device_name +
                               " akt Leistungsaufnahme Abschaltgruppe " +
                               str(Sbase.ausschaltwatt) +
@@ -918,7 +917,7 @@ class Sbase(Sbase0):
                 if (((Sbase.ausschaltwatt + self._uberschuss) >
                    Sbase.einschwelle) and Sbase.einrelais == 0 and
                    Sbase.eindevstatus == 10):
-                    self.logClass(2, "(" + str(self.device_nummer) +
+                    self.log.info("(" + str(self.device_nummer) +
                                   ") " + self.device_name +
                                   " erfolgreich, schalte aus ")
                     self.turndevicerelais(0, 0, 1)
@@ -934,18 +933,18 @@ class Sbase(Sbase0):
         if ((self.devuberschuss > self._device_einschaltschwelle)
            or (onnow == 1)):
             self._c_ausverz_f = 'N'
-            self.logClass(2, "(" + str(self.device_nummer) + ") " +
+            self.log.info("(" + str(self.device_nummer) + ") " +
                           str(self.device_name) + " Überschuss " +
                           str(self.devuberschuss) + " größer Einschaltschwelle"
                           + " oder Immer an zeit erreicht " +
                           str(self._device_einschaltschwelle))
             if (self.relais == 0):
-                self.logClass(2, "(" + str(self.device_nummer) + ") " +
+                self.log.info("(" + str(self.device_nummer) + ") " +
                               self.device_name + " SoC " + str(speichersoc) +
                               " Einschalt SoC " +
                               str(self._device_speichersocbeforestart) +
                               " Ueberschuss " + str(self.devuberschuss))
-                self.logClass(2, "(" + str(self.device_nummer) + ") " +
+                self.log.info("(" + str(self.device_nummer) + ") " +
                               self.device_name + " Ueberschussberechnung (1 ="
                               + " mit Speicher, 2 = mit Offset) " +
                               str(self.ueberschussberechnung))
@@ -954,7 +953,7 @@ class Sbase(Sbase0):
                                     str(self._device_starttime).
                                     partition(':')[0])
                     startminute = int(str(self._device_starttime)[-2:])
-                    self.logClass(2, "(" + str(self.device_nummer) + ") " +
+                    self.log.info("(" + str(self.device_nummer) + ") " +
                                   self.device_name +
                                   " Fruehster Start um definiert " +
                                   str(starthour) + ":" +
@@ -963,7 +962,7 @@ class Sbase(Sbase0):
                                   str('%.2d' % localminute))
                     if ((starthour > localhour) or ((starthour == localhour)
                        and (startminute >= localminute))):
-                        self.logClass(2, "(" + str(self.device_nummer) + ") " +
+                        self.log.info("(" + str(self.device_nummer) + ") " +
                                       self.device_name +
                                       " Fruehster Start noch nicht erreicht ")
                         return
@@ -971,7 +970,7 @@ class Sbase(Sbase0):
                     endhour = int(str("0") +
                                   str(self._device_endtime).partition(':')[0])
                     endminute = int(str(self._device_endtime)[-2:])
-                    self.logClass(2, "(" + str(self.device_nummer) + ") " +
+                    self.log.info("(" + str(self.device_nummer) + ") " +
                                   self.device_name +
                                   " Spaetester Start um definiert " +
                                   str(endhour) + ":" + str('%.2d' % endminute)
@@ -981,14 +980,14 @@ class Sbase(Sbase0):
                        and (endminute >= localminute))):
                         pass
                     else:
-                        self.logClass(2, "(" + str(self.device_nummer) + ") " +
+                        self.log.info("(" + str(self.device_nummer) + ") " +
                                       self.device_name +
                                       " Spaetester Start vorbei ")
                         return
                 if (self._c_einverz_f == 'Y'):
                     timesince = int(time.time()) - int(self._c_einverz)
                     if (self._device_einschaltverzoegerung < timesince):
-                        self.logClass(2, "(" + str(self.device_nummer) + ") "
+                        self.log.info("(" + str(self.device_nummer) + ") "
                                       + self.device_name +
                                       " Einschaltverzögerung erreicht, " +
                                       "schalte ein " +
@@ -996,7 +995,7 @@ class Sbase(Sbase0):
                         self.turndevicerelais(1, self.ueberschussberechnung, 1)
                         self._c_einverz_f = 'N'
                     else:
-                        self.logClass(2, "(" + str(self.device_nummer) + ") " +
+                        self.log.info("(" + str(self.device_nummer) + ") " +
                                       self.device_name +
                                       " Einschaltverzögerung nicht erreicht. "
                                       + str(self._device_einschaltverzoegerung)
@@ -1004,11 +1003,11 @@ class Sbase(Sbase0):
                 else:
                     self._c_einverz_f = 'Y'
                     self._c_einverz = int(time.time())
-                    self.logClass(2, "(" + str(self.device_nummer) + ") " +
+                    self.log.info("(" + str(self.device_nummer) + ") " +
                                   self.device_name +
                                   " Einschaltverzögerung gestartet")
             else:
-                self.logClass(2, "(" + str(self.device_nummer) + ") " +
+                self.log.info("(" + str(self.device_nummer) + ") " +
                               self.device_name +
                               " Einschaltverzögerung erreicht, bereits ein")
                 self._c_einverz_f = 'N'
@@ -1016,17 +1015,17 @@ class Sbase(Sbase0):
             self._c_einverz_f = 'N'
             if (self.devuberschuss < work_ausschaltschwelle):
                 if (speichersoc > self._device_speichersocbeforestop):
-                    self.logClass(2, "(" + str(self.device_nummer) + ") " +
+                    self.log.info("(" + str(self.device_nummer) + ") " +
                                   self.device_name +
                                   " SoC höher als Abschalt SoC," +
                                   " lasse Gerät weiterlaufen")
                     return
                 else:
-                    self.logClass(2, "(" + str(self.device_nummer) + ") " +
+                    self.log.info("(" + str(self.device_nummer) + ") " +
                                   self.device_name +
                                   " SoC niedriger als Abschalt SoC," +
                                   " prüfe weiter")
-                self.logClass(2, "(" + str(self.device_nummer) + ") " +
+                self.log.info("(" + str(self.device_nummer) + ") " +
                               self.device_name + " Überschuss " +
                               str(self.devuberschuss) +
                               " kleiner Ausschaltschwelle " +
@@ -1039,7 +1038,7 @@ class Sbase(Sbase0):
                                 timesta = int((time.time()) -
                                               int(self._c_eintime))
                                 if (self._device_mineinschaltdauer < timesta):
-                                    self.logClass(2, "(" +
+                                    self.log.info("(" +
                                                   str(self.device_nummer) +
                                                   ") " + self.device_name +
                                                   " Ausschaltverzögerung &" +
@@ -1050,7 +1049,7 @@ class Sbase(Sbase0):
                                     self._c_ausverz_f = 'N'
                                 else:
                                     s1 = str(self._device_mineinschaltdauer)
-                                    self.logClass(2, "(" +
+                                    self.log.info("(" +
                                                   str(self.device_nummer) +
                                                   ") " + self.device_name +
                                                   " Ausschaltverzögerung errei"
@@ -1058,32 +1057,32 @@ class Sbase(Sbase0):
                                                   "dauer nicht erreicht, " +
                                                   s1 + " > " + str(timesta))
                             else:
-                                self.logClass(2, "(" + str(self.device_nummer)
+                                self.log.info("(" + str(self.device_nummer)
                                               + ") " + self.device_name +
                                               " Mindesteinschaltdauer nicht" +
                                               " bekannt, schalte aus")
                                 self.turndevicerelais(0, 0, 1)
                         else:
-                            self.logClass(2, "(" + str(self.device_nummer) +
+                            self.log.info("(" + str(self.device_nummer) +
                                           ") " + self.device_name +
                                           " Ausschaltverzögerung nicht" +
                                           " erreicht. " +
                                           str(work_ausschaltverzoegerung) +
                                           " > " + str(timesince))
                     else:
-                        self.logClass(2, "(" + str(self.device_nummer) + ") " +
+                        self.log.info("(" + str(self.device_nummer) + ") " +
                                       self.device_name +
                                       " Ausschaltverzögerung gestartet ")
                         self._c_ausverz_f = 'Y'
                         self._c_ausverz = int(time.time())
 
                 else:
-                    self.logClass(2, "(" + str(self.device_nummer) + ") " +
+                    self.log.info("(" + str(self.device_nummer) + ") " +
                                   self.device_name +
                                   " Ausschaltverzögerung erreicht,bereits aus")
                     self._c_ausverz_f = 'N'
             else:
-                self.logClass(2, "(" + str(self.device_nummer) + ") " +
+                self.log.info("(" + str(self.device_nummer) + ") " +
                               self.device_name + " Überschuss kleiner als" +
                               " Einschaltschwelle und größer als " +
                               "Ausschaltschwelle. Ueberschuss " +
@@ -1195,7 +1194,7 @@ class Sbase(Sbase0):
             return
         self.newdevice_manual = newmanual
         self.newdevice_manual_control = newmanual_control
-        self.logClass(2, "(" + str(self.device_nummer) + ") " +
+        self.log.info("(" + str(self.device_nummer) + ") " +
                       self.device_name +
                       " Umschaltung manual modus alt/neu " +
                       str(self.device_manual) + "/" +

--- a/runs/usmarthome/smartbase0.py
+++ b/runs/usmarthome/smartbase0.py
@@ -1,25 +1,14 @@
 import json
-from datetime import datetime, timezone
+import logging
 
 
 class Sbase0:
     _basePath = '/var/www/html/openWB'
     _prefixpy = _basePath+'/modules/smarthome/'
 
-    def logClass(self, level, msg):
-        if (int(level) >= 0):
-            local_time = datetime.now(timezone.utc).astimezone()
-            with open(self._basePath+'/ramdisk/smarthome.log', 'a',
-                      encoding='utf8', buffering=1) as file:
-                if (int(level) == 0):
-                    file.write(local_time.strftime(format="%Y-%m-%d %H:%M:%S")
-                               + '-: ' + str(msg) + '\n')
-                if (int(level) == 1):
-                    file.write(local_time.strftime(format="%Y-%m-%d %H:%M:%S")
-                               + '-: ' + str(msg) + '\n')
-                if (int(level) == 2):
-                    file.write(local_time.strftime(format="%Y-%m-%d %H:%M:%S")
-                               + '-: ' + str(msg) + '\n')
+    def __init__(self):
+        print('__init__ Sbase executed')
+        self.log = logging.getLogger("smarthome")
 
     def readret(self):
         with open(self._basePath+'/ramdisk/smarthome_device_ret' +

--- a/runs/usmarthome/smartbase0.py
+++ b/runs/usmarthome/smartbase0.py
@@ -1,5 +1,4 @@
 import json
-import logging
 
 
 class Sbase0:
@@ -8,7 +7,6 @@ class Sbase0:
 
     def __init__(self):
         print('__init__ Sbase executed')
-        self.log = logging.getLogger("smarthome")
 
     def readret(self):
         with open(self._basePath+'/ramdisk/smarthome_device_ret' +

--- a/runs/usmarthome/smartbut.py
+++ b/runs/usmarthome/smartbut.py
@@ -1,4 +1,5 @@
 from usmarthome.smartbase0 import Sbase0
+from usmarthome.global0 import log
 import urllib.request
 import json
 
@@ -19,9 +20,9 @@ class Spbase(Sbase0):
             if (key == 'device_pbip'):
                 self._device_pbip = value
             else:
-                self.log.info("(" + str(self.device_nummer) + ") "
-                              + __class__.__name__ + " überlesen " + key +
-                              " " + value)
+                log.info("(" + str(self.device_nummer) + ") "
+                         + __class__.__name__ + " überlesen " + key +
+                         " " + value)
 
     def showstat(self, manual, relais):
         pass
@@ -57,9 +58,8 @@ class Sbshelly(Spbase):
                                             + "/status",
                                             timeout=3).read().decode("utf-8"))
         except Exception as e1:
-            self.log.warning("Shelly button ch (%d) %s Fehlermeldung: %s "
-                             % (self.device_nummer,
-                                self._device_pbip, str(e1)))
+            log.warning("Shelly button ch (%d) %s Fehlermeldung: %s "
+                        % (self.device_nummer, self._device_pbip, str(e1)))
             return newmanual, newmanual_control
         a = json.loads(at)
         with open(self._basePath+'/ramdisk/smarthome_device_ret' +
@@ -74,9 +74,8 @@ class Sbshelly(Spbase):
         if ((self.event == self.oldevent) and
            (self.event_cnt == self.oldevent_cnt)):
             return newmanual, newmanual_control
-        self.log.info("Shelly button pressed (%d) %s %s"
-                      % (self.device_nummer,
-                         self._device_pbip, self.event))
+        log.info("Shelly button pressed (%d) %s %s"
+                 % (self.device_nummer, self._device_pbip, self.event))
         # im automatic modus -> ein mal Drücken wechselen auf manual
         if (manual == 0):
             newmanual = 1
@@ -99,14 +98,12 @@ class Sbshelly(Spbase):
             urllib.request.urlopen("http://" + str(self._device_pbip) +
                                    "/settings?led_status_disable=true",
                                    timeout=3)
-            self.log.info("Shelly button led off (%d) %s"
-                          % (self.device_nummer,
-                             self._device_pbip))
+            log.info("Shelly button led off (%d) %s"
+                     % (self.device_nummer, self._device_pbip))
 
         except Exception as e1:
-            self.log.warning("Shelly button off (%d) %s Fehlermeldung: %s "
-                             % (self.device_nummer,
-                                self._device_pbip, str(e1)))
+            log.warning("Shelly button off (%d) %s Fehlermeldung: %s "
+                        % (self.device_nummer, self._device_pbip, str(e1)))
         self.led = 0
 
     def pbon(self):
@@ -116,13 +113,11 @@ class Sbshelly(Spbase):
             urllib.request.urlopen("http://" + str(self._device_pbip) +
                                    "/settings?led_status_disable=false",
                                    timeout=3)
-            self.log.info("Shelly button led on (%d) %s"
-                          % (self.device_nummer,
-                             self._device_pbip))
+            log.info("Shelly button led on (%d) %s"
+                     % (self.device_nummer, self._device_pbip))
         except Exception as e1:
-            self.log.warning("Shelly button on (%d) %s Fehlermeldung: %s "
-                             % (self.device_nummer,
-                                self._device_pbip, str(e1)))
+            log.warning("Shelly button on (%d) %s Fehlermeldung: %s "
+                        % (self.device_nummer, self._device_pbip, str(e1)))
         self.led = 1
 
     def pbblink(self):

--- a/runs/usmarthome/smartbut.py
+++ b/runs/usmarthome/smartbut.py
@@ -7,6 +7,7 @@ class Spbase(Sbase0):
     def __init__(self):
         #
         # setting
+        super().__init__()
         print('__init__ Spbase executed')
         self._device_pbip = 'none'
         self.device_nummer = 0
@@ -18,7 +19,7 @@ class Spbase(Sbase0):
             if (key == 'device_pbip'):
                 self._device_pbip = value
             else:
-                self.logClass(2, "(" + str(self.device_nummer) + ") "
+                self.log.info("(" + str(self.device_nummer) + ") "
                               + __class__.__name__ + " überlesen " + key +
                               " " + value)
 
@@ -56,10 +57,10 @@ class Sbshelly(Spbase):
                                             + "/status",
                                             timeout=3).read().decode("utf-8"))
         except Exception as e1:
-            self.logClass(2, "Shelly button ch (%d) %s Fehlermeldung: %s "
-                          % (self.device_nummer,
-                             self._device_pbip, str(e1)))   
-            return newmanual, newmanual_control                         
+            self.log.warning("Shelly button ch (%d) %s Fehlermeldung: %s "
+                             % (self.device_nummer,
+                                self._device_pbip, str(e1)))
+            return newmanual, newmanual_control
         a = json.loads(at)
         with open(self._basePath+'/ramdisk/smarthome_device_ret' +
                   str(self.device_nummer) + '_shelly_bp', 'w') as f:
@@ -73,7 +74,7 @@ class Sbshelly(Spbase):
         if ((self.event == self.oldevent) and
            (self.event_cnt == self.oldevent_cnt)):
             return newmanual, newmanual_control
-        self.logClass(2, "Shelly button pressed (%d) %s %s"
+        self.log.info("Shelly button pressed (%d) %s %s"
                       % (self.device_nummer,
                          self._device_pbip, self.event))
         # im automatic modus -> ein mal Drücken wechselen auf manual
@@ -98,14 +99,14 @@ class Sbshelly(Spbase):
             urllib.request.urlopen("http://" + str(self._device_pbip) +
                                    "/settings?led_status_disable=true",
                                    timeout=3)
-            self.logClass(2, "Shelly button led off (%d) %s"
+            self.log.info("Shelly button led off (%d) %s"
                           % (self.device_nummer,
                              self._device_pbip))
 
         except Exception as e1:
-            self.logClass(2, "Shelly button off (%d) %s Fehlermeldung: %s "
-                          % (self.device_nummer,
-                             self._device_pbip, str(e1)))
+            self.log.warning("Shelly button off (%d) %s Fehlermeldung: %s "
+                             % (self.device_nummer,
+                                self._device_pbip, str(e1)))
         self.led = 0
 
     def pbon(self):
@@ -115,13 +116,13 @@ class Sbshelly(Spbase):
             urllib.request.urlopen("http://" + str(self._device_pbip) +
                                    "/settings?led_status_disable=false",
                                    timeout=3)
-            self.logClass(2, "Shelly button led on (%d) %s"
+            self.log.info("Shelly button led on (%d) %s"
                           % (self.device_nummer,
                              self._device_pbip))
         except Exception as e1:
-            self.logClass(2, "Shelly button on (%d) %s Fehlermeldung: %s "
-                          % (self.device_nummer,
-                             self._device_pbip, str(e1)))
+            self.log.warning("Shelly button on (%d) %s Fehlermeldung: %s "
+                             % (self.device_nummer,
+                                self._device_pbip, str(e1)))
         self.led = 1
 
     def pbblink(self):

--- a/runs/usmarthome/smartelwa.py
+++ b/runs/usmarthome/smartelwa.py
@@ -1,5 +1,6 @@
 #!/usr/bin/python3
 from usmarthome.smartbase import Sbase
+from usmarthome.global0 import log
 import subprocess
 
 
@@ -23,10 +24,10 @@ class Selwa(Sbase):
             self.newwattk = int(self.answer['powerc'])
             self.relais = int(self.answer['on'])
         except Exception as e1:
-            self.log.warning("(" + str(self.device_nummer) +
-                             ") Leistungsmessung %s %d %s Fehlermeldung: %s "
-                             % ('elwa ', self.device_nummer,
-                                str(self._device_ip), str(e1)))
+            log.warning("(" + str(self.device_nummer) +
+                        ") Leistungsmessung %s %d %s Fehlermeldung: %s "
+                        % ('elwa ', self.device_nummer,
+                           str(self._device_ip), str(e1)))
         self.postwatt()
 
     def turndevicerelais(self, zustand, ueberschussberechnung, updatecnt):
@@ -42,7 +43,7 @@ class Selwa(Sbase):
             self.proc = subprocess.Popen(argumentList)
             self.proc.communicate()
         except Exception as e1:
-            self.log.warning("(" + str(self.device_nummer) +
-                             ") on / off  %s %d %s Fehlermeldung: %s "
-                             % ('elwa ', self.device_nummer,
-                                str(self._device_ip), str(e1)))
+            log.warning("(" + str(self.device_nummer) +
+                        ") on / off  %s %d %s Fehlermeldung: %s "
+                        % ('elwa ', self.device_nummer,
+                           str(self._device_ip), str(e1)))

--- a/runs/usmarthome/smartelwa.py
+++ b/runs/usmarthome/smartelwa.py
@@ -1,7 +1,6 @@
 #!/usr/bin/python3
 from usmarthome.smartbase import Sbase
 import subprocess
-import json
 
 
 class Selwa(Sbase):
@@ -19,19 +18,15 @@ class Selwa(Sbase):
         try:
             self.proc = subprocess.Popen(argumentList)
             self.proc.communicate()
-            self.f1 = open(self._basePath+'/ramdisk/smarthome_device_ret' +
-                           str(self.device_nummer), 'r')
-            self.answerj = json.load(self.f1)
-            self.f1.close()
-            self.answer = json.loads(self.answerj)
+            self.answer = self.readret()
             self.newwatt = int(self.answer['power'])
             self.newwattk = int(self.answer['powerc'])
             self.relais = int(self.answer['on'])
         except Exception as e1:
-            self.logClass(2, "(" + str(self.device_nummer) +
-                          ") Leistungsmessung %s %d %s Fehlermeldung: %s "
-                          % ('elwa ', self.device_nummer,
-                             str(self._device_ip), str(e1)))
+            self.log.warning("(" + str(self.device_nummer) +
+                             ") Leistungsmessung %s %d %s Fehlermeldung: %s "
+                             % ('elwa ', self.device_nummer,
+                                str(self._device_ip), str(e1)))
         self.postwatt()
 
     def turndevicerelais(self, zustand, ueberschussberechnung, updatecnt):
@@ -47,7 +42,7 @@ class Selwa(Sbase):
             self.proc = subprocess.Popen(argumentList)
             self.proc.communicate()
         except Exception as e1:
-            self.logClass(2, "(" + str(self.device_nummer) +
-                          ") on / off  %s %d %s Fehlermeldung: %s "
-                          % ('elwa ', self.device_nummer,
-                             str(self._device_ip), str(e1)))
+            self.log.warning("(" + str(self.device_nummer) +
+                             ") on / off  %s %d %s Fehlermeldung: %s "
+                             % ('elwa ', self.device_nummer,
+                                str(self._device_ip), str(e1)))

--- a/runs/usmarthome/smarthttp.py
+++ b/runs/usmarthome/smarthttp.py
@@ -42,17 +42,17 @@ class Shttp(Sbase):
             elif (key == 'device_ausschalturl'):
                 self._device_ausschalturl = value
             else:
-                self.logClass(2, "(" + str(self.device_nummer) + ") " +
+                self.log.info("(" + str(self.device_nummer) + ") " +
                               __class__.__name__ + " überlesen " + key +
                               " " + value)
         if (self._old_measuretype0 == 'none'):
             self._mydevicemeasure0 = Slhttp()
             self._old_measuretype0 = 'http'
-            self.logClass(2, "(" + str(self.device_nummer) +
+            self.log.info("(" + str(self.device_nummer) +
                           ") Integrierte Leistungsmessung. Neues Measure" +
                           " device erzeugt " + self.device_type)
         else:
-            self.logClass(2, "(" + str(self.device_nummer) +
+            self.log.info("(" + str(self.device_nummer) +
                           ") Integrierte Leistungsmessung. Nur Parameter" +
                           " update " + self.device_type)
         self._mydevicemeasure0.updatepar(input_param)
@@ -73,7 +73,7 @@ class Shttp(Sbase):
             self.proc = subprocess.Popen(argumentList)
             self.proc.communicate()
         except Exception as e1:
-            self.logClass(2, "(" + str(self.device_nummer) +
-                          ") on / off %s %d %s Fehlermeldung: %s "
-                          % ('Shttp', self.device_nummer,
-                             str(self._device_ip), str(e1)))
+            self.log.warning("(" + str(self.device_nummer) +
+                             ") on / off %s %d %s Fehlermeldung: %s "
+                             % ('Shttp', self.device_nummer,
+                                str(self._device_ip), str(e1)))

--- a/runs/usmarthome/smarthttp.py
+++ b/runs/usmarthome/smarthttp.py
@@ -1,5 +1,6 @@
 #!/usr/bin/python3
 from usmarthome.smartbase import Sbase, Slhttp
+from usmarthome.global0 import log
 import subprocess
 
 
@@ -42,19 +43,19 @@ class Shttp(Sbase):
             elif (key == 'device_ausschalturl'):
                 self._device_ausschalturl = value
             else:
-                self.log.info("(" + str(self.device_nummer) + ") " +
-                              __class__.__name__ + " überlesen " + key +
-                              " " + value)
+                log.info("(" + str(self.device_nummer) + ") " +
+                         __class__.__name__ + " überlesen " + key +
+                         " " + value)
         if (self._old_measuretype0 == 'none'):
             self._mydevicemeasure0 = Slhttp()
             self._old_measuretype0 = 'http'
-            self.log.info("(" + str(self.device_nummer) +
-                          ") Integrierte Leistungsmessung. Neues Measure" +
-                          " device erzeugt " + self.device_type)
+            log.info("(" + str(self.device_nummer) +
+                     ") Integrierte Leistungsmessung. Neues Measure" +
+                     " device erzeugt " + self.device_type)
         else:
-            self.log.info("(" + str(self.device_nummer) +
-                          ") Integrierte Leistungsmessung. Nur Parameter" +
-                          " update " + self.device_type)
+            log.info("(" + str(self.device_nummer) +
+                     ") Integrierte Leistungsmessung. Nur Parameter" +
+                     " update " + self.device_type)
         self._mydevicemeasure0.updatepar(input_param)
 
     def turndevicerelais(self, zustand, ueberschussberechnung, updatecnt):
@@ -73,7 +74,7 @@ class Shttp(Sbase):
             self.proc = subprocess.Popen(argumentList)
             self.proc.communicate()
         except Exception as e1:
-            self.log.warning("(" + str(self.device_nummer) +
-                             ") on / off %s %d %s Fehlermeldung: %s "
-                             % ('Shttp', self.device_nummer,
-                                str(self._device_ip), str(e1)))
+            log.warning("(" + str(self.device_nummer) +
+                        ") on / off %s %d %s Fehlermeldung: %s "
+                        % ('Http', self.device_nummer,
+                           str(self._device_ip), str(e1)))

--- a/runs/usmarthome/smartidm.py
+++ b/runs/usmarthome/smartidm.py
@@ -1,14 +1,13 @@
 #!/usr/bin/python3
 from usmarthome.smartbase import Sbase
 import subprocess
-import json
 
 
 class Sidm(Sbase):
     def __init__(self):
         # setting
-        super().__init__()       
-        self._smart_paramadd = {}        
+        super().__init__()
+        self._smart_paramadd = {}
         self._device_idmnav = '2'
         self.device_nummer = 0
         print('__init__ Sidm executed')
@@ -24,7 +23,7 @@ class Sidm(Sbase):
             elif (key == 'device_idmnav'):
                 self._device_idmnav = value
             else:
-                self.logClass(2, "(" + str(self.device_nummer) + ") " +
+                self.log.info("(" + str(self.device_nummer) + ") " +
                               __class__.__name__ + " überlesen " + key +
                               " " + value)
 
@@ -36,15 +35,15 @@ class Sidm(Sbase):
         try:
             self.proc = subprocess.Popen(argumentList)
             self.proc.communicate()
-            self.answer = self.readret()   
+            self.answer = self.readret()
             self.newwatt = int(self.answer['power'])
             self.newwattk = int(self.answer['powerc'])
             self.relais = int(self.answer['on'])
         except Exception as e1:
-            self.logClass(2, "(" + str(self.device_nummer) +
-                          ") Leistungsmessung %s %d %s Fehlermeldung: %s "
-                          % ('idm ', self.device_nummer,
-                             str(self._device_ip), str(e1)))
+            self.log.warning("(" + str(self.device_nummer) +
+                             ") Leistungsmessung %s %d %s Fehlermeldung: %s "
+                             % ('idm ', self.device_nummer,
+                                str(self._device_ip), str(e1)))
         self.postwatt()
 
     def turndevicerelais(self, zustand, ueberschussberechnung, updatecnt):
@@ -60,7 +59,7 @@ class Sidm(Sbase):
             self.proc = subprocess.Popen(argumentList)
             self.proc.communicate()
         except Exception as e1:
-            self.logClass(2, "(" + str(self.device_nummer) +
-                          ") on / off  %s %d %s Fehlermeldung: %s "
-                          % ('idm ', self.device_nummer,
-                             str(self._device_ip), str(e1)))
+            self.log.warning("(" + str(self.device_nummer) +
+                             ") on / off  %s %d %s Fehlermeldung: %s "
+                             % ('idm ', self.device_nummer,
+                                str(self._device_ip), str(e1)))

--- a/runs/usmarthome/smartidm.py
+++ b/runs/usmarthome/smartidm.py
@@ -1,5 +1,6 @@
 #!/usr/bin/python3
 from usmarthome.smartbase import Sbase
+from usmarthome.global0 import log
 import subprocess
 
 
@@ -23,9 +24,9 @@ class Sidm(Sbase):
             elif (key == 'device_idmnav'):
                 self._device_idmnav = value
             else:
-                self.log.info("(" + str(self.device_nummer) + ") " +
-                              __class__.__name__ + " überlesen " + key +
-                              " " + value)
+                log.info("(" + str(self.device_nummer) + ") " +
+                         __class__.__name__ + " überlesen " + key +
+                         " " + value)
 
     def getwatt(self, uberschuss, uberschussoffset):
         self.prewatt(uberschuss, uberschussoffset)
@@ -40,10 +41,10 @@ class Sidm(Sbase):
             self.newwattk = int(self.answer['powerc'])
             self.relais = int(self.answer['on'])
         except Exception as e1:
-            self.log.warning("(" + str(self.device_nummer) +
-                             ") Leistungsmessung %s %d %s Fehlermeldung: %s "
-                             % ('idm ', self.device_nummer,
-                                str(self._device_ip), str(e1)))
+            log.warning("(" + str(self.device_nummer) +
+                        ") Leistungsmessung %s %d %s Fehlermeldung: %s "
+                        % ('idm ', self.device_nummer,
+                           str(self._device_ip), str(e1)))
         self.postwatt()
 
     def turndevicerelais(self, zustand, ueberschussberechnung, updatecnt):
@@ -59,7 +60,7 @@ class Sidm(Sbase):
             self.proc = subprocess.Popen(argumentList)
             self.proc.communicate()
         except Exception as e1:
-            self.log.warning("(" + str(self.device_nummer) +
-                             ") on / off  %s %d %s Fehlermeldung: %s "
-                             % ('idm ', self.device_nummer,
-                                str(self._device_ip), str(e1)))
+            log.warning("(" + str(self.device_nummer) +
+                        ") on / off  %s %d %s Fehlermeldung: %s "
+                        % ('idm ', self.device_nummer,
+                           str(self._device_ip), str(e1)))

--- a/runs/usmarthome/smartmeas.py
+++ b/runs/usmarthome/smartmeas.py
@@ -6,6 +6,7 @@ class Slbase(Sbase0):
     def __init__(self):
         #
         # setting
+        super().__init__()
         print('__init__ Slbase executed')
         self.device_nummer = 0
         self.device_name = 'none'
@@ -92,7 +93,7 @@ class Slbase(Sbase0):
             elif (key == 'device_measchan'):
                 self._device_measchan = valueint
             elif (key == 'device_chan'):
-                self._device_chan = valueint                
+                self._device_chan = valueint
             elif (key == 'device_measuresmaser'):
                 self._device_measuresmaser = value
             elif (key == 'device_measureid'):
@@ -124,7 +125,7 @@ class Slbase(Sbase0):
             elif (key == 'device_stateurl'):
                 self._device_stateurl = value
             else:
-                self.logClass(2, "(" + str(self.device_nummer) + ") "
+                self.log.info("(" + str(self.device_nummer) + ") "
                               + __class__.__name__ + " überlesen " + key +
                               " " + value)
 
@@ -157,8 +158,8 @@ class Slmqtt(Slbase):
             self.newwattk = int(answer['powerc'])
             self.relais = int(answer['on'])
         except Exception as e1:
-            self.logClass(2, "Leistungsmessung %s %d %s Fehlermeldung: %s "
-                          % ('mqtt', self.device_nummer, ip, str(e1)))
+            self.log.warning("Leistungsmessung %s %d %s Fehlermeldung: %s "
+                             % ('mqtt', self.device_nummer, ip, str(e1)))
 
 
 class Slshelly(Slbase):
@@ -207,8 +208,8 @@ class Slshelly(Slbase):
             else:
                 self.temp2 = '300'
         except Exception as e1:
-            self.logClass(2, "Leistungsmessung %s %d %s Fehlermeldung: %s "
-                          % ('Shelly', self.device_nummer, ip, str(e1)))
+            self.log.warning("Leistungsmessung %s %d %s Fehlermeldung: %s "
+                             % ('Shelly', self.device_nummer, ip, str(e1)))
 
 
 class Slavm(Slbase):
@@ -243,8 +244,8 @@ class Slavm(Slbase):
             self.newwattk = int(answer['powerc'])
             self.relais = int(answer['on'])
         except Exception as e1:
-            self.logClass(2, "Leistungsmessung %s %d %s Fehlermeldung: %s "
-                          % ('Avm ', self.device_nummer, ip, str(e1)))
+            self.log.warning("Leistungsmessung %s %d %s Fehlermeldung: %s "
+                             % ('Avm ', self.device_nummer, ip, str(e1)))
 
 
 class Sltasmota(Slbase):
@@ -271,8 +272,8 @@ class Sltasmota(Slbase):
             self.newwattk = int(answer['powerc'])
             self.relais = int(answer['on'])
         except Exception as e1:
-            self.logClass(2, "Leistungsmessung %s %d %s Fehlermeldung: %s "
-                          % ('Tasmota', self.device_nummer, ip, str(e1)))
+            self.log.warning("Leistungsmessung %s %d %s Fehlermeldung: %s "
+                             % ('Tasmota', self.device_nummer, ip, str(e1)))
 
 
 class Slhttp(Slbase):
@@ -305,8 +306,8 @@ class Slhttp(Slbase):
             self.newwattk = int(answer['powerc'])
             self.relais = int(answer['on'])
         except Exception as e1:
-            self.logClass(2, "Leistungsmessung %s %d Fehlermeldung: %s "
-                          % ('http', self.device_nummer, str(e1)))
+            self.log.warning("Leistungsmessung %s %d Fehlermeldung: %s "
+                             % ('http', self.device_nummer, str(e1)))
 
 
 class Slmystrom(Slbase):
@@ -340,8 +341,8 @@ class Slmystrom(Slbase):
             else:
                 self.temp0 = '300'
         except Exception as e1:
-            self.logClass(2, "Leistungsmessung %s %d %s Fehlermeldung: %s "
-                          % ('Mystrom', self.device_nummer, ip, str(e1)))
+            self.log.warning("Leistungsmessung %s %d %s Fehlermeldung: %s "
+                             % ('Mystrom', self.device_nummer, ip, str(e1)))
 
 
 class Slsmaem(Slbase):
@@ -362,9 +363,9 @@ class Slsmaem(Slbase):
             self.newwatt = int(answer['power'])
             self.newwattk = int(answer['powerc'])
         except Exception as e1:
-            self.logClass(2, "Leistungsmessung %s %d %s Fehlermeldung: %s "
-                          % ('smaem ', self.device_nummer,
-                             str(self._device_measureip), str(e1)))
+            self.log.warning("Leistungsmessung %s %d %s Fehlermeldung: %s "
+                             % ('smaem ', self.device_nummer,
+                                str(self._device_measureip), str(e1)))
         return self.newwatt, self.newwattk
 
 
@@ -385,9 +386,9 @@ class Slwe514(Slbase):
             self.newwatt = int(answer['power'])
             self.newwattk = int(answer['powerc'])
         except Exception as e1:
-            self.logClass(2, "Leistungsmessung %s %d %s Fehlermeldung: %s "
-                          % ('we514 ', self.device_nummer,
-                             str(self._device_measureip), str(e1)))
+            self.log.warning("Leistungsmessung %s %d %s Fehlermeldung: %s "
+                             % ('we514 ', self.device_nummer,
+                                str(self._device_measureip), str(e1)))
         return self.newwatt, self.newwattk
 
 
@@ -410,8 +411,8 @@ class Sljson(Slbase):
             self.newwatt = int(answer['power'])
             self.newwattk = int(answer['powerc'])
         except Exception as e1:
-            self.logClass(2, "Leistungsmessung %s %s Fehlermeldung: %s "
-                          % ('json ', self.device_nummer, str(e1)))
+            self.log.warning("Leistungsmessung %s %s Fehlermeldung: %s "
+                             % ('json ', self.device_nummer, str(e1)))
         return self.newwatt, self.newwattk
 
 
@@ -432,9 +433,9 @@ class Slfronius(Slbase):
             self.newwatt = int(answer['power'])
             self.newwattk = int(answer['powerc'])
         except Exception as e1:
-            self.logClass(2, "Leistungsmessung %s %d %s Fehlermeldung: %s "
-                          % ('fronius ', self.device_nummer,
-                             str(self._device_measureip), str(e1)))
+            self.log.warning("Leistungsmessung %s %d %s Fehlermeldung: %s "
+                             % ('fronius ', self.device_nummer,
+                                str(self._device_measureip), str(e1)))
         return self.newwatt, self.newwattk
 
 
@@ -456,9 +457,9 @@ class Slsdm630(Slbase):
             self.newwatt = int(answer['power'])
             self.newwattk = int(answer['powerc'])
         except Exception as e1:
-            self.logClass(2, "Leistungsmessung %s %d %s Fehlermeldung: %s "
-                          % ('Sdm630 ', self.device_nummer,
-                             str(self._device_measureip), str(e1)))
+            self.log.warning("Leistungsmessung %s %d %s Fehlermeldung: %s "
+                             % ('Sdm630 ', self.device_nummer,
+                                str(self._device_measureip), str(e1)))
         return self.newwatt, self.newwattk
 
 
@@ -480,7 +481,7 @@ class Slsdm120(Slbase):
             self.newwatt = int(answer['power'])
             self.newwattk = int(answer['powerc'])
         except Exception as e1:
-            self.logClass(2, "Leistungsmessung %s %d %s Fehlermeldung: %s "
-                          % ('Sdm120 ', self.device_nummer,
-                             str(self._device_measureip), str(e1)))
+            self.log.warning("Leistungsmessung %s %d %s Fehlermeldung: %s "
+                             % ('Sdm120 ', self.device_nummer,
+                                str(self._device_measureip), str(e1)))
         return self.newwatt, self.newwattk

--- a/runs/usmarthome/smartmeas.py
+++ b/runs/usmarthome/smartmeas.py
@@ -1,4 +1,5 @@
 from usmarthome.smartbase0 import Sbase0
+from usmarthome.global0 import log
 import subprocess
 
 
@@ -125,9 +126,9 @@ class Slbase(Sbase0):
             elif (key == 'device_stateurl'):
                 self._device_stateurl = value
             else:
-                self.log.info("(" + str(self.device_nummer) + ") "
-                              + __class__.__name__ + " überlesen " + key +
-                              " " + value)
+                log.info("(" + str(self.device_nummer) + ") "
+                         + __class__.__name__ + " überlesen " + key +
+                         " " + value)
 
     def __del__(self):
         print('__del__ Slbase executed ')
@@ -158,8 +159,8 @@ class Slmqtt(Slbase):
             self.newwattk = int(answer['powerc'])
             self.relais = int(answer['on'])
         except Exception as e1:
-            self.log.warning("Leistungsmessung %s %d %s Fehlermeldung: %s "
-                             % ('mqtt', self.device_nummer, ip, str(e1)))
+            log.warning("Leistungsmessung %s %d %s Fehlermeldung: %s "
+                        % ('mqtt', self.device_nummer, ip, str(e1)))
 
 
 class Slshelly(Slbase):
@@ -208,8 +209,8 @@ class Slshelly(Slbase):
             else:
                 self.temp2 = '300'
         except Exception as e1:
-            self.log.warning("Leistungsmessung %s %d %s Fehlermeldung: %s "
-                             % ('Shelly', self.device_nummer, ip, str(e1)))
+            log.warning("Leistungsmessung %s %d %s Fehlermeldung: %s "
+                        % ('Shelly', self.device_nummer, ip, str(e1)))
 
 
 class Slavm(Slbase):
@@ -244,8 +245,8 @@ class Slavm(Slbase):
             self.newwattk = int(answer['powerc'])
             self.relais = int(answer['on'])
         except Exception as e1:
-            self.log.warning("Leistungsmessung %s %d %s Fehlermeldung: %s "
-                             % ('Avm ', self.device_nummer, ip, str(e1)))
+            log.warning("Leistungsmessung %s %d %s Fehlermeldung: %s "
+                        % ('Avm ', self.device_nummer, ip, str(e1)))
 
 
 class Sltasmota(Slbase):
@@ -272,8 +273,8 @@ class Sltasmota(Slbase):
             self.newwattk = int(answer['powerc'])
             self.relais = int(answer['on'])
         except Exception as e1:
-            self.log.warning("Leistungsmessung %s %d %s Fehlermeldung: %s "
-                             % ('Tasmota', self.device_nummer, ip, str(e1)))
+            log.warning("Leistungsmessung %s %d %s Fehlermeldung: %s "
+                        % ('Tasmota', self.device_nummer, ip, str(e1)))
 
 
 class Slhttp(Slbase):
@@ -306,8 +307,8 @@ class Slhttp(Slbase):
             self.newwattk = int(answer['powerc'])
             self.relais = int(answer['on'])
         except Exception as e1:
-            self.log.warning("Leistungsmessung %s %d Fehlermeldung: %s "
-                             % ('http', self.device_nummer, str(e1)))
+            log.warning("Leistungsmessung %s %d Fehlermeldung: %s "
+                        % ('http', self.device_nummer, str(e1)))
 
 
 class Slmystrom(Slbase):
@@ -341,8 +342,8 @@ class Slmystrom(Slbase):
             else:
                 self.temp0 = '300'
         except Exception as e1:
-            self.log.warning("Leistungsmessung %s %d %s Fehlermeldung: %s "
-                             % ('Mystrom', self.device_nummer, ip, str(e1)))
+            log.warning("Leistungsmessung %s %d %s Fehlermeldung: %s "
+                        % ('Mystrom', self.device_nummer, ip, str(e1)))
 
 
 class Slsmaem(Slbase):
@@ -363,9 +364,9 @@ class Slsmaem(Slbase):
             self.newwatt = int(answer['power'])
             self.newwattk = int(answer['powerc'])
         except Exception as e1:
-            self.log.warning("Leistungsmessung %s %d %s Fehlermeldung: %s "
-                             % ('smaem ', self.device_nummer,
-                                str(self._device_measureip), str(e1)))
+            log.warning("Leistungsmessung %s %d %s Fehlermeldung: %s "
+                        % ('smaem ', self.device_nummer,
+                           str(self._device_measureip), str(e1)))
         return self.newwatt, self.newwattk
 
 
@@ -386,9 +387,9 @@ class Slwe514(Slbase):
             self.newwatt = int(answer['power'])
             self.newwattk = int(answer['powerc'])
         except Exception as e1:
-            self.log.warning("Leistungsmessung %s %d %s Fehlermeldung: %s "
-                             % ('we514 ', self.device_nummer,
-                                str(self._device_measureip), str(e1)))
+            log.warning("Leistungsmessung %s %d %s Fehlermeldung: %s "
+                        % ('we514 ', self.device_nummer,
+                           str(self._device_measureip), str(e1)))
         return self.newwatt, self.newwattk
 
 
@@ -411,8 +412,8 @@ class Sljson(Slbase):
             self.newwatt = int(answer['power'])
             self.newwattk = int(answer['powerc'])
         except Exception as e1:
-            self.log.warning("Leistungsmessung %s %s Fehlermeldung: %s "
-                             % ('json ', self.device_nummer, str(e1)))
+            log.warning("Leistungsmessung %s %s Fehlermeldung: %s "
+                        % ('json ', self.device_nummer, str(e1)))
         return self.newwatt, self.newwattk
 
 
@@ -433,9 +434,9 @@ class Slfronius(Slbase):
             self.newwatt = int(answer['power'])
             self.newwattk = int(answer['powerc'])
         except Exception as e1:
-            self.log.warning("Leistungsmessung %s %d %s Fehlermeldung: %s "
-                             % ('fronius ', self.device_nummer,
-                                str(self._device_measureip), str(e1)))
+            log.warning("Leistungsmessung %s %d %s Fehlermeldung: %s "
+                        % ('fronius ', self.device_nummer,
+                           str(self._device_measureip), str(e1)))
         return self.newwatt, self.newwattk
 
 
@@ -457,9 +458,9 @@ class Slsdm630(Slbase):
             self.newwatt = int(answer['power'])
             self.newwattk = int(answer['powerc'])
         except Exception as e1:
-            self.log.warning("Leistungsmessung %s %d %s Fehlermeldung: %s "
-                             % ('Sdm630 ', self.device_nummer,
-                                str(self._device_measureip), str(e1)))
+            log.warning("Leistungsmessung %s %d %s Fehlermeldung: %s "
+                        % ('Sdm630 ', self.device_nummer,
+                           str(self._device_measureip), str(e1)))
         return self.newwatt, self.newwattk
 
 
@@ -481,7 +482,7 @@ class Slsdm120(Slbase):
             self.newwatt = int(answer['power'])
             self.newwattk = int(answer['powerc'])
         except Exception as e1:
-            self.log.warning("Leistungsmessung %s %d %s Fehlermeldung: %s "
-                             % ('Sdm120 ', self.device_nummer,
-                                str(self._device_measureip), str(e1)))
+            log.warning("Leistungsmessung %s %d %s Fehlermeldung: %s "
+                        % ('Sdm120 ', self.device_nummer,
+                           str(self._device_measureip), str(e1)))
         return self.newwatt, self.newwattk

--- a/runs/usmarthome/smartmqtt.py
+++ b/runs/usmarthome/smartmqtt.py
@@ -27,11 +27,11 @@ class Smqtt(Sbase):
         if (self._old_measuretype0 == 'none'):
             self._mydevicemeasure0 = Slmqtt()
             self._old_measuretype0 = 'mqtt'
-            self.logClass(2, "(" + str(self.device_nummer) +
+            self.log.info("(" + str(self.device_nummer) +
                           ") Integrierte Leistungsmessung. Neues Measure" +
                           " device erzeugt " + self.device_type)
         else:
-            self.logClass(2, "(" + str(self.device_nummer) +
+            self.log.info("(" + str(self.device_nummer) +
                           ") Integrierte Leistungsmessung. Nur Parameter" +
                           " update " + self.device_type)
         self._mydevicemeasure0.updatepar(input_param)
@@ -49,7 +49,7 @@ class Smqtt(Sbase):
             self.proc = subprocess.Popen(argumentList)
             self.proc.communicate()
         except Exception as e1:
-            self.logClass(2, "(" + str(self.device_nummer) +
-                          ") on / off  %s %d %s Fehlermeldung: %s "
-                          % ('mqtt ', self.device_nummer,
-                             str(self._device_ip), str(e1)))
+            self.log.warning("(" + str(self.device_nummer) +
+                             ") on / off  %s %d %s Fehlermeldung: %s "
+                             % ('mqtt ', self.device_nummer,
+                                str(self._device_ip), str(e1)))

--- a/runs/usmarthome/smartmqtt.py
+++ b/runs/usmarthome/smartmqtt.py
@@ -1,5 +1,6 @@
 #!/usr/bin/python3
 from usmarthome.smartbase import Sbase, Slmqtt
+from usmarthome.global0 import log
 import subprocess
 
 
@@ -27,13 +28,13 @@ class Smqtt(Sbase):
         if (self._old_measuretype0 == 'none'):
             self._mydevicemeasure0 = Slmqtt()
             self._old_measuretype0 = 'mqtt'
-            self.log.info("(" + str(self.device_nummer) +
-                          ") Integrierte Leistungsmessung. Neues Measure" +
-                          " device erzeugt " + self.device_type)
+            log.info("(" + str(self.device_nummer) +
+                     ") Integrierte Leistungsmessung. Neues Measure" +
+                     " device erzeugt " + self.device_type)
         else:
-            self.log.info("(" + str(self.device_nummer) +
-                          ") Integrierte Leistungsmessung. Nur Parameter" +
-                          " update " + self.device_type)
+            log.info("(" + str(self.device_nummer) +
+                     ") Integrierte Leistungsmessung. Nur Parameter" +
+                     " update " + self.device_type)
         self._mydevicemeasure0.updatepar(input_param)
 
     def turndevicerelais(self, zustand, ueberschussberechnung, updatecnt):
@@ -49,7 +50,7 @@ class Smqtt(Sbase):
             self.proc = subprocess.Popen(argumentList)
             self.proc.communicate()
         except Exception as e1:
-            self.log.warning("(" + str(self.device_nummer) +
-                             ") on / off  %s %d %s Fehlermeldung: %s "
-                             % ('mqtt ', self.device_nummer,
-                                str(self._device_ip), str(e1)))
+            log.warning("(" + str(self.device_nummer) +
+                        ") on / off  %s %d %s Fehlermeldung: %s "
+                        % ('mqtt ', self.device_nummer,
+                           str(self._device_ip), str(e1)))

--- a/runs/usmarthome/smartmystrom.py
+++ b/runs/usmarthome/smartmystrom.py
@@ -1,5 +1,6 @@
 #!/usr/bin/python3
 import subprocess
+from usmarthome.global0 import log
 from usmarthome.smartbase import Sbase, Slmystrom
 
 
@@ -27,13 +28,13 @@ class Smystrom(Sbase):
         if (self._old_measuretype0 == 'none'):
             self._mydevicemeasure0 = Slmystrom()
             self._old_measuretype0 = 'mystrom'
-            self.log.info("(" + str(self.device_nummer) +
-                          ") Integrierte Leistungsmessung. Neues Measure" +
-                          " device erzeugt " + self.device_type)
+            log.info("(" + str(self.device_nummer) +
+                     ") Integrierte Leistungsmessung. Neues Measure" +
+                     " device erzeugt " + self.device_type)
         else:
-            self.log.info("(" + str(self.device_nummer) +
-                          ") Integrierte Leistungsmessung. Nur Parameter" +
-                          " update " + self.device_type)
+            log.info("(" + str(self.device_nummer) +
+                     ") Integrierte Leistungsmessung. Nur Parameter" +
+                     " update " + self.device_type)
         self._mydevicemeasure0.updatepar(input_param)
 
     def turndevicerelais(self, zustand, ueberschussberechnung, updatecnt):
@@ -49,7 +50,7 @@ class Smystrom(Sbase):
             self.proc = subprocess.Popen(argumentList)
             self.proc.communicate()
         except Exception as e1:
-            self.log.warning("(" + str(self.device_nummer) +
-                             ") on / off %s %d %s Fehlermeldung: %s "
-                             % ('mystrom', self.device_nummer,
-                                str(self._device_ip), str(e1)))
+            log.warning("(" + str(self.device_nummer) +
+                        ") on / off %s %d %s Fehlermeldung: %s "
+                        % ('mystrom', self.device_nummer,
+                           str(self._device_ip), str(e1)))

--- a/runs/usmarthome/smartmystrom.py
+++ b/runs/usmarthome/smartmystrom.py
@@ -27,11 +27,11 @@ class Smystrom(Sbase):
         if (self._old_measuretype0 == 'none'):
             self._mydevicemeasure0 = Slmystrom()
             self._old_measuretype0 = 'mystrom'
-            self.logClass(2, "(" + str(self.device_nummer) +
+            self.log.info("(" + str(self.device_nummer) +
                           ") Integrierte Leistungsmessung. Neues Measure" +
                           " device erzeugt " + self.device_type)
         else:
-            self.logClass(2, "(" + str(self.device_nummer) +
+            self.log.info("(" + str(self.device_nummer) +
                           ") Integrierte Leistungsmessung. Nur Parameter" +
                           " update " + self.device_type)
         self._mydevicemeasure0.updatepar(input_param)
@@ -49,7 +49,7 @@ class Smystrom(Sbase):
             self.proc = subprocess.Popen(argumentList)
             self.proc.communicate()
         except Exception as e1:
-            self.logClass(2, "(" + str(self.device_nummer) +
-                          ") on / off %s %d %s Fehlermeldung: %s "
-                          % ('mystrom', self.device_nummer,
-                             str(self._device_ip), str(e1)))
+            self.log.warning("(" + str(self.device_nummer) +
+                             ") on / off %s %d %s Fehlermeldung: %s "
+                             % ('mystrom', self.device_nummer,
+                                str(self._device_ip), str(e1)))

--- a/runs/usmarthome/smartshelly.py
+++ b/runs/usmarthome/smartshelly.py
@@ -1,5 +1,6 @@
 #!/usr/bin/python3
 from usmarthome.smartbase import Sbase, Slshelly
+from usmarthome.global0 import log
 import subprocess
 
 
@@ -27,13 +28,13 @@ class Sshelly(Sbase):
         if (self._old_measuretype0 == 'none'):
             self._mydevicemeasure0 = Slshelly()
             self._old_measuretype0 = 'shelly'
-            self.log.info("(" + str(self.device_nummer) +
-                          ") Integrierte Leistungsmessung. Neues Measure" +
-                          " device erzeugt " + self.device_type)
+            log.info("(" + str(self.device_nummer) +
+                     ") Integrierte Leistungsmessung. Neues Measure" +
+                     " device erzeugt " + self.device_type)
         else:
-            self.log.info("(" + str(self.device_nummer) +
-                          ") Integrierte Leistungsmessung. Nur Parameter " +
-                          " update " + self.device_type)
+            log.info("(" + str(self.device_nummer) +
+                     ") Integrierte Leistungsmessung. Nur Parameter " +
+                     " update " + self.device_type)
         self._mydevicemeasure0.updatepar(input_param)
 
     def turndevicerelais(self, zustand, ueberschussberechnung, updatecnt):
@@ -50,7 +51,7 @@ class Sshelly(Sbase):
             self.proc = subprocess.Popen(argumentList)
             self.proc.communicate()
         except Exception as e1:
-            self.log.warning("(" + str(self.device_nummer) +
-                             ") on / off %s %d %s Fehlermeldung: %s "
-                             % ('Shelly', self.device_nummer,
-                                str(self._device_ip), str(e1)))
+            log.warning("(" + str(self.device_nummer) +
+                        ") on / off %s %d %s Fehlermeldung: %s "
+                        % ('Shelly', self.device_nummer,
+                           str(self._device_ip), str(e1)))

--- a/runs/usmarthome/smartshelly.py
+++ b/runs/usmarthome/smartshelly.py
@@ -27,11 +27,11 @@ class Sshelly(Sbase):
         if (self._old_measuretype0 == 'none'):
             self._mydevicemeasure0 = Slshelly()
             self._old_measuretype0 = 'shelly'
-            self.logClass(2, "(" + str(self.device_nummer) +
+            self.log.info("(" + str(self.device_nummer) +
                           ") Integrierte Leistungsmessung. Neues Measure" +
                           " device erzeugt " + self.device_type)
         else:
-            self.logClass(2, "(" + str(self.device_nummer) +
+            self.log.info("(" + str(self.device_nummer) +
                           ") Integrierte Leistungsmessung. Nur Parameter " +
                           " update " + self.device_type)
         self._mydevicemeasure0.updatepar(input_param)
@@ -50,7 +50,7 @@ class Sshelly(Sbase):
             self.proc = subprocess.Popen(argumentList)
             self.proc.communicate()
         except Exception as e1:
-            self.logClass(2, "(" + str(self.device_nummer) +
-                          ") on / off %s %d %s Fehlermeldung: %s "
-                          % ('Shelly', self.device_nummer,
-                             str(self._device_ip), str(e1)))
+            self.log.warning("(" + str(self.device_nummer) +
+                             ") on / off %s %d %s Fehlermeldung: %s "
+                             % ('Shelly', self.device_nummer,
+                                str(self._device_ip), str(e1)))

--- a/runs/usmarthome/smartstiebel.py
+++ b/runs/usmarthome/smartstiebel.py
@@ -1,7 +1,6 @@
 #!/usr/bin/python3
 from usmarthome.smartbase import Sbase
 import subprocess
-import json
 
 
 class Sstiebel(Sbase):
@@ -23,10 +22,10 @@ class Sstiebel(Sbase):
             self.newwattk = int(self.answer['powerc'])
             self.relais = int(self.answer['on'])
         except Exception as e1:
-            self.logClass(2, "(" + str(self.device_nummer) +
-                          ") Leistungsmessung %s %d %s Fehlermeldung: %s "
-                          % ('Stiebel', self.device_nummer,
-                             str(self._device_ip), str(e1)))
+            self.log.warning("(" + str(self.device_nummer) +
+                             ") Leistungsmessung %s %d %s Fehlermeldung: %s "
+                             % ('Stiebel', self.device_nummer,
+                                str(self._device_ip), str(e1)))
         self.postwatt()
 
     def turndevicerelais(self, zustand, ueberschussberechnung, updatecnt):
@@ -42,7 +41,7 @@ class Sstiebel(Sbase):
             self.proc = subprocess.Popen(argumentList)
             self.proc.communicate()
         except Exception as e1:
-            self.logClass(2, "(" + str(self.device_nummer) +
-                          ") on / off  %s %d %s Fehlermeldung: %s "
-                          % ('Stiebel', self.device_nummer,
-                             str(self._device_ip), str(e1)))
+            self.log.warning("(" + str(self.device_nummer) +
+                             ") on / off  %s %d %s Fehlermeldung: %s "
+                             % ('Stiebel', self.device_nummer,
+                                str(self._device_ip), str(e1)))

--- a/runs/usmarthome/smartstiebel.py
+++ b/runs/usmarthome/smartstiebel.py
@@ -1,5 +1,6 @@
 #!/usr/bin/python3
 from usmarthome.smartbase import Sbase
+from usmarthome.global0 import log
 import subprocess
 
 
@@ -22,10 +23,10 @@ class Sstiebel(Sbase):
             self.newwattk = int(self.answer['powerc'])
             self.relais = int(self.answer['on'])
         except Exception as e1:
-            self.log.warning("(" + str(self.device_nummer) +
-                             ") Leistungsmessung %s %d %s Fehlermeldung: %s "
-                             % ('Stiebel', self.device_nummer,
-                                str(self._device_ip), str(e1)))
+            log.warning("(" + str(self.device_nummer) +
+                        ") Leistungsmessung %s %d %s Fehlermeldung: %s "
+                        % ('Stiebel', self.device_nummer,
+                           str(self._device_ip), str(e1)))
         self.postwatt()
 
     def turndevicerelais(self, zustand, ueberschussberechnung, updatecnt):
@@ -41,7 +42,7 @@ class Sstiebel(Sbase):
             self.proc = subprocess.Popen(argumentList)
             self.proc.communicate()
         except Exception as e1:
-            self.log.warning("(" + str(self.device_nummer) +
-                             ") on / off  %s %d %s Fehlermeldung: %s "
-                             % ('Stiebel', self.device_nummer,
-                                str(self._device_ip), str(e1)))
+            log.warning("(" + str(self.device_nummer) +
+                        ") on / off  %s %d %s Fehlermeldung: %s "
+                        % ('Stiebel', self.device_nummer,
+                           str(self._device_ip), str(e1)))

--- a/runs/usmarthome/smarttasmota.py
+++ b/runs/usmarthome/smarttasmota.py
@@ -1,5 +1,6 @@
 #!/usr/bin/python3
 from usmarthome.smartbase import Sbase, Sltasmota
+from usmarthome.global0 import log
 import subprocess
 
 
@@ -24,13 +25,13 @@ class Stasmota(Sbase):
         if (self._old_measuretype0 == 'none'):
             self._mydevicemeasure0 = Sltasmota()
             self._old_measuretype0 = 'tasmota'
-            self.log.info("(" + str(self.device_nummer) +
-                          ") Integrierte Leistungsmessung. Neues Measure" +
-                          " device erzeugt " + self.device_type)
+            log.info("(" + str(self.device_nummer) +
+                     ") Integrierte Leistungsmessung. Neues Measure" +
+                     " device erzeugt " + self.device_type)
         else:
-            self.log.info("(" + str(self.device_nummer) +
-                          ") Integrierte Leistungsmessung. Nur Parameter " +
-                          " update  " + self.device_type)
+            log.info("(" + str(self.device_nummer) +
+                     ") Integrierte Leistungsmessung. Nur Parameter " +
+                     " update  " + self.device_type)
         self._mydevicemeasure0.updatepar(input_param)
 
     def turndevicerelais(self, zustand, ueberschussberechnung, updatecnt):
@@ -46,7 +47,7 @@ class Stasmota(Sbase):
             self.proc = subprocess.Popen(argumentList)
             self.proc.communicate()
         except Exception as e1:
-            self.log.warning("(" + str(self.device_nummer) +
-                             ") on / off %s %d %s Fehlermeldung: %s "
-                             % ('tasmota', self.device_nummer,
-                                str(self._device_ip), str(e1)))
+            log.warning("(" + str(self.device_nummer) +
+                        ") on / off %s %d %s Fehlermeldung: %s "
+                        % ('tasmota', self.device_nummer,
+                           str(self._device_ip), str(e1)))

--- a/runs/usmarthome/smarttasmota.py
+++ b/runs/usmarthome/smarttasmota.py
@@ -24,11 +24,11 @@ class Stasmota(Sbase):
         if (self._old_measuretype0 == 'none'):
             self._mydevicemeasure0 = Sltasmota()
             self._old_measuretype0 = 'tasmota'
-            self.logClass(2, "(" + str(self.device_nummer) +
+            self.log.info("(" + str(self.device_nummer) +
                           ") Integrierte Leistungsmessung. Neues Measure" +
                           " device erzeugt " + self.device_type)
         else:
-            self.logClass(2, "(" + str(self.device_nummer) +
+            self.log.info("(" + str(self.device_nummer) +
                           ") Integrierte Leistungsmessung. Nur Parameter " +
                           " update  " + self.device_type)
         self._mydevicemeasure0.updatepar(input_param)
@@ -46,7 +46,7 @@ class Stasmota(Sbase):
             self.proc = subprocess.Popen(argumentList)
             self.proc.communicate()
         except Exception as e1:
-            self.logClass(2, "(" + str(self.device_nummer) +
-                          ") on / off %s %d %s Fehlermeldung: %s "
-                          % ('tasmota', self.device_nummer,
-                             str(self._device_ip), str(e1)))
+            self.log.warning("(" + str(self.device_nummer) +
+                             ") on / off %s %d %s Fehlermeldung: %s "
+                             % ('tasmota', self.device_nummer,
+                                str(self._device_ip), str(e1)))

--- a/runs/usmarthome/smartvampair.py
+++ b/runs/usmarthome/smartvampair.py
@@ -22,10 +22,10 @@ class Svampair(Sbase):
             self.newwattk = int(self.answer['powerc'])
             self.relais = int(self.answer['on'])
         except Exception as e1:
-            self.logClass(2, "(" + str(self.device_nummer) +
-                          ") Leistungsmessung %s %d %s Fehlermeldung: %s "
-                          % ('vampair', self.device_nummer,
-                             str(self._device_ip), str(e1)))
+            self.log.warning("(" + str(self.device_nummer) +
+                             ") Leistungsmessung %s %d %s Fehlermeldung: %s "
+                             % ('vampair', self.device_nummer,
+                                str(self._device_ip), str(e1)))
         self.postwatt()
 
     def turndevicerelais(self, zustand, ueberschussberechnung, updatecnt):
@@ -41,7 +41,7 @@ class Svampair(Sbase):
             self.proc = subprocess.Popen(argumentList)
             self.proc.communicate()
         except Exception as e1:
-            self.logClass(2, "(" + str(self.device_nummer) +
-                          ") on / off  %s %d %s Fehlermeldung: %s "
-                          % ('vampair', self.device_nummer,
-                             str(self._device_ip), str(e1)))
+            self.log.warning("(" + str(self.device_nummer) +
+                             ") on / off  %s %d %s Fehlermeldung: %s "
+                             % ('vampair', self.device_nummer,
+                                str(self._device_ip), str(e1)))

--- a/runs/usmarthome/smartvampair.py
+++ b/runs/usmarthome/smartvampair.py
@@ -1,5 +1,6 @@
 #!/usr/bin/python3
 from usmarthome.smartbase import Sbase
+from usmarthome.global0 import log
 import subprocess
 
 
@@ -22,10 +23,10 @@ class Svampair(Sbase):
             self.newwattk = int(self.answer['powerc'])
             self.relais = int(self.answer['on'])
         except Exception as e1:
-            self.log.warning("(" + str(self.device_nummer) +
-                             ") Leistungsmessung %s %d %s Fehlermeldung: %s "
-                             % ('vampair', self.device_nummer,
-                                str(self._device_ip), str(e1)))
+            log.warning("(" + str(self.device_nummer) +
+                        ") Leistungsmessung %s %d %s Fehlermeldung: %s "
+                        % ('vampair', self.device_nummer,
+                           str(self._device_ip), str(e1)))
         self.postwatt()
 
     def turndevicerelais(self, zustand, ueberschussberechnung, updatecnt):
@@ -41,7 +42,7 @@ class Svampair(Sbase):
             self.proc = subprocess.Popen(argumentList)
             self.proc.communicate()
         except Exception as e1:
-            self.log.warning("(" + str(self.device_nummer) +
-                             ") on / off  %s %d %s Fehlermeldung: %s "
-                             % ('vampair', self.device_nummer,
-                                str(self._device_ip), str(e1)))
+            log.warning("(" + str(self.device_nummer) +
+                        ") on / off  %s %d %s Fehlermeldung: %s "
+                        % ('vampair', self.device_nummer,
+                           str(self._device_ip), str(e1)))

--- a/runs/usmarthome/smartviessmann.py
+++ b/runs/usmarthome/smartviessmann.py
@@ -27,10 +27,10 @@ class Sviessmann(Sbase):
             self.newwattk = int(self.answer['powerc'])
             self.relais = int(self.answer['on'])
         except Exception as e1:
-            self.logClass(2, "(" + str(self.device_nummer) +
-                          ") Leistungsmessung %s %d %s Fehlermeldung: %s "
-                          % ('viessmann', self.device_nummer,
-                             str(self._device_ip), str(e1)))
+            self.log.warning("(" + str(self.device_nummer) +
+                             ") Leistungsmessung %s %d %s Fehlermeldung: %s "
+                             % ('viessmann', self.device_nummer,
+                                str(self._device_ip), str(e1)))
         self.postwatt()
 
     def turndevicerelais(self, zustand, ueberschussberechnung, updatecnt):
@@ -46,7 +46,7 @@ class Sviessmann(Sbase):
             self.proc = subprocess.Popen(argumentList)
             self.proc.communicate()
         except Exception as e1:
-            self.logClass(2, "(" + str(self.device_nummer) +
-                          ") on / off  %s %d %s Fehlermeldung: %s "
-                          % ('viessmann ', self.device_nummer,
-                             str(self._device_ip), str(e1)))
+            self.log.warning("(" + str(self.device_nummer) +
+                             ") on / off  %s %d %s Fehlermeldung: %s "
+                             % ('viessmann ', self.device_nummer,
+                                str(self._device_ip), str(e1)))

--- a/runs/usmarthome/smartviessmann.py
+++ b/runs/usmarthome/smartviessmann.py
@@ -1,5 +1,6 @@
 #!/usr/bin/python3
 from usmarthome.smartbase import Sbase
+from usmarthome.global0 import log
 import subprocess
 import json
 
@@ -27,10 +28,10 @@ class Sviessmann(Sbase):
             self.newwattk = int(self.answer['powerc'])
             self.relais = int(self.answer['on'])
         except Exception as e1:
-            self.log.warning("(" + str(self.device_nummer) +
-                             ") Leistungsmessung %s %d %s Fehlermeldung: %s "
-                             % ('viessmann', self.device_nummer,
-                                str(self._device_ip), str(e1)))
+            log.warning("(" + str(self.device_nummer) +
+                        ") Leistungsmessung %s %d %s Fehlermeldung: %s "
+                        % ('viessmann', self.device_nummer,
+                           str(self._device_ip), str(e1)))
         self.postwatt()
 
     def turndevicerelais(self, zustand, ueberschussberechnung, updatecnt):
@@ -46,7 +47,7 @@ class Sviessmann(Sbase):
             self.proc = subprocess.Popen(argumentList)
             self.proc.communicate()
         except Exception as e1:
-            self.log.warning("(" + str(self.device_nummer) +
-                             ") on / off  %s %d %s Fehlermeldung: %s "
-                             % ('viessmann ', self.device_nummer,
-                                str(self._device_ip), str(e1)))
+            log.warning("(" + str(self.device_nummer) +
+                        ") on / off  %s %d %s Fehlermeldung: %s "
+                        % ('viessmann ', self.device_nummer,
+                           str(self._device_ip), str(e1)))


### PR DESCRIPTION
Neu werden beim ReRead und dem Start alle gelesenen mqtt Parameter protokolliert und validiert. Dazu wird die Datei smartcon.log erstellt, welches nur die Config parameter enthält. Der Startup wurde leicht geändert, um dem null (alle config Parameter weg) Problem auf die Spur zu kommen. Aus jetziger Sicht läuft zu viel parallel auf dem mqtt Broker so dass nicht innert 5 Sekunden alle smarthome parameter gelesen werden können.