### PR TITLE
sunny boy smart energy

### DIFF
--- a/modules/speicher_sbs25/main.sh
+++ b/modules/speicher_sbs25/main.sh
@@ -14,7 +14,11 @@ else
 	MYLOGFILE="${RAMDISKDIR}/speicher.log"
 fi
 
-bash "$OPENWBBASEDIR/packages/legacy_run.sh" "modules.sma_sunny_boy.device" "bat" "${sbs25ip}">>"$MYLOGFILE" 2>&1
+if [[ "$sbs25se" == "1" ]]  ; then
+	bash "$OPENWBBASEDIR/packages/legacy_run.sh" "modules.sma_sunny_boy.device" "bat_smart_energy" "${sbs25ip}">>"$MYLOGFILE" 2>&1
+else
+	bash "$OPENWBBASEDIR/packages/legacy_run.sh" "modules.sma_sunny_boy.device" "bat" "${sbs25ip}">>"$MYLOGFILE" 2>&1
+fi
 ret=$?
 
 openwbDebugLog ${DMOD} 2 "RET: ${ret}"

--- a/packages/modules/sma_sunny_boy/bat_smart_energy.py
+++ b/packages/modules/sma_sunny_boy/bat_smart_energy.py
@@ -1,0 +1,48 @@
+#!/usr/bin/env python3
+from modules.common import simcount
+from modules.common.component_state import BatState
+from modules.common.fault_state import ComponentInfo
+from modules.common.modbus import ModbusClient, ModbusDataType
+from modules.common.store import get_bat_value_store
+
+
+def get_default_config() -> dict:
+    return {
+        "name": "SMA Sunny Boy Smart Energy Speicher",
+        "id": 0,
+        "type": "bat_smart_energy",
+        "configuration": {}
+    }
+
+
+class SunnyBoySmartEnergyBat:
+    def __init__(self, device_id: int, component_config: dict, tcp_client: ModbusClient) -> None:
+        self.__device_id = device_id
+        self.component_config = component_config
+        self.__tcp_client = tcp_client
+        self.__sim_count = simcount.SimCountFactory().get_sim_counter()()
+        self.simulation = {}
+        self.__store = get_bat_value_store(component_config["id"])
+        self.component_info = ComponentInfo.from_component_config(component_config)
+
+    def update(self) -> None:
+        unit = 3
+        with self.__tcp_client:
+            soc = self.__tcp_client.read_holding_registers(30845, ModbusDataType.UINT_32, unit=unit)
+            current = self.__tcp_client.read_holding_registers(30843, ModbusDataType.INT_32, unit=unit)/-1000
+            voltage = self.__tcp_client.read_holding_registers(30851, ModbusDataType.INT_32, unit=unit)/100
+
+        power = current*voltage
+        topic_str = "openWB/set/system/device/" + str(
+            self.__device_id)+"/component/"+str(self.component_config["id"])+"/"
+        imported, exported = self.__sim_count.sim_count(
+            power, topic=topic_str, data=self.simulation, prefix="speicher"
+        )
+
+        bat_state = BatState(
+            power=power,
+            soc=soc,
+            imported=imported,
+            exported=exported
+        )
+        self.__store.set(bat_state)

--- a/packages/modules/sma_sunny_boy/device.py
+++ b/packages/modules/sma_sunny_boy/device.py
@@ -10,7 +10,7 @@ from modules.common.component_context import SingleComponentUpdateContext
 from modules.common.component_state import InverterState
 from modules.common.store import get_inverter_value_store
 from modules.sma_webbox import inverter as webbox_inverter
-from modules.sma_sunny_boy import bat, counter, inverter
+from modules.sma_sunny_boy import bat, bat_smart_energy, counter, inverter
 from modules.sma_sunny_boy.inverter_version import SmaInverterVersion
 
 log = logging.getLogger(__name__)
@@ -29,6 +29,7 @@ def get_default_config() -> dict:
 
 sma_modbus_tcp_component_classes = Union[
     bat.SunnyBoyBat,
+    bat_smart_energy.SunnyBoySmartEnergyBat,
     counter.SmaSunnyBoyCounter,
     inverter.SmaModbusTcpInverter
 ]
@@ -37,6 +38,7 @@ sma_modbus_tcp_component_classes = Union[
 class Device(AbstractDevice):
     COMPONENT_TYPE_TO_CLASS = {
         "bat": bat.SunnyBoyBat,
+        "bat_smart_energy": bat_smart_energy.SunnyBoySmartEnergyBat,
         "counter": counter.SmaSunnyBoyCounter,
         "inverter": inverter.SmaModbusTcpInverter
     }
@@ -79,6 +81,7 @@ class Device(AbstractDevice):
 
 COMPONENT_TYPE_TO_MODULE = {
     "bat": bat,
+    "bat_smart_energy": bat_smart_energy,
     "counter": counter,
     "inverter": inverter
 }

--- a/web/settings/modulconfigbat.php
+++ b/web/settings/modulconfigbat.php
@@ -494,6 +494,22 @@
 									</div>
 								</div>
 							</div>
+							<div class="form-row mb-1">
+								<label class="col-md-4 col-form-label">Sunny Boy Smart Energy</label>
+								<div class="col">
+									<div class="btn-group btn-group-toggle btn-block" data-toggle="buttons">
+										<label class="btn btn-outline-info<?php if($sbs25seold == 0) echo " active" ?>">
+											<input type="radio" name="sbs25se" id="sbs25seNo" value="0"<?php if($sbs25seold == 0) echo " checked=\"checked\"" ?>>Nein
+										</label>
+										<label class="btn btn-outline-info<?php if($sbs25seold == 1) echo " active" ?>">
+											<input type="radio" name="sbs25se" id="sbs25seYes" value="1"<?php if($sbs25seold == 1) echo " checked=\"checked\"" ?>>Ja
+										</label>
+									</div>
+									<span class="form-text small">
+										Diese Option aktivieren, wenn ein Sunny Boy Smart Energy verbaut ist.
+									</span>
+								</div>
+							</div>
 						</div>
 
 						<div id="divspeichersunnyisland" class="hide">

--- a/web/settings/modulconfigpv.php
+++ b/web/settings/modulconfigpv.php
@@ -585,7 +585,7 @@
 										</label>
 									</div>
 									<span class="form-text small">
-										Diese Option aktivieren, wenn ein Tripower Smart Energy oder ein anderes Hybrid-System verbaut ist.
+										Diese Option aktivieren, wenn ein Tripower Smart Energy oder ein anderes Hybrid-System verbaut ist. Diese Option darf NICHT akitviert werden, wenn ein Sunny Boy Smart Energy verbaut ist. Dieses System liefert alle Werte korrekt. Im Speichermodul muss die Option Sunny Boy Smart Energy aktiviert werden.
 									</span>
 								</div>
 							</div>


### PR DESCRIPTION
Sunny Boy Smart Energy liefert keine Lade-/Entladeleistung. Diese muss aus Batteriestrom und -spannung berechnet werden.