### PR TITLE
rewrite isss daemon

### DIFF
--- a/packages/helpermodules/compatibility.py
+++ b/packages/helpermodules/compatibility.py
@@ -1,7 +1,9 @@
 from pathlib import Path
 
+RAMDSIK_PATH = Path(__file__).resolve().parents[2] / "ramdisk"
+
 
 def is_ramdisk_in_use() -> bool:
     """ prüft, ob die Daten in der Ramdisk liegen (v1.x), sonst wird mit dem Broker (2.x) gearbeitet.
     """
-    return (Path(__file__).resolve().parents[2] / "ramdisk" / "bootinprogress").is_file()
+    return (RAMDSIK_PATH / "bootinprogress").is_file()

--- a/packages/modules/common/abstract_chargepoint.py
+++ b/packages/modules/common/abstract_chargepoint.py
@@ -3,7 +3,7 @@ from abc import abstractmethod
 
 class AbstractChargepoint:
     @abstractmethod
-    def __init__(self, config: dict) -> None:
+    def __init__(self, id: int, connection_module: dict, power_module: dict) -> None:
         pass
 
     @abstractmethod

--- a/packages/modules/common/b32.py
+++ b/packages/modules/common/b32.py
@@ -1,0 +1,29 @@
+#!/usr/bin/env python3
+from typing import List, Tuple
+
+from modules.common import modbus
+from modules.common.modbus import ModbusDataType
+
+
+class B32:
+    def __init__(self, modbus_id: int, client: modbus.ModbusTcpClient_) -> None:
+        self.client = client
+        self.id = modbus_id
+
+    def get_imported(self) -> float:
+        return self.client.read_holding_registers(0x5000, ModbusDataType.UINT_64, unit=self.id) / 1000
+
+    def get_frequency(self) -> float:
+        return self.client.read_holding_registers(0x5B2C, ModbusDataType.INT_16, unit=self.id) / 100
+
+    def get_currents(self) -> List[float]:
+        return [val / 10 for val in self.client.read_holding_registers(
+            0x5B0C, [ModbusDataType.UINT_32]*3, unit=self.id)]
+
+    def get_power(self) -> Tuple[List[float], float]:
+        power = self.client.read_input_registers(0x0C, ModbusDataType.INT_32, unit=self.id) / 100
+        return [0]*3, power
+
+    def get_voltages(self) -> List[float]:
+        return [val / 10 for val in self.client.read_holding_registers(
+            0x5B00, [ModbusDataType.UINT_32]*3, unit=self.id)]

--- a/packages/modules/common/component_state.py
+++ b/packages/modules/common/component_state.py
@@ -1,4 +1,4 @@
-from typing import Dict, List, Optional
+from typing import List, Optional
 
 from helpermodules.auto_str import auto_str
 
@@ -105,6 +105,7 @@ class CarState:
         self.soc_timestamp = soc_timestamp
 
 
+@auto_str
 class ChargepointState:
     def __init__(self,
                  phases_in_use: int,
@@ -116,7 +117,7 @@ class ChargepointState:
                  power_factors: Optional[List[float]] = None,
                  charge_state: bool = False,
                  plug_state: bool = False,
-                 read_tag: Optional[Dict[str, str]] = None):
+                 rfid: Optional[str] = None):
         if voltages is None:
             voltages = [0.0]*3
         self.voltages = voltages
@@ -132,4 +133,4 @@ class ChargepointState:
         self.phases_in_use = phases_in_use
         self.charge_state = charge_state
         self.plug_state = plug_state
-        self.read_tag = read_tag
+        self.rfid = rfid

--- a/packages/modules/common/evse.py
+++ b/packages/modules/common/evse.py
@@ -1,0 +1,51 @@
+#!/usr/bin/env python3
+import logging
+from enum import IntEnum
+from typing import Optional, Tuple
+
+from modules.common import modbus
+from modules.common.fault_state import FaultState
+from modules.common.modbus import ModbusDataType
+
+log = logging.getLogger(__name__)
+
+
+class EvseState(IntEnum):
+    READY = (1, False, False)
+    EV_PRESENT = (2, True, False)
+    CHARGING = (3, True, True)
+    CHARGING_WITH_VENTILATION = (4, True, True)
+    FAILURE = (5, None, None)
+
+    def __new__(cls, num: int, plugged: Optional[bool], charge_enabled: Optional[bool]):
+        member = int.__new__(cls, num)
+        member._value_ = num
+        member.plugged = plugged
+        member.charge_enabled = charge_enabled
+        return member
+
+
+class Evse:
+    def __init__(self, modbus_id: int, client: modbus.ModbusSerialClient_) -> None:
+        self.client = client
+        self.id = modbus_id
+
+    def get_plug_charge_state(self) -> Tuple[bool, bool, float]:
+        set_current, _, state_number = self.client.read_holding_registers(
+            1000, [ModbusDataType.UINT_16]*3, unit=self.id)
+        log.debug("Gesetzte Stromstärke EVSE: "+str(set_current) +
+                  ", Status: "+str(state_number)+", Modbus-ID: "+str(self.id))
+        state = EvseState(state_number)
+        if state == EvseState.FAILURE:
+            raise FaultState.error("Unbekannter Zustand der EVSE: State " +
+                                   str(state)+", Sollstromstärke: "+str(set_current))
+        plugged = state.plugged
+        charging = set_current > 0 if state.charge_enabled else False
+        return plugged, charging, set_current
+
+    def get_firmware_version(self) -> None:
+        log.debug(
+            "FW-Version: "+str(self.client.read_holding_registers(1005, ModbusDataType.UINT_16, unit=self.id)))
+
+    def set_current(self, current: int) -> None:
+        self.client.delegate.write_registers(1000, current, unit=self.id)

--- a/packages/modules/common/lovato.py
+++ b/packages/modules/common/lovato.py
@@ -1,6 +1,5 @@
 #!/usr/bin/env python3
 
-from modules.common.fault_state import FaultState
 from modules.common import modbus
 from typing import List, Tuple
 from modules.common.modbus import ModbusDataType
@@ -11,49 +10,28 @@ class Lovato:
         self.client = client
         self.id = modbus_id
 
-    def __process_error(self, e):
-        if isinstance(e, FaultState):
-            raise
-        else:
-            raise FaultState.error(__name__+" "+str(type(e))+" "+str(e)) from e
-
     def get_voltages(self) -> List[float]:
-        try:
-            return [val / 100 for val in self.client.read_input_registers(
-                0x0001, [ModbusDataType.INT_32]*3, unit=self.id)]
-        except Exception as e:
-            self.__process_error(e)
+        return [val / 100 for val in self.client.read_input_registers(
+            0x0001, [ModbusDataType.INT_32]*3, unit=self.id)]
 
     def get_power(self) -> Tuple[List[float], float]:
-        try:
-            powers = [val / 100 for val in self.client.read_input_registers(
-                0x0013, [ModbusDataType.INT_32]*3, unit=self.id
-            )]
-            power = sum(powers)
-            return powers, power
-        except Exception as e:
-            self.__process_error(e)
+        powers = [val / 100 for val in self.client.read_input_registers(
+            0x0013, [ModbusDataType.INT_32]*3, unit=self.id
+        )]
+        power = sum(powers)
+        return powers, power
 
     def get_power_factors(self) -> List[float]:
-        try:
-            return [val / 10000 for val in self.client.read_input_registers(
-                0x0025, [ModbusDataType.INT_32]*3, unit=self.id)]
-        except Exception as e:
-            self.__process_error(e)
+        return [val / 10000 for val in self.client.read_input_registers(
+            0x0025, [ModbusDataType.INT_32]*3, unit=self.id)]
 
     def get_frequency(self) -> float:
-        try:
-            frequency = self.client.read_input_registers(0x0031, ModbusDataType.INT_32, unit=self.id) / 100
-            if frequency > 100:
-                # needed if external measurement clamps connected
-                frequency = frequency / 10
-            return frequency
-        except Exception as e:
-            self.__process_error(e)
+        frequency = self.client.read_input_registers(0x0031, ModbusDataType.INT_32, unit=self.id) / 100
+        if frequency > 100:
+            # needed if external measurement clamps connected
+            frequency = frequency / 10
+        return frequency
 
     def get_currents(self) -> List[float]:
-        try:
-            return [val / 10000 for val in self.client.read_input_registers(
-                0x0007, [ModbusDataType.INT_32]*3, unit=self.id)]
-        except Exception as e:
-            self.__process_error(e)
+        return [val / 10000 for val in self.client.read_input_registers(
+            0x0007, [ModbusDataType.INT_32]*3, unit=self.id)]

--- a/packages/modules/common/modbus.py
+++ b/packages/modules/common/modbus.py
@@ -43,7 +43,7 @@ Number = Union[int, float]
 
 
 class ModbusClient:
-    def __init__(self, delegate, address: str, port: int = 502):
+    def __init__(self, delegate: Union[ModbusSerialClient, ModbusTcpClient], address: str, port: int = 502):
         self.delegate = delegate
         self.address = address
         self.port = port

--- a/packages/modules/common/mpm3pm.py
+++ b/packages/modules/common/mpm3pm.py
@@ -1,8 +1,8 @@
 #!/usr/bin/env python3
-from modules.common.fault_state import FaultState
+from typing import List, Tuple
+
 from modules.common import modbus
 from modules.common.modbus import ModbusDataType
-from typing import List, Tuple
 
 
 class Mpm3pm:
@@ -10,59 +10,32 @@ class Mpm3pm:
         self.client = client
         self.id = modbus_id
 
-    def __process_error(self, e):
-        if isinstance(e, FaultState):
-            raise
-        else:
-            raise FaultState.error(__name__+" "+str(type(e))+" " + str(e)) from e
-
     def get_voltages(self) -> List[float]:
-        try:
-            return [val / 10 for val in self.client.read_input_registers(
-                0x08, [ModbusDataType.UINT_32]*3, unit=self.id)]
-        except Exception as e:
-            self.__process_error(e)
+        return [val / 10 for val in self.client.read_input_registers(
+            0x08, [ModbusDataType.UINT_32]*3, unit=self.id)]
 
     def get_imported(self) -> float:
-        try:
-            # Faktorisierung anders als in der Dokumentation angegeben
-            return self.client.read_input_registers(0x0002, ModbusDataType.UINT_32, unit=self.id) * 10
-        except Exception as e:
-            self.__process_error(e)
+        # Faktorisierung anders als in der Dokumentation angegeben
+        return self.client.read_input_registers(0x0002, ModbusDataType.UINT_32, unit=self.id) * 10
 
     def get_power(self) -> Tuple[List[float], float]:
-        try:
-            powers = [val / 100 for val in self.client.read_input_registers(
-                0x14, [ModbusDataType.INT_32]*3, unit=self.id)]
-            power = self.client.read_input_registers(0x26, ModbusDataType.INT_32, unit=self.id) / 100
-            return powers, power
-        except Exception as e:
-            self.__process_error(e)
+        powers = [val / 100 for val in self.client.read_input_registers(
+            0x14, [ModbusDataType.INT_32]*3, unit=self.id)]
+        power = self.client.read_input_registers(0x26, ModbusDataType.INT_32, unit=self.id) / 100
+        return powers, power
 
     def get_exported(self) -> float:
-        try:
-            # Faktorisierung anders als in der Dokumentation angegeben
-            return self.client.read_input_registers(0x0004, ModbusDataType.UINT_32, unit=self.id) * 10
-        except Exception as e:
-            self.__process_error(e)
+        # Faktorisierung anders als in der Dokumentation angegeben
+        return self.client.read_input_registers(0x0004, ModbusDataType.UINT_32, unit=self.id) * 10
 
     def get_power_factors(self) -> List[float]:
-        try:
-            # Faktorisierung anders als in der Dokumentation angegeben
-            return [val / 10 for val in self.client.read_input_registers(
-                0x20, [ModbusDataType.UINT_32]*3, unit=self.id)]
-        except Exception as e:
-            self.__process_error(e)
+        # Faktorisierung anders als in der Dokumentation angegeben
+        return [val / 10 for val in self.client.read_input_registers(
+            0x20, [ModbusDataType.UINT_32]*3, unit=self.id)]
 
     def get_frequency(self) -> float:
-        try:
-            return self.client.read_input_registers(0x2c, ModbusDataType.UINT_32, unit=self.id) / 100
-        except Exception as e:
-            self.__process_error(e)
+        return self.client.read_input_registers(0x2c, ModbusDataType.UINT_32, unit=self.id) / 100
 
     def get_currents(self) -> List[float]:
-        try:
-            return [val / 100 for val in self.client.read_input_registers(
-                0x0E, [ModbusDataType.UINT_32]*3, unit=self.id)]
-        except Exception as e:
-            self.__process_error(e)
+        return [val / 100 for val in self.client.read_input_registers(
+            0x0E, [ModbusDataType.UINT_32]*3, unit=self.id)]

--- a/packages/modules/common/sdm.py
+++ b/packages/modules/common/sdm.py
@@ -1,8 +1,8 @@
 #!/usr/bin/env python3
-from modules.common import modbus
-from modules.common.fault_state import FaultState
-from modules.common.modbus import ModbusDataType
 from typing import List, Tuple
+
+from modules.common import modbus
+from modules.common.modbus import ModbusDataType
 
 
 class Sdm:
@@ -10,32 +10,17 @@ class Sdm:
         self.client = client
         self.id = modbus_id
 
-    def process_error(self, e):
-        if isinstance(e, FaultState):
-            raise
-        else:
-            raise FaultState.error(__name__+" "+str(type(e))+" "+str(e)) from e
-
     def get_imported(self) -> float:
-        try:
-            return self.client.read_input_registers(0x0048, ModbusDataType.FLOAT_32, unit=self.id) * 1000
-        except Exception as e:
-            self.process_error(e)
+        return self.client.read_input_registers(0x0048, ModbusDataType.FLOAT_32, unit=self.id) * 1000
 
     def get_exported(self) -> float:
-        try:
-            return self.client.read_input_registers(0x004a, ModbusDataType.FLOAT_32, unit=self.id) * 1000
-        except Exception as e:
-            self.process_error(e)
+        return self.client.read_input_registers(0x004a, ModbusDataType.FLOAT_32, unit=self.id) * 1000
 
     def get_frequency(self) -> float:
-        try:
-            frequency = self.client.read_input_registers(0x46, ModbusDataType.FLOAT_32, unit=self.id)
-            if frequency > 100:
-                frequency = frequency / 10
-            return frequency
-        except Exception as e:
-            self.process_error(e)
+        frequency = self.client.read_input_registers(0x46, ModbusDataType.FLOAT_32, unit=self.id)
+        if frequency > 100:
+            frequency = frequency / 10
+        return frequency
 
 
 class Sdm630(Sdm):
@@ -43,30 +28,18 @@ class Sdm630(Sdm):
         super().__init__(modbus_id, client)
 
     def get_currents(self) -> List[float]:
-        try:
-            return self.client.read_input_registers(0x06, [ModbusDataType.FLOAT_32]*3, unit=self.id)
-        except Exception as e:
-            self.process_error(e)
+        return self.client.read_input_registers(0x06, [ModbusDataType.FLOAT_32]*3, unit=self.id)
 
     def get_power_factors(self) -> List[float]:
-        try:
-            return self.client.read_input_registers(0x1E, [ModbusDataType.FLOAT_32]*3, unit=self.id)
-        except Exception as e:
-            self.process_error(e)
+        return self.client.read_input_registers(0x1E, [ModbusDataType.FLOAT_32]*3, unit=self.id)
 
     def get_power(self) -> Tuple[List[float], float]:
-        try:
-            powers = self.client.read_input_registers(0x0C, [ModbusDataType.FLOAT_32]*3, unit=self.id)
-            power = sum(powers)
-            return powers, power
-        except Exception as e:
-            self.process_error(e)
+        powers = self.client.read_input_registers(0x0C, [ModbusDataType.FLOAT_32]*3, unit=self.id)
+        power = sum(powers)
+        return powers, power
 
     def get_voltages(self) -> List[float]:
-        try:
-            return self.client.read_input_registers(0x00, [ModbusDataType.FLOAT_32]*3, unit=self.id)
-        except Exception as e:
-            self.process_error(e)
+        return self.client.read_input_registers(0x00, [ModbusDataType.FLOAT_32]*3, unit=self.id)
 
 
 class Sdm120(Sdm):
@@ -74,8 +47,5 @@ class Sdm120(Sdm):
         super().__init__(modbus_id, client)
 
     def get_power(self) -> Tuple[List[float], float]:
-        try:
-            power = self.client.read_input_registers(0x0C, ModbusDataType.FLOAT_32, unit=self.id)
-            return [power, 0, 0], power
-        except Exception as e:
-            self.process_error(e)
+        power = self.client.read_input_registers(0x0C, ModbusDataType.FLOAT_32, unit=self.id)
+        return [power, 0, 0], power

--- a/packages/modules/common/store/_chargepoint.py
+++ b/packages/modules/common/store/_chargepoint.py
@@ -1,6 +1,23 @@
 from modules.common.component_state import ChargepointState
 from modules.common.store import ValueStore
+from modules.common.store._api import LoggingValueStore
 from modules.common.store._broker import pub_to_broker
+from modules.common.store.ramdisk import files
+from helpermodules import compatibility
+
+
+class ChargepointValueStoreRamdisk(ValueStore[ChargepointState]):
+    def __init__(self, cp_id: int):
+        self.num = cp_id
+
+    def set(self, cp_state: ChargepointState):
+        charge_point = files.charge_points[self.num]
+        charge_point.is_charging.write(cp_state.charge_state)
+        charge_point.voltages.write(cp_state.voltages)
+        charge_point.currents.write(cp_state.currents)
+        charge_point.energy.write(cp_state.imported)
+        charge_point.is_plugged.write(cp_state.plug_state)
+        charge_point.power.write(cp_state.power)
 
 
 class ChargepointValueStoreBroker(ValueStore[ChargepointState]):
@@ -21,4 +38,6 @@ class ChargepointValueStoreBroker(ValueStore[ChargepointState]):
 
 
 def get_chargepoint_value_store(id: int) -> ValueStore[ChargepointState]:
-    return ChargepointValueStoreBroker(id)
+    return LoggingValueStore(
+        ChargepointValueStoreRamdisk(id) if compatibility.is_ramdisk_in_use() else ChargepointValueStoreBroker(id)
+    )

--- a/packages/modules/internal_openwb/chargepoint_module.py
+++ b/packages/modules/internal_openwb/chargepoint_module.py
@@ -1,0 +1,187 @@
+import logging
+import RPi.GPIO as GPIO
+import time
+from typing import Dict, List, NamedTuple, Optional, Tuple, Union
+
+from modules.common.abstract_chargepoint import AbstractChargepoint
+from modules.common.component_context import SingleComponentUpdateContext
+from modules.common.component_state import ChargepointState
+from modules.common.fault_state import ComponentInfo, FaultState
+from modules.common.modbus import ModbusSerialClient_
+from modules.common.store import ramdisk_read, ramdisk_write
+from modules.common import sdm
+from modules.common import evse
+from modules.common import b32
+from modules.common.store import get_chargepoint_value_store
+
+log = logging.getLogger(__name__)
+
+
+def get_default_config() -> Dict:
+    return {"id": 0,
+            "serial_client": None,  # type: Optional[ModbusSerialClient_]
+            "connection_module": {
+                "client": None  # type: Optional[CONNECTION_MODULES]
+            },
+            "power_module": {
+                "client": None  # type: Optional[evse.Evse]
+            }}
+
+
+CONNECTION_MODULES = Union[sdm.Sdm630, b32.B32]
+
+
+class InternalOpenWB:
+    def __init__(self, id: int, serial_client: ModbusSerialClient_) -> None:
+        self.id = id
+        self.serial_client = serial_client
+
+
+class ClientFactory:
+    def __init__(self, local_charge_point_num: int, serial_client: ModbusSerialClient_) -> None:
+        self.local_charge_point_num = local_charge_point_num
+        self.meter_client, self.evse_client = self.__factory(serial_client)
+        self.read_error = 0
+
+    def __factory(self, serial_client: ModbusSerialClient_) -> Tuple[CONNECTION_MODULES, evse.Evse]:
+        meter_config = NamedTuple("MeterConfig", [('type', CONNECTION_MODULES), ('modbus_id', int)])
+        meter_configuration_options = [
+            [meter_config(sdm.Sdm630, modbus_id=105), meter_config(b32.B32, modbus_id=201)],
+            [meter_config(sdm.Sdm630, modbus_id=106)]
+        ]
+
+        def _check_meter(serial_client: ModbusSerialClient_, meters: List[meter_config]):
+            for meter_type, modbus_id in meters:
+                try:
+                    meter_client = meter_type(modbus_id, serial_client)
+                    if meter_client.get_voltages()[0] > 20:
+                        return meter_client
+                except Exception:
+                    pass
+            else:
+                raise Exception("Es konnte keines der Meter in "+str(meters)+" zugeordnet werden.")
+
+        meter_client = _check_meter(serial_client, meter_configuration_options[self.local_charge_point_num - 1])
+        evse_client = evse.Evse(self.local_charge_point_num, serial_client)
+        return meter_client, evse_client
+
+    def get_pins_phase_switch(self, new_phases: int) -> Tuple[int, int]:
+        # return gpio_cp, gpio_relay
+        if self.local_charge_point_num == 1:
+            return 22, 29 if new_phases == 1 else 37
+        else:
+            return 15, 11 if new_phases == 1 else 13
+
+    def get_pins_cp_interruption(self) -> int:
+        # return gpio_cp, gpio_relay
+        if self.local_charge_point_num == 1:
+            return 22
+        else:
+            return 15
+
+
+class ChargepointModule(AbstractChargepoint):
+    PLUG_STANDBY_POWER_THRESHOLD = 10
+
+    def __init__(self, config: InternalOpenWB) -> None:
+        self.config = config
+        self.component_info = ComponentInfo(
+            self.config.id,
+            "Ladepunkt "+str(self.config.id), "chargepoint")
+        self.__store = get_chargepoint_value_store(self.config.id)
+        self.__client = ClientFactory(self.config.id, self.config.serial_client)
+        self.old_plug_state = False
+
+    def set_current(self, current: float) -> None:
+        with SingleComponentUpdateContext(self.component_info):
+            if self.set_current_evse != current:
+                self.__client.evse_client.set_current(int(current))
+
+    def get_values(self, phase_switch_cp_active: bool) -> Tuple[ChargepointState, float]:
+        try:
+            _, power = self.__client.meter_client.get_power()
+            if power < self.PLUG_STANDBY_POWER_THRESHOLD:
+                power = 0
+            voltages = self.__client.meter_client.get_voltages()
+            currents = self.__client.meter_client.get_currents()
+            imported = self.__client.meter_client.get_imported()
+            phases_in_use = sum(1 for current in currents if current > 3)
+
+            time.sleep(0.1)
+            plug_state, charge_state, self.set_current_evse = self.__client.evse_client.get_plug_charge_state()
+            self.__client.read_error = 0
+
+            rfid = ramdisk_read("readtag")
+            # reset tag
+            if rfid != "0" and plug_state is False:
+                ramdisk_write("readtag", "0")
+
+            if phase_switch_cp_active:
+                # Während des Threads wird die CP-Leitung unterbrochen, das EV soll aber als angesteckt betrachtet
+                # werden. In 1.9 war das kein Problem, da währendessen keine Werte von der EVSE abgefragt wurden.
+                log.debug(
+                    "Plug_state %s beibehalten, da CP-Unterbrechung oder Phasenumschaltung aktiv.", self.old_plug_state
+                )
+                plug_state = self.old_plug_state
+            else:
+                self.old_plug_state = plug_state
+
+            if (max(currents) > 0.1 and charge_state is False) or (max(currents) == 0 and charge_state):
+                raise ValueError("Ladestatus {} passt nicht zu den Strömen {}.".format(charge_state, currents))
+
+            chargepoint_state = ChargepointState(
+                power=power,
+                currents=currents,
+                imported=imported,
+                exported=0,
+                # powers=powers,
+                voltages=voltages,
+                # frequency=frequency,
+                plug_state=plug_state,
+                charge_state=charge_state,
+                phases_in_use=phases_in_use,
+                rfid=rfid
+            )
+        except Exception as e:
+            self.__client.read_error += 1
+            if self.__client.read_error > 5:
+                log.exception(
+                    "Anhaltender Fehler beim Auslesen der EVSE. Lade- und Steckerstatus werden zurückgesetzt.")
+                plug_state = False
+                charge_state = False
+                chargepoint_state = ChargepointState(
+                    plug_state=plug_state,
+                    charge_state=charge_state,
+                    phases_in_use=0
+                )
+                FaultState.error(__name__ + " " + str(type(e)) + " " + str(e)).store_error(self.component_info)
+            else:
+                raise FaultState.error(__name__ + " " + str(type(e)) + " " + str(e)) from e
+
+        self.__store.set(chargepoint_state)
+        return chargepoint_state, self.set_current_evse
+
+    def perform_phase_switch(self, phases_to_use: int, duration: int) -> None:
+        gpio_cp, gpio_relay = self.__client.get_pins_phase_switch(phases_to_use)
+        with SingleComponentUpdateContext(self.component_info):
+            self.__client.evse_client.set_current(0)
+        time.sleep(1)
+        GPIO.output(gpio_cp, GPIO.HIGH)  # CP off
+        GPIO.output(gpio_relay, GPIO.HIGH)  # 3 on/off
+        time.sleep(duration)
+        GPIO.output(gpio_relay, GPIO.LOW)  # 3 on/off
+        time.sleep(duration)
+        GPIO.output(gpio_cp, GPIO.LOW)  # CP on
+        time.sleep(1)
+
+    def perform_cp_interruption(self, duration: int) -> None:
+        gpio_cp = self.__client.get_pins_cp_interruption()
+        with SingleComponentUpdateContext(self.component_info):
+            self.__client.evse_client.set_current(0)
+        GPIO.setwarnings(False)
+        GPIO.setmode(GPIO.BOARD)
+        GPIO.setup(gpio_cp, GPIO.OUT)
+
+        GPIO.output(gpio_cp, GPIO.HIGH)
+        time.sleep(duration)
+        GPIO.output(gpio_cp, GPIO.LOW)

--- a/packages/modules/internal_openwb/socket.py
+++ b/packages/modules/internal_openwb/socket.py
@@ -1,0 +1,99 @@
+from enum import IntEnum
+import functools
+import logging
+import RPi.GPIO as GPIO
+import time
+from typing import Callable, Dict, Tuple
+
+from modules.common.component_context import SingleComponentUpdateContext
+from modules.common.component_state import ChargepointState
+from modules.internal_openwb.chargepoint_module import ChargepointModule, InternalOpenWB
+
+log = logging.getLogger(__name__)
+
+
+def get_default_config() -> Dict:
+    return {"id": 0,
+            "connection_module": {
+                "type": "internal_openwb",
+                "configuration": {}
+            },
+            "power_module": {}}
+
+
+class RateLimiter:
+    def __init__(self, max_calls: int, max_seconds: int):
+        self.movement_times = [0.0]*max_calls
+        self.max_seconds = max_seconds
+        self.counter = 0
+
+    def __call__(self, delegate: Callable):
+        @functools.wraps(delegate)
+        def wrapper(*args, **kwargs):
+            now = time.time()
+            sleep_needed = self.max_seconds - (now - self.movement_times[self.counter])
+            if sleep_needed > 0:
+                log.debug("Actor cooldown. Don't move actor.")
+                return None
+            else:
+                self.movement_times[self.counter] = time.time()
+                self.counter = (self.counter + 1) % len(self.movement_times)
+                return delegate(*args, **kwargs)
+        return wrapper
+
+
+class ActorState(IntEnum):
+    CLOSED = 0,
+    OPENED = 1
+
+
+class Socket(ChargepointModule):
+    def __init__(self, max_current: int, config: InternalOpenWB) -> None:
+        self.max_current = max_current
+        super().__init__(config)
+
+    def set_current(self, current: float) -> None:
+        with SingleComponentUpdateContext(self.component_info):
+            try:
+                actor = ActorState(GPIO.input(19))
+            except Exception:
+                log.error("Error getting actor status! Using default 'opened'.")
+                actor = ActorState.OPENED
+
+            if actor == ActorState.CLOSED:
+                if current == self.set_current_evse or self.chargepoint_state.plug_state is False:
+                    return
+            else:
+                current = 0
+            super().set_current(min(current, self.max_current))
+
+    def get_values(self, phase_switch_cp_active: bool) -> Tuple[ChargepointState, float]:
+        try:
+            actor = ActorState(GPIO.input(19))
+        except Exception:
+            log.error("Error getting actor status! Using default 'opened'.")
+            actor = ActorState.OPENED
+        log.debug("Actor: "+str(actor))
+        self.chargepoint_state, self.set_current_evse = super().get_values(phase_switch_cp_active)
+        if phase_switch_cp_active:
+            log.debug("Keine Actor-Bewegung, da CP-Unterbrechung oder Phasenumschaltung aktiv.")
+        else:
+            if self.chargepoint_state.plug_state is True and actor == ActorState.OPENED:
+                self.__close_actor()
+            if self.chargepoint_state.plug_state is False and actor == ActorState.CLOSED:
+                self.__open_actor()
+        return self.chargepoint_state, self.set_current_evse
+
+    def __open_actor(self):
+        self.__set_actor(open=True)
+
+    def __close_actor(self):
+        self.__set_actor(open=False)
+
+    @RateLimiter(max_calls=10, max_seconds=300)
+    def __set_actor(self, open: bool):
+        GPIO.output(23, GPIO.LOW if open else GPIO.HIGH)
+        GPIO.output(26, GPIO.HIGH)
+        time.sleep(2 if open else 3)
+        GPIO.output(26, GPIO.LOW)
+        log.debug("Actor opened" if open else "Actor closed")

--- a/runs/initRamdisk.sh
+++ b/runs/initRamdisk.sh
@@ -186,6 +186,7 @@ initRamdisk(){
 	echo 0 > $RamdiskPath/tmpsoc1
 	echo 0 > $RamdiskPath/zielladenkorrektura
 	echo 0 > $RamdiskPath/ladungdurchziel
+	echo 0 > $RamdiskPath/extcpulp1
 	echo 20000 > $RamdiskPath/soctimer
 	echo 20000 > $RamdiskPath/soctimer1
 	echo 28 > $RamdiskPath/evsemodbustimer

--- a/runs/isss.py
+++ b/runs/isss.py
@@ -1,958 +1,282 @@
 #!/usr/bin/python
-import json
-import re
+import logging
 import os
+import re
+import threading
 import time
-import struct
-import traceback
-from typing import Tuple
+from typing import Dict, List, Optional
 import RPi.GPIO as GPIO
-from pymodbus.client.sync import ModbusSerialClient
-import paho.mqtt.client as mqtt
+
+from helpermodules.pub import pub_single
+from helpermodules import compatibility
+from modules.common.store import ramdisk_read, ramdisk_write
+from modules.common.store._util import get_rounding_function_by_digits
+from modules.common.fault_state import FaultState
+from modules.common.component_state import ChargepointState
+from modules.common.modbus import ModbusSerialClient_
+from modules.internal_openwb import chargepoint_module, socket
+from modules.internal_openwb.chargepoint_module import InternalOpenWB
 
 basePath = "/var/www/html/openWB"
 ramdiskPath = basePath + "/ramdisk"
 logFilename = ramdiskPath + "/isss.log"
-
-DeviceValues = {}
-Values = {}
+MAP_LOG_LEVEL = [logging.ERROR, logging.WARNING, logging.DEBUG]
 
 
-# handling of all logging statements
-def log_debug(level: int, msg: str, traceback_str: str = None) -> None:
-    if level >= loglevel:
-        with open(logFilename, 'a') as log_file:
-            log_file.write(time.ctime() + ': ' + msg + '\n')
-            if traceback_str is not None:
-                log_file.write(traceback_str + '\n')
+logging.basicConfig(filename=ramdiskPath+'/isss.log',
+                    format='%(asctime)s - {%(name)s:%(lineno)s} - %(levelname)s - %(message)s',
+                    level=MAP_LOG_LEVEL[int(os.environ.get('debug'))])
+log = logging.getLogger()
+log.error("Loglevel: "+str(int(os.environ.get('debug'))))
+
+pymodbus_logger = logging.getLogger("pymodbus")
+pymodbus_logger.setLevel(logging.WARNING)
 
 
-# write value to file in ramdisk
-def write_to_ramdisk(filename: str, content: str) -> None:
-    with open(ramdiskPath + "/" + filename, "w") as file:
-        file.write(content)
+class UpdateValues:
+    MAP_KEY_TO_OLD_TOPIC = {
+        "imported": "kWhCounter",
+        "exported": None,
+        "power": "W",
+        "voltages": ["VPhase1", "VPhase2", "VPhase3"],
+        "currents": ["APhase1", "APhase2", "APhase3"],
+        "power_factors": None,
+        "phases_in_use": "countPhasesInUse",
+        "charge_state": "boolChargeStat",
+        "plug_state": "boolPlugStat",
+        "rfid": "LastScannedRfidTag",
+    }
 
+    def __init__(self, local_charge_point_num: int) -> None:
+        self.cp_num = str(Isss.get_cp_num(local_charge_point_num))
+        self.old_counter_state = None
 
-# read value from file in ramdisk
-def read_from_ramdisk(filename: str) -> str:
-    try:
-        with open(ramdiskPath + "/" + filename, 'r') as file:
-            return file.read()
-    except FileNotFoundError:
-        log_debug(2, "Error reading file '" + filename + "' from ramdisk!", traceback.format_exc())
-        return ""
-
-
-def init_gpio() -> None:
-    GPIO.setwarnings(False)
-    GPIO.setmode(GPIO.BOARD)
-    GPIO.setup(37, GPIO.OUT)
-    GPIO.setup(13, GPIO.OUT)
-    GPIO.setup(22, GPIO.OUT)
-    GPIO.setup(29, GPIO.OUT)
-    GPIO.setup(11, GPIO.OUT)
-    GPIO.setup(15, GPIO.OUT)
-    # GPIOs for socket
-    GPIO.setup(23, GPIO.OUT)
-    GPIO.setup(26, GPIO.OUT)
-    GPIO.setup(19, GPIO.IN, pull_up_down=GPIO.PUD_UP)
-
-
-def init_values() -> None:
-    global DeviceValues
-    global Values
-    # global values
-    DeviceValues.update({'rfidtag': str(5)})
-    DeviceValues.update({'rfidtag2': str(5)})
-    # values LP1
-    DeviceValues.update({'lp1voltage1': str(5)})
-    DeviceValues.update({'lp1voltage2': str(5)})
-    DeviceValues.update({'lp1voltage3': str(5)})
-    DeviceValues.update({'lp1lla1': str(5)})
-    DeviceValues.update({'lp1lla2': str(5)})
-    DeviceValues.update({'lp1lla3': str(5)})
-    DeviceValues.update({'lp1llkwh': str(5)})
-    DeviceValues.update({'lp1watt': str(5)})
-    DeviceValues.update({'lp1countphasesinuse': str(5)})
-    DeviceValues.update({'lp1chargestat': str(5)})
-    DeviceValues.update({'lp1plugstat': str(5)})
-    DeviceValues.update({'lp1readerror': str(0)})
-    Values.update({'lp1plugstat': str(5)})
-    Values.update({'lp1chargestat': str(5)})
-    Values.update({'lp1evsell': str(1)})
-    # values LP2
-    DeviceValues.update({'lp2voltage1': str(5)})
-    DeviceValues.update({'lp2voltage2': str(5)})
-    DeviceValues.update({'lp2voltage3': str(5)})
-    DeviceValues.update({'lp2lla1': str(5)})
-    DeviceValues.update({'lp2lla2': str(5)})
-    DeviceValues.update({'lp2lla3': str(5)})
-    DeviceValues.update({'lp2llkwh': str(5)})
-    DeviceValues.update({'lp2watt': str(5)})
-    DeviceValues.update({'lp2countphasesinuse': str(5)})
-    DeviceValues.update({'lp2chargestat': str(5)})
-    DeviceValues.update({'lp2plugstat': str(5)})
-    DeviceValues.update({'lp2readerror': str(0)})
-    Values.update({'lp2plugstat': str(5)})
-    Values.update({'lp2chargestat': str(5)})
-    Values.update({'lp2evsell': str(1)})
-
-
-# read all meter values and publish to mqtt broker
-def read_meter():
-    global metercounter
-    global evsefailure
-    global client
-    global lp2installed
-    global llmeterconfiglp1
-    global sdmid
-    global sdm2id
-    global lp1countphasesinuse
-    global lp2countphasesinuse
-    global lp1evsehres
-    global lp2evsehres
-    global rfidtag
-    global rfidtag2
-
-    if metercounter > 0:
-        metercounter = metercounter - 0.5
-    if llmeterconfiglp1 == 0:
-        log_debug(2, "Erkenne verbauten Zaehler.")
-        # check sdm
-        try:
-            resp = client.read_input_registers(0x00, 2, unit=105)
-            voltage = struct.unpack('>f', struct.pack('>HH', *resp.registers))[0]
-            if int(voltage) > 20:
-                llmeterconfiglp1 = 105
-                sdmid = 105
-                log_debug(2, "SDM Zaehler erkannt")
-        except Exception:
-            pass
-        # check b23
-        try:
-            resp = client.read_holding_registers(0x5B00, 2, unit=201)
-            voltage = resp.registers[1]
-            if int(voltage) > 20:
-                llmeterconfiglp1 = 201
-                sdmid = 201
-                log_debug(2, "B23 Zaehler erkannt")
-        except Exception:
-            pass
-
-    else:
-        sdmid = llmeterconfiglp1
-    try:
-        if sdmid < 200:
-            time.sleep(0.1)
-            resp = client.read_input_registers(0x0C, 2, unit=sdmid)
-            lp1llw1 = struct.unpack('>f', struct.pack('>HH', *resp.registers))[0]
-            lp1llw1 = int(lp1llw1)
-            resp = client.read_input_registers(0x0E, 2, unit=sdmid)
-            lp1llw2 = struct.unpack('>f', struct.pack('>HH', *resp.registers))[0]
-            lp1llw2 = int(lp1llw2)
-            resp = client.read_input_registers(0x10, 2, unit=sdmid)
-            lp1llw3 = struct.unpack('>f', struct.pack('>HH', *resp.registers))[0]
-            lp1llw3 = int(lp1llw3)
-            lp1llg = lp1llw1 + lp1llw2 + lp1llw3
-            if lp1llg < 10:
-                lp1llg = 0
-            write_to_ramdisk("llaktuell", str(lp1llg))
-            resp = client.read_input_registers(0x00, 2, unit=sdmid)
-            voltage = struct.unpack('>f', struct.pack('>HH', *resp.registers))[0]
-            lp1voltage1 = float("%.1f" % voltage)
-            write_to_ramdisk("llv1", str(lp1voltage1))
-            resp = client.read_input_registers(0x02, 2, unit=sdmid)
-            voltage = struct.unpack('>f', struct.pack('>HH', *resp.registers))[0]
-            lp1voltage2 = float("%.1f" % voltage)
-            write_to_ramdisk("llv2", str(lp1voltage2))
-            resp = client.read_input_registers(0x04, 2, unit=sdmid)
-            voltage = struct.unpack('>f', struct.pack('>HH', *resp.registers))[0]
-            lp1voltage3 = float("%.1f" % voltage)
-            write_to_ramdisk("llv3", str(lp1voltage3))
-            resp = client.read_input_registers(0x06, 2, unit=sdmid)
-            lp1lla1 = float(struct.unpack('>f', struct.pack('>HH', *resp.registers))[0])
-            lp1lla1 = float("%.1f" % lp1lla1)
-            write_to_ramdisk("lla1", str(lp1lla1))
-            resp = client.read_input_registers(0x08, 2, unit=sdmid)
-            lp1lla2 = float(struct.unpack('>f', struct.pack('>HH', *resp.registers))[0])
-            lp1lla2 = float("%.1f" % lp1lla2)
-            write_to_ramdisk("lla2", str(lp1lla2))
-            resp = client.read_input_registers(0x0A, 2, unit=sdmid)
-            lp1lla3 = struct.unpack('>f', struct.pack('>HH', *resp.registers))[0]
-            lp1lla3 = float("%.1f" % lp1lla3)
-            write_to_ramdisk("lla3", str(lp1lla3))
-            resp = client.read_input_registers(0x0156, 2, unit=sdmid)
-            lp1llkwh = struct.unpack('>f', struct.pack('>HH', *resp.registers))[0]
-            lp1llkwh = float("%.3f" % lp1llkwh)
-            write_to_ramdisk("llkwh", str(lp1llkwh))
-            resp = client.read_input_registers(0x46, 2, unit=sdmid)
-            hz = struct.unpack('>f', struct.pack('>HH', *resp.registers))[0]
-            hz = float("%.2f" % hz)
-            write_to_ramdisk("llhz", str(hz))
-        elif sdmid < 255:
-            # llkwh
-            resp = client.read_holding_registers(0x5000, 4, unit=sdmid)
-            lp1llkwh = struct.unpack('>Q', struct.pack('>HHHH', *resp.registers))[0]/100
-            write_to_ramdisk("llkwh", str(lp1llkwh))
-            # Voltage
-            resp = client.read_holding_registers(0x5B00, 2, unit=sdmid)
-            voltage = resp.registers[1]
-            lp1voltage1 = float(voltage) / 10
-            write_to_ramdisk("llv1", str(lp1voltage1))
-            resp = client.read_holding_registers(0x5B02, 2, unit=sdmid)
-            lp1voltage2 = resp.registers[1]
-            lp1voltage2 = float(lp1voltage2) / 10
-            write_to_ramdisk("llv2", str(lp1voltage2))
-            resp = client.read_holding_registers(0x5B04, 2, unit=sdmid)
-            voltage = resp.registers[1]
-            lp1voltage3 = float(voltage) / 10
-            write_to_ramdisk("llv3", str(lp1voltage3))
-            # Ampere
-            resp = client.read_holding_registers(0x5B0C, 2, unit=sdmid)
-            amp = resp.registers[1]
-            lp1lla1 = float(amp) / 100
-            write_to_ramdisk("lla1", str(lp1lla1))
-            resp = client.read_holding_registers(0x5B0E, 2, unit=sdmid)
-            amp = resp.registers[1]
-            lp1lla2 = float(amp) / 100
-            write_to_ramdisk("lla2", str(lp1lla2))
-            resp = client.read_holding_registers(0x5B10, 2, unit=sdmid)
-            amp = resp.registers[1]
-            lp1lla3 = float(amp) / 100
-            write_to_ramdisk("lla3", str(lp1lla3))
-            # Gesamt watt
-            resp = client.read_holding_registers(0x5B14, 2, unit=sdmid)
-            lp1llg = int(struct.unpack('>i', struct.pack('>HH', *resp.registers))[0]/100)
-            write_to_ramdisk("llaktuell", str(lp1llg))
-            # LL Hz
-            resp = client.read_holding_registers(0x5B2C, 2, unit=sdmid)
-            hz = float(resp.registers[0]) / 100
-            write_to_ramdisk("llhz", str(hz))
+    def update_values(self, counter_state: ChargepointState) -> None:
+        self.parent_wb = Isss.get_parent_wb()
+        if self.old_counter_state:
+            # iterate over counterstate
+            vars_old_counter_state = vars(self.old_counter_state)
+            for key, value in vars(counter_state).items():
+                if value != vars_old_counter_state[key]:
+                    self._pub_values_to_1_9(key, value)
+                    self._pub_values_to_2(key, value)
+            self.old_counter_state = counter_state
         else:
-            # dummy
-            lp1voltage1 = 230
-            lp1voltage2 = 230
-            lp1voltage3 = 230
-            lp1lla1 = 0
-            lp1lla2 = 0
-            lp1lla3 = 0
-            lp1llkwh = 10
-            hz = 0
-            lp1llg = 0
+            # Bei Neustart alles publishen
+            for key, value in vars(counter_state).items():
+                self._pub_values_to_1_9(key, value)
+                self._pub_values_to_2(key, value)
+            self.old_counter_state = counter_state
 
-        try:
-            lp1countphasesinuse = 0
-            if lp1lla1 > 3:
-                lp1countphasesinuse += 1
-            if lp1lla2 > 3:
-                lp1countphasesinuse += 1
-            if lp1lla3 > 3:
-                lp1countphasesinuse += 1
-        except Exception:
-            lp1countphasesinuse = 0
+    def _pub_values_to_1_9(self, key: str, value) -> None:
+        def pub_value(topic: str, value):
+            pub_single("openWB/lp/"+self.cp_num+"/"+topic, payload=str(value), no_json=True)
+            pub_single("openWB/lp/"+self.cp_num+"/"+topic, payload=str(value), hostname=self.parent_wb, no_json=True)
+        topic = self.MAP_KEY_TO_OLD_TOPIC[key]
+        rounding = get_rounding_function_by_digits(2)
+        if topic is not None:
+            if isinstance(topic, List):
+                for i in range(0, 3):
+                    pub_value(topic[i], rounding(value[i]))
+            else:
+                if "power" == key:
+                    value = int(value)
+                elif "imported" == key:
+                    value = value / 1000
+                if "rfid" == key:
+                    pub_value(self.MAP_KEY_TO_OLD_TOPIC[key], value)
+                else:
+                    pub_value(self.MAP_KEY_TO_OLD_TOPIC[key], rounding(value))
 
-        if lp2installed:
-            try:
-                time.sleep(0.1)
-                resp = client.read_input_registers(0x0C, 2, unit=sdm2id)
-                lp2llw1 = struct.unpack('>f', struct.pack('>HH', *resp.registers))[0]
-                lp2llw1 = int(lp2llw1)
-                resp = client.read_input_registers(0x0E, 2, unit=sdm2id)
-                lp2llw2 = struct.unpack('>f', struct.pack('>HH', *resp.registers))[0]
-                lp2llw2 = int(lp2llw2)
-                resp = client.read_input_registers(0x10, 2, unit=sdm2id)
-                lp2llw3 = struct.unpack('>f', struct.pack('>HH', *resp.registers))[0]
-                lp2llw3 = int(lp2llw3)
-                lp2llg = lp2llw1 + lp2llw2 + lp2llw3
-                if lp2llg < 10:
-                    lp2llg = 0
-                write_to_ramdisk("llaktuells1", str(lp2llg))
-                resp = client.read_input_registers(0x00, 2, unit=sdm2id)
-                voltage = struct.unpack('>f', struct.pack('>HH', *resp.registers))[0]
-                lp2voltage1 = float("%.1f" % voltage)
-                write_to_ramdisk("llvs11", str(lp2voltage1))
-                resp = client.read_input_registers(0x02, 2, unit=sdm2id)
-                voltage = struct.unpack('>f', struct.pack('>HH', *resp.registers))[0]
-                lp2voltage2 = float("%.1f" % voltage)
-                write_to_ramdisk("llvs12", str(lp2voltage2))
-                resp = client.read_input_registers(0x04, 2, unit=sdm2id)
-                voltage = struct.unpack('>f', struct.pack('>HH', *resp.registers))[0]
-                lp2voltage3 = float("%.1f" % voltage)
-                write_to_ramdisk("llvs13", str(lp2voltage3))
-                resp = client.read_input_registers(0x06, 2, unit=sdm2id)
-                lp2lla1 = float(struct.unpack('>f', struct.pack('>HH', *resp.registers))[0])
-                lp2lla1 = float("%.1f" % lp2lla1)
-                write_to_ramdisk("llas11", str(lp2lla1))
-                resp = client.read_input_registers(0x08, 2, unit=sdm2id)
-                lp2lla2 = float(struct.unpack('>f', struct.pack('>HH', *resp.registers))[0])
-                lp2lla2 = float("%.1f" % lp2lla2)
-                write_to_ramdisk("llas12", str(lp2lla2))
-                resp = client.read_input_registers(0x0A, 2, unit=sdm2id)
-                lp2lla3 = struct.unpack('>f', struct.pack('>HH', *resp.registers))[0]
-                lp2lla3 = float("%.1f" % lp2lla3)
-                write_to_ramdisk("llas13", str(lp2lla3))
-                resp = client.read_input_registers(0x0156, 2, unit=sdm2id)
-                lp2llkwh = struct.unpack('>f', struct.pack('>HH', *resp.registers))[0]
-                lp2llkwh = float("%.3f" % lp2llkwh)
-                write_to_ramdisk("llkwhs1", str(lp2llkwh))
-                try:
-                    lp2countphasesinuse = 0
-                    if lp2lla1 > 3:
-                        lp2countphasesinuse += 1
-                    if lp2lla2 > 3:
-                        lp2countphasesinuse += 1
-                    if lp2lla3 > 3:
-                        lp2countphasesinuse += 1
-                except Exception:
-                    lp2countphasesinuse = 0
-                try:
-                    time.sleep(0.1)
-                    rq = client.read_holding_registers(1000, 1, unit=2)
-                    lp2ll = rq.registers[0]
-                except Exception:
-                    lp2ll = 0
-                try:
-                    time.sleep(0.1)
-                    rq = client.read_holding_registers(1002, 1, unit=2)
-                    lp2var = rq.registers[0]
-                    DeviceValues.update({'lp2readerror': str(0)})
-                except Exception:
-                    DeviceValues.update({'lp2readerror': str(int(DeviceValues['lp2readerror']) + 1)})
-                    log_debug(2, "Fehler!", traceback.format_exc())
-                    lp2var = 5
-                if (lp2var == 5 and int(DeviceValues['lp2readerror']) > MaxEvseError):
-                    log_debug(2, "Anhaltender Fehler beim Auslesen der EVSE von lp2! ("
-                              + str(DeviceValues['lp2readerror']) + ")")
-                    log_debug(2, "Plugstat und Chargestat werden zurückgesetzt.")
-                    Values.update({'lp2plugstat': 0})
-                    Values.update({'lp2chargestat': 0})
-                elif lp2var == 1:
-                    Values.update({'lp2plugstat': 0})
-                    Values.update({'lp2chargestat': 0})
-                elif lp2var == 2:
-                    Values.update({'lp2plugstat': 1})
-                    Values.update({'lp2chargestat': 0})
-                elif (lp2var == 3 and lp2ll > 0):
-                    Values.update({'lp2plugstat': 1})
-                    Values.update({'lp2chargestat': 1})
-                elif (lp2var == 3 and lp2ll == 0):
-                    Values.update({'lp2plugstat': 1})
-                    Values.update({'lp2chargestat': 0})
-                write_to_ramdisk("plugstats1", str(Values["lp2plugstat"]))
-                write_to_ramdisk("chargestats1", str(Values["lp2chargestat"]))
-                Values.update({'lp2evsell': lp2ll})
-                log_debug(0, "EVSE lp2plugstat: " + str(lp2var) + " EVSE lp2LL: " + str(lp2ll))
-            except Exception:
-                pass
+    def _pub_values_to_2(self, topic: str, value) -> None:
+        rounding = get_rounding_function_by_digits(2)
+        # fix rfid default value
+        if topic == "rfid" and value == "0":
+            value = None
+        if isinstance(value, (str, bool, type(None))):
+            pub_single("openWB/set/chargepoint/" + self.cp_num+"/get/"+topic, payload=value, hostname=self.parent_wb)
+        else:
+            if isinstance(value, list):
+                pub_single("openWB/set/chargepoint/" + self.cp_num+"/get/"+topic,
+                           payload=[rounding(v) for v in value], hostname=self.parent_wb)
+            else:
+                pub_single("openWB/set/chargepoint/" + self.cp_num+"/get/"+topic,
+                           payload=rounding(value), hostname=self.parent_wb)
 
+
+class UpdateState:
+    def __init__(self, cp_module: chargepoint_module.ChargepointModule) -> None:
+        self.old_phases_to_use = 3
+        self.old_set_current = 0
+        self.phase_switch_thread = None  # type: Optional[threading.Thread]
+        self.cp_interruption_thread = None  # type: Optional[threading.Thread]
+        self.actor_cooldown_thread = None  # type: Optional[threading.Thread]
+        self.cp_module = cp_module
+
+    def update_state(self) -> None:
+        if self.cp_module.config.id == 1:
+            suffix = ""
+        else:
+            suffix = "s1"
         try:
-            time.sleep(0.1)
-            rq = client.read_holding_registers(1000, 1, unit=1)
-            lp1ll = rq.registers[0]
-            evsefailure = 0
-        except Exception:
-            lp1ll = 0
-            evsefailure = 1
+            set_current = int(float(ramdisk_read("llsoll"+suffix)))
+        except (FileNotFoundError, ValueError):
+            set_current = 0
         try:
-            time.sleep(0.1)
-            rq = client.read_holding_registers(1002, 1, unit=1)
-            lp1var = rq.registers[0]
-            evsefailure = 0
-            DeviceValues.update({'lp1readerror': str(0)})
-        except Exception:
-            DeviceValues.update({'lp1readerror': str(int(DeviceValues['lp1readerror'])+1)})
-            log_debug(2, "Fehler!", traceback.format_exc())
-            lp1var = 5
-            evsefailure = 1
-        if (lp1var == 5 and int(DeviceValues['lp1readerror']) > MaxEvseError):
-            log_debug(2, "Anhaltender Fehler beim Auslesen der EVSE von lp1! ("
-                      + str(DeviceValues['lp1readerror']) + ")")
-            log_debug(2, "Plugstat und Chargestat werden zurückgesetzt.")
-            Values.update({'lp1plugstat': 0})
-            Values.update({'lp1chargestat': 0})
-        elif lp1var == 1:
-            Values.update({'lp1plugstat': 0})
-            Values.update({'lp1chargestat': 0})
-        elif lp1var == 2:
-            Values.update({'lp1plugstat': 1})
-            Values.update({'lp1chargestat': 0})
-        elif (lp1var == 3 and lp1ll > 0):
-            Values.update({'lp1plugstat': 1})
-            Values.update({'lp1chargestat': 1})
-        elif (lp1var == 3 and lp1ll == 0):
-            Values.update({'lp1plugstat': 1})
-            Values.update({'lp1chargestat': 0})
-        write_to_ramdisk("plugstat", str(Values["lp1plugstat"]))
-        write_to_ramdisk("chargestat", str(Values["lp1chargestat"]))
-        Values.update({'lp1evsell': lp1ll})
-        log_debug(0, "EVSE lp1plugstat: " + str(lp1var) + " EVSE lp1LL: " + str(lp1ll))
+            heartbeat = int(ramdisk_read("heartbeat"))
+        except (FileNotFoundError, ValueError):
+            heartbeat = 0
         try:
-            rfidtag = read_from_ramdisk("readtag")
-            rfidtag2 = rfidtag
+            cp_interruption_duration = int(float(ramdisk_read("extcpulp1")))
+        except (FileNotFoundError, ValueError):
+            cp_interruption_duration = 3
+        try:
+            phases_to_use = int(float(ramdisk_read("u1p3pstat")))
+        except (FileNotFoundError, ValueError):
+            phases_to_use = 3
+        log.debug("Values from ramdisk: set_current"+str(set_current) +
+                  " heartbeat "+str(heartbeat) + " phases_to_use "+str(phases_to_use) + "cp_interruption_duration" + str(cp_interruption_duration))
+
+        if heartbeat > 80:
+            set_current = 0
+            log.error("Heartbeat Fehler seit " + str(heartbeat) + "Sekunden keine Verbindung, Stoppe Ladung.")
+
+        if self.phase_switch_thread:
+            if self.phase_switch_thread.is_alive():
+                log.debug("Thread zur Phasenumschaltung an LP"+str(self.cp_module.config.id) +
+                          " noch aktiv. Es muss erst gewartet werden, bis die Phasenumschaltung abgeschlossen ist.")
+                return
+        if self.cp_interruption_thread:
+            if self.cp_interruption_thread.is_alive():
+                log.debug("Thread zur CP-Unterbrechung an LP"+str(self.cp_module.config.id) +
+                          " noch aktiv. Es muss erst gewartet werden, bis die CP-Unterbrechung abgeschlossen ist.")
+                return
+        self.cp_module.set_current(set_current)
+        if self.old_phases_to_use != phases_to_use and phases_to_use != 0:
+            log.debug("Switch Phases from "+str(self.old_phases_to_use) + " to " + str(phases_to_use))
+            self.__thread_phase_switch(phases_to_use)
+            self.old_phases_to_use = phases_to_use
+
+        if cp_interruption_duration > 0:
+            self.__thread_cp_interruption(cp_interruption_duration)
+
+    def __thread_phase_switch(self, phases_to_use: int) -> None:
+        self.phase_switch_thread = threading.Thread(
+            target=self.cp_module.perform_phase_switch, args=(phases_to_use, 5))
+        self.phase_switch_thread.start()
+        log.debug("Thread zur Phasenumschaltung an LP"+str(self.cp_module.config.id)+" gestartet.")
+
+    def __thread_cp_interruption(self, duration: int) -> None:
+        self.cp_interruption_thread = threading.Thread(
+            target=self.cp_module.perform_cp_interruption, args=(duration,))
+        self.cp_interruption_thread.start()
+        log.debug("Thread zur CP-Unterbrechung an LP"+str(self.cp_module.config.id)+" gestartet.")
+        ramdisk_write("extcpulp1", "0")
+
+
+class Isss:
+    def __init__(self) -> None:
+        log.debug("Init isss")
+        self.serial_client = ModbusSerialClient_(self.detect_modbus_usb_port())
+        self.cp1 = IsssChargepoint(self.serial_client, 1)
+        try:
+            if int(ramdisk_read("issslp2act")) == 1:
+                self.cp2 = IsssChargepoint(self.serial_client, 2)
+            else:
+                self.cp2 = None
+        except (FileNotFoundError, ValueError) as e:
+            log.error("Error reading issslp2act! Guessing cp2 is not configured.")
+            self.cp2 = None
+        self.init_gpio()
+
+    def init_gpio(self) -> None:
+        GPIO.setwarnings(False)
+        GPIO.setmode(GPIO.BOARD)
+        GPIO.setup(37, GPIO.OUT)
+        GPIO.setup(13, GPIO.OUT)
+        GPIO.setup(22, GPIO.OUT)
+        GPIO.setup(29, GPIO.OUT)
+        GPIO.setup(11, GPIO.OUT)
+        GPIO.setup(15, GPIO.OUT)
+        # GPIOs for socket
+        GPIO.setup(23, GPIO.OUT)
+        GPIO.setup(26, GPIO.OUT)
+        GPIO.setup(19, GPIO.IN, pull_up_down=GPIO.PUD_UP)
+
+    def loop(self) -> None:
+        # connect with USB/modbus device
+        with self.serial_client:
+            # start our control loop
+            while True:
+                log.setLevel(MAP_LOG_LEVEL[int(os.environ.get('debug'))])
+                log.debug("***Start***")
+                self.cp1.update()
+                if self.cp2:
+                    self.cp2.update()
+                time.sleep(1.1)
+
+    def detect_modbus_usb_port(self) -> str:
+        """guess USB/modbus device name"""
+        try:
+            with open("/dev/ttyUSB0"):
+                return "/dev/ttyUSB0"
+        except FileNotFoundError:
+            return "/dev/serial0"
+
+    @staticmethod
+    def get_cp_num(local_charge_point_num) -> int:
+        try:
+            if local_charge_point_num == 1:
+                return int(re.sub(r'\D', '', ramdisk_read("parentCPlp1")))
+            else:
+                return int(re.sub(r'\D', '', ramdisk_read("parentCPlp2")))
         except Exception:
-            pass
+            FaultState.warning("Es konnte keine Ladepunkt-Nummer ermittelt werden. Auf Default-Wert 0 gesetzt.")
+            return 0
+
+    @staticmethod
+    def get_parent_wb() -> str:
         # check for parent openWB
         try:
-            parentWB = read_from_ramdisk("parentWB").replace('\\n', '').replace('\"', '')
-            parentCPlp1 = str(int(re.sub(r'\D', '', read_from_ramdisk("parentCPlp1"))))
-            if lp2installed:
-                parentCPlp2 = str(int(re.sub(r'\D', '', read_from_ramdisk("parentCPlp2"))))
+            return ramdisk_read("parentWB").replace('\\n', '').replace('\"', '')
         except Exception:
-            log_debug(2, "Failed to get infos about parent wb! Setting default values.")
-            parentWB = str("0")
-            parentCPlp1 = str("0")
-            parentCPlp2 = str("0")
-
-        if parentWB != "0":
-            remoteclient = mqtt.Client("openWB-isss-bulkpublisher-" + str(os.getpid()))
-            remoteclient.connect(str(parentWB))
-            remoteclient.loop(timeout=2.0)
-        mclient = mqtt.Client("openWB-isss-bulkpublisher-" + str(os.getpid()))
-        mclient.connect("localhost")
-        mclient.loop(timeout=2.0)
-        for key in DeviceValues:
-            if "lp1watt" in key:
-                if DeviceValues[str(key)] != str(lp1llg):
-                    mclient.publish("openWB/lp/1/W", payload=str(lp1llg), qos=0, retain=True)
-                    mclient.loop(timeout=2.0)
-                    DeviceValues.update({'lp1watt': str(lp1llg)})
-                if parentWB != "0":
-                    remoteclient.publish("openWB/lp/"+parentCPlp1+"/W", payload=str(lp1llg), qos=0, retain=True)
-                    remoteclient.publish("openWB/set/chargepoint/"+parentCPlp1+"/get/power", payload=str(lp1llg),
-                                         qos=0, retain=True)
-                    remoteclient.loop(timeout=2.0)
-            if "lp1voltage1" in key:
-                if DeviceValues[str(key)] != str(lp1voltage1):
-                    mclient.publish("openWB/lp/1/VPhase1", payload=str(lp1voltage1), qos=0, retain=True)
-                    mclient.loop(timeout=2.0)
-                    DeviceValues.update({'lp1voltage1': str(lp1voltage1)})
-                if parentWB != "0":
-                    remoteclient.publish("openWB/lp/"+parentCPlp1 + "/Vphase1",
-                                         payload=str(lp1voltage1), qos=0, retain=True)
-                    remoteclient.publish("openWB/set/chargepoint/" + parentCPlp1+"/get/voltages", payload="["
-                                         + str(lp1voltage1) + "," + str(lp1voltage2) + "," + str(lp1voltage3) + "]",
-                                         qos=0, retain=True)
-                    remoteclient.loop(timeout=2.0)
-            if "lp1voltage2" in key:
-                if DeviceValues[str(key)] != str(lp1voltage2):
-                    mclient.publish("openWB/lp/1/VPhase2", payload=str(lp1voltage2), qos=0, retain=True)
-                    mclient.loop(timeout=2.0)
-                    DeviceValues.update({'lp1voltage2': str(lp1voltage2)})
-            if "lp1voltage3" in key:
-                if DeviceValues[str(key)] != str(lp1voltage3):
-                    mclient.publish("openWB/lp/1/VPhase3", payload=str(lp1voltage3), qos=0, retain=True)
-                    mclient.loop(timeout=2.0)
-                    DeviceValues.update({'lp1voltage3': str(lp1voltage3)})
-            if "lp1lla1" in key:
-                if DeviceValues[str(key)] != str(lp1lla1):
-                    mclient.publish("openWB/lp/1/APhase1", payload=str(lp1lla1), qos=0, retain=True)
-                    mclient.loop(timeout=2.0)
-                    DeviceValues.update({'lp1lla1': str(lp1lla1)})
-                if parentWB != "0":
-                    remoteclient.publish("openWB/lp/" + parentCPlp1 + "/Aphase1", payload=str(lp1lla1),
-                                         qos=0, retain=True)
-                    remoteclient.publish("openWB/set/chargepoint/" + parentCPlp1 + "/get/currents",
-                                         payload="[" + str(lp1lla1) + "," + str(lp1lla2) + "," + str(lp1lla3) + "]",
-                                         qos=0, retain=True)
-                    remoteclient.loop(timeout=2.0)
-
-            if "lp1lla2" in key:
-                if DeviceValues[str(key)] != str(lp1lla2):
-                    mclient.publish("openWB/lp/1/APhase2", payload=str(lp1lla2), qos=0, retain=True)
-                    mclient.loop(timeout=2.0)
-                    DeviceValues.update({'lp1lla2': str(lp1lla2)})
-                if parentWB != "0":
-                    remoteclient.publish("openWB/lp/"+parentCPlp1+"/Aphase2", payload=str(lp1lla2), qos=0, retain=True)
-                    remoteclient.loop(timeout=2.0)
-
-            if "lp1lla3" in key:
-                if DeviceValues[str(key)] != str(lp1lla3):
-                    mclient.publish("openWB/lp/1/APhase3", payload=str(lp1lla3), qos=0, retain=True)
-                    mclient.loop(timeout=2.0)
-                    DeviceValues.update({'lp1lla3': str(lp1lla3)})
-                if parentWB != "0":
-                    remoteclient.publish("openWB/lp/"+parentCPlp1+"/Aphase3", payload=str(lp1lla3), qos=0, retain=True)
-                    remoteclient.loop(timeout=2.0)
-
-            if "lp1countphasesinuse" in key:
-                if DeviceValues[str(key)] != str(lp1countphasesinuse):
-                    mclient.publish("openWB/lp/1/countPhasesInUse", payload=str(lp1countphasesinuse),
-                                    qos=0, retain=True)
-                    mclient.loop(timeout=2.0)
-                    DeviceValues.update({'lp1countphasesinuse': str(lp1countphasesinuse)})
-                if parentWB != "0":
-                    remoteclient.publish("openWB/lp/"+parentCPlp1+"/countPhasesInUse", payload=str(lp1countphasesinuse),
-                                         qos=0, retain=True)
-                    remoteclient.publish("openWB/set/chargepoint/"+parentCPlp1+"/get/phases_in_use",
-                                         payload=str(lp1countphasesinuse), qos=0, retain=True)
-                    remoteclient.loop(timeout=2.0)
-            if "lp1llkwh" in key:
-                if DeviceValues[str(key)] != str(lp1llkwh):
-                    mclient.publish("openWB/lp/1/kWhCounter", payload=str(lp1llkwh), qos=0, retain=True)
-                    mclient.loop(timeout=2.0)
-                    DeviceValues.update({'lp1llkwh': str(lp1llkwh)})
-                if parentWB != "0":
-                    remoteclient.publish("openWB/lp/"+parentCPlp1+"/kWhCounter", payload=str(lp1llkwh),
-                                         qos=0, retain=True)
-                    remoteclient.publish("openWB/set/chargepoint/"+parentCPlp1+"/get/imported",
-                                         payload=str(lp1llkwh*1000), qos=0, retain=True)
-                    remoteclient.loop(timeout=2.0)
-
-            if "lp1plugstat" in key:
-                if DeviceValues[str(key)] != Values["lp1plugstat"]:
-                    mclient.publish("openWB/lp/1/boolPlugStat", payload=Values["lp1plugstat"], qos=0, retain=True)
-                    mclient.loop(timeout=2.0)
-                    if int(Values["lp1plugstat"]) == "1":
-                        write_to_ramdisk("pluggedin", str(Values["lp1plugstat"]))
-                    DeviceValues.update({'lp1plugstat': Values["lp1plugstat"]})
-                if parentWB != "0":
-                    remoteclient.publish("openWB/lp/"+parentCPlp1+"/boolPlugStat", payload=Values["lp1plugstat"],
-                                         qos=0, retain=True)
-                    remoteclient.publish("openWB/set/chargepoint/"+parentCPlp1+"/get/plug_state",
-                                         payload=Values["lp1plugstat"], qos=0, retain=True)
-                    remoteclient.loop(timeout=2.0)
-
-            if "lp1chargestat" in key:
-                if DeviceValues[str(key)] != Values["lp1chargestat"]:
-                    mclient.publish("openWB/lp/1/boolChargeStat", payload=Values["lp1chargestat"], qos=0, retain=True)
-                    mclient.loop(timeout=2.0)
-                    DeviceValues.update({'lp1chargestat': Values["lp1chargestat"]})
-                if parentWB != "0":
-                    remoteclient.publish("openWB/lp/"+parentCPlp1+"/boolChargeStat", payload=Values["lp1chargestat"],
-                                         qos=0, retain=True)
-                    remoteclient.publish("openWB/set/chargepoint/"+parentCPlp1+"/get/charge_state",
-                                         payload=Values["lp1chargestat"], qos=0, retain=True)
-                    remoteclient.loop(timeout=2.0)
-            if "rfidtag" in key:
-                if DeviceValues[str(key)] != str(rfidtag):
-                    mclient.publish("openWB/lp/1/LastScannedRfidTag", payload=str(rfidtag), qos=0, retain=True)
-                    mclient.loop(timeout=2.0)
-                    DeviceValues.update({'rfidtag': str(rfidtag)})
-                if parentWB != "0":
-                    rfidtag_temp = rfidtag
-                    if rfidtag.rstrip() == "0":
-                        rfidtag_temp = None  # default value for 2.0 is None, not "0"
-                    remoteclient.publish("openWB/set/chargepoint/"+parentCPlp1+"/get/rfid",
-                                         payload=json.dumps(rfidtag_temp), qos=0, retain=True)
-                    remoteclient.loop(timeout=2.0)
-            if lp2installed:
-                if "lp2countphasesinuse" in key:
-                    if DeviceValues[str(key)] != str(lp2countphasesinuse):
-                        mclient.publish("openWB/lp/2/countPhasesInUse", payload=str(lp2countphasesinuse),
-                                        qos=0, retain=True)
-                        mclient.loop(timeout=2.0)
-                        DeviceValues.update({'lp2countphasesinuse': str(lp2countphasesinuse)})
-                    if parentWB != "0":
-                        remoteclient.publish("openWB/lp/"+parentCPlp2+"/countPhasesInUse",
-                                             payload=str(lp2countphasesinuse), qos=0, retain=True)
-                        remoteclient.publish("openWB/set/chargepoint/"+parentCPlp2+"/get/phases_in_use",
-                                             payload=str(lp2countphasesinuse), qos=0, retain=True)
-                        remoteclient.loop(timeout=2.0)
-                if "lp2watt" in key:
-                    if DeviceValues[str(key)] != str(lp2llg):
-                        mclient.publish("openWB/lp/2/W", payload=str(lp2llg), qos=0, retain=True)
-                        mclient.loop(timeout=2.0)
-                        DeviceValues.update({'lp2watt': str(lp2llg)})
-                    if parentWB != "0":
-                        remoteclient.publish("openWB/lp/"+parentCPlp2+"/W", payload=str(lp2llg), qos=0, retain=True)
-                        remoteclient.publish("openWB/set/chargepoint/"+parentCPlp2+"/get/power",
-                                             payload=str(lp2llg), qos=0, retain=True)
-                        remoteclient.loop(timeout=2.0)
-                if "lp2voltage1" in key:
-                    if DeviceValues[str(key)] != str(lp2voltage1):
-                        mclient.publish("openWB/lp/2/VPhase1", payload=str(lp2voltage1), qos=0, retain=True)
-                        mclient.loop(timeout=2.0)
-                        DeviceValues.update({'lp2voltage1': str(lp2voltage1)})
-                    if parentWB != "0":
-                        remoteclient.publish("openWB/lp/"+parentCPlp2+"/Vphase1", payload=str(lp2voltage1),
-                                             qos=0, retain=True)
-                        remoteclient.publish("openWB/set/chargepoint/"+parentCPlp2+"/get/voltages",
-                                             payload="["+str(lp2voltage1)+","+str(lp2voltage2)+","+str(lp2voltage3)+"]",
-                                             qos=0, retain=True)
-                        remoteclient.loop(timeout=2.0)
-                if "lp2voltage2" in key:
-                    if DeviceValues[str(key)] != str(lp2voltage2):
-                        mclient.publish("openWB/lp/2/VPhase2", payload=str(lp2voltage2), qos=0, retain=True)
-                        mclient.loop(timeout=2.0)
-                        DeviceValues.update({'lp2voltage2': str(lp2voltage2)})
-                    if parentWB != "0":
-                        remoteclient.publish("openWB/lp/"+parentCPlp2+"/Vphase2", payload=str(lp2voltage2),
-                                             qos=0, retain=True)
-                        remoteclient.loop(timeout=2.0)
-
-                if "lp2voltage3" in key:
-                    if DeviceValues[str(key)] != str(lp2voltage3):
-                        mclient.publish("openWB/lp/2/VPhase3", payload=str(lp2voltage3), qos=0, retain=True)
-                        mclient.loop(timeout=2.0)
-                        DeviceValues.update({'lp2voltage3': str(lp2voltage3)})
-                    if parentWB != "0":
-                        remoteclient.publish("openWB/lp/"+parentCPlp2+"/Vphase3", payload=str(lp2voltage3),
-                                             qos=0, retain=True)
-                        remoteclient.loop(timeout=2.0)
-
-                if "lp2lla1" in key:
-                    if DeviceValues[str(key)] != str(lp2lla1):
-                        mclient.publish("openWB/lp/2/APhase1", payload=str(lp2lla1), qos=0, retain=True)
-                        mclient.loop(timeout=2.0)
-                        DeviceValues.update({'lp2lla1': str(lp2lla1)})
-                    if parentWB != "0":
-                        remoteclient.publish("openWB/lp/"+parentCPlp2+"/Aphase1", payload=str(lp2lla1),
-                                             qos=0, retain=True)
-                        remoteclient.publish("openWB/set/chargepoint/"+parentCPlp2+"/get/currents",
-                                             payload="["+str(lp2lla1)+","+str(lp2lla2)+","+str(lp2lla3)+"]",
-                                             qos=0, retain=True)
-                        remoteclient.loop(timeout=2.0)
-
-                if "lp2lla2" in key:
-                    if DeviceValues[str(key)] != str(lp2lla2):
-                        mclient.publish("openWB/lp/2/APhase2", payload=str(lp2lla2), qos=0, retain=True)
-                        mclient.loop(timeout=2.0)
-                        DeviceValues.update({'lp2lla2': str(lp2lla2)})
-                    if parentWB != "0":
-                        remoteclient.publish("openWB/lp/"+parentCPlp2+"/Aphase2", payload=str(lp2lla2),
-                                             qos=0, retain=True)
-                        remoteclient.loop(timeout=2.0)
-
-                if "lp2lla3" in key:
-                    if DeviceValues[str(key)] != str(lp2lla3):
-                        mclient.publish("openWB/lp/2/APhase3", payload=str(lp2lla3), qos=0, retain=True)
-                        mclient.loop(timeout=2.0)
-                        DeviceValues.update({'lp2lla3': str(lp2lla3)})
-                    if parentWB != "0":
-                        remoteclient.publish("openWB/lp/"+parentCPlp2+"/Aphase3", payload=str(lp2lla3),
-                                             qos=0, retain=True)
-                        remoteclient.loop(timeout=2.0)
-
-                if "lp2llkwh" in key:
-                    if DeviceValues[str(key)] != str(lp2llkwh):
-                        mclient.publish("openWB/lp/2/kWhCounter", payload=str(lp2llkwh), qos=0, retain=True)
-                        mclient.loop(timeout=2.0)
-                        DeviceValues.update({'lp2llkwh': str(lp2llkwh)})
-                    if parentWB != "0":
-                        remoteclient.publish("openWB/lp/"+parentCPlp2+"/kWhCounter", payload=str(lp2llkwh),
-                                             qos=0, retain=True)
-                        remoteclient.publish("openWB/set/chargepoint/"+parentCPlp2+"/get/imported",
-                                             payload=str(lp2llkwh*1000), qos=0, retain=True)
-                        remoteclient.loop(timeout=2.0)
-                if "lp2plugstat" in key:
-                    if DeviceValues[str(key)] != Values["lp2plugstat"]:
-                        mclient.publish("openWB/lp/2/boolPlugStat", payload=Values["lp2plugstat"], qos=0, retain=True)
-                        mclient.loop(timeout=2.0)
-                        DeviceValues.update({'lp2plugstat': Values["lp2plugstat"]})
-                        if (int(Values["lp2plugstat"]) == "1"):
-                            write_to_ramdisk("pluggedin", str(Values["lp2plugstat"]))
-                    if parentWB != "0":
-                        remoteclient.publish("openWB/lp/"+parentCPlp2+"/boolPlugStat", payload=Values["lp2plugstat"],
-                                             qos=0, retain=True)
-                        remoteclient.publish("openWB/set/chargepoint/"+parentCPlp2+"/get/plug_state",
-                                             payload=Values["lp2plugstat"], qos=0, retain=True)
-                        remoteclient.loop(timeout=2.0)
-
-                if "lp2chargestat" in key:
-                    if DeviceValues[str(key)] != Values["lp2chargestat"]:
-                        mclient.publish("openWB/lp/2/boolChargeStat", payload=Values["lp2chargestat"],
-                                        qos=0, retain=True)
-                        mclient.loop(timeout=2.0)
-                        DeviceValues.update({'lp2chargestat': Values["lp2chargestat"]})
-                    if parentWB != "0":
-                        remoteclient.publish("openWB/lp/"+parentCPlp2+"/boolChargeStat",
-                                             payload=Values["lp2chargestat"], qos=0, retain=True)
-                        remoteclient.publish("openWB/set/chargepoint/"+parentCPlp2+"/get/charge_state",
-                                             payload=Values["lp2chargestat"], qos=0, retain=True)
-                        remoteclient.loop(timeout=2.0)
-
-                if "rfidtag2" in key:
-                    if DeviceValues[str(key)] != str(rfidtag2):
-                        mclient.publish("openWB/lp/2/LastScannedRfidTag", payload=str(rfidtag2), qos=0, retain=True)
-                        mclient.loop(timeout=2.0)
-                        DeviceValues.update({'rfidtag2': str(rfidtag2)})
-                    if parentWB != "0":
-                        rfidtag2_temp = rfidtag2
-                        if rfidtag2.rstrip() == "0":
-                            rfidtag2_temp = None  # default value for 2.0 is None, not "0"
-                        remoteclient.publish("openWB/set/chargepoint/"+parentCPlp2+"/get/rfid",
-                                             payload=json.dumps(rfidtag2_temp), qos=0, retain=True)
-                        remoteclient.loop(timeout=2.0)
-        mclient.disconnect()
-        if parentWB != "0":
-            remoteclient.disconnect()
-    except Exception:
-        metercounter = metercounter + 1
-        if metercounter > 5:
-            log_debug(2, "Get meter Fehler!", traceback.format_exc())
+            FaultState.warning("Für den Betrieb im Nur-Ladepunkt-Modus ist zwingend eine Master-openWB erforderlich.")
+            return ""
 
 
-# control of socket lock
-# GPIO 23: control direction of lock motor
-# GPIO 26: power to lock motor
-def set_socket_actuator(action: str):
-    global actcooldown
-    global actcooldowntimestamp
-
-    if actcooldown < 10:
-        if action == "auf":
-            GPIO.output(23, GPIO.LOW)
-            GPIO.output(26, GPIO.HIGH)
-            time.sleep(2)
-            GPIO.output(26, GPIO.LOW)
-            log_debug(1, "Aktor auf")
-        if action == "zu":
-            GPIO.output(23, GPIO.HIGH)
-            GPIO.output(26, GPIO.HIGH)
-            time.sleep(3)
-            GPIO.output(26, GPIO.LOW)
-            log_debug(1, "Aktor zu")
-    else:
-        log_debug(2, "Cooldown für Aktor aktiv.")
-        if actcooldowntimestamp < 50:
-            actcooldowntimestamp = int(time.time())
-            log_debug(1, "Beginne 5 Minuten Cooldown für Aktor")
-            write_to_ramdisk("lastregelungaktiv",
-                             "Cooldown für Aktor der Verriegelung erforderlich. Steckt der Stecker richtig?")
-    actcooldown = actcooldown + 1
-
-
-# get actual socket lock state
-def get_socket_state() -> int:
-    actorstat_tmp = GPIO.input(19)
-    if actorstat_tmp == GPIO.LOW:
-        return 1
-    else:
-        return 0
-
-
-# get all values to control our chargepoints
-def load_control_values():
-    global actorstat
-    global lp1solla
-    global u1p3pstat
-    global u1p3plp2stat
-    global u1p3ptmpstat
-    global u1p3plp2tmpstat
-    global evsefailure
-    global lp2installed
-    global heartbeat
-    global actcooldown
-    global actcooldowntimestamp
-    global lp1evsehres
-    global lp2evsehres
-
-    actorstat = get_socket_state()
-    try:
-        if lp1evsehres == 0:
-            lp1solla = int(float(read_from_ramdisk("llsoll")))
+class IsssChargepoint:
+    def __init__(self, serial_client, local_charge_point_num) -> None:
+        self.local_charge_point_num = local_charge_point_num
+        if local_charge_point_num == 1:
+            try:
+                with open('/home/pi/ppbuchse', 'r') as f:
+                    max_current = int(f.read())
+                self.module = socket.Socket(max_current, InternalOpenWB(1, serial_client))
+            except (FileNotFoundError, ValueError):
+                self.module = chargepoint_module.ChargepointModule(InternalOpenWB(1, serial_client))
         else:
-            lp1solla = int(float(read_from_ramdisk("llsoll"))*100)
-    except (FileNotFoundError, ValueError):
-        log_debug(2, "Error reading configured current! Using default '0'.")
-        lp1solla = 0
-    try:
-        heartbeat = int(read_from_ramdisk("heartbeat"))
-        if heartbeat > 80:
-            lp1solla = 0
-            log_debug(2, "Heartbeat Fehler seit " + str(heartbeat) + "Sekunden keine Verbindung, Stoppe Ladung.")
-    except (FileNotFoundError, ValueError):
-        log_debug(2, "Error reading heartbeat! Using default '0'.")
-        heartbeat = 0
-    log_debug(0, "LL Soll: " + str(lp1solla) + " ActorStatus: " + str(actorstat))
-    if socket_configured:
-        log_debug(1, "in Buchse " + str(evsefailure) + " lp1plugstat:" + str(Values["lp1plugstat"]))
-        if actcooldowntimestamp > 50:
-            tst = actcooldowntimestamp + 300
-            if tst < int(time.time()):
-                actcooldowntimestamp = 0
-                actcooldown = 0
-                log_debug(1, "Cooldown für Aktor zurückgesetzt")
-            else:
-                timeleft = tst-int(time.time())
-                log_debug(1, str(timeleft) + " Sekunden Cooldown für Aktor verbleiben.")
+            self.module = chargepoint_module.ChargepointModule(InternalOpenWB(2, serial_client))
+        self.update_values = UpdateValues(local_charge_point_num)
+        self.update_state = UpdateState(self.module)
+        self.old_plug_state = False
 
-        if evsefailure == 0:
-            log_debug(1, "need to control actor? actorstat=" + str(actorstat) +
-                      " plugstat=" + str(Values["lp1plugstat"]))
-            if Values["lp1plugstat"] == 1:
-                if actorstat == 0:
-                    set_socket_actuator("zu")
-            if Values["lp1plugstat"] == 0:
-                if actorstat == 1:
-                    writelp1evse(0)
-                    set_socket_actuator("auf")
-            if actorstat == 1:
-                if Values["lp1evsell"] != lp1solla and Values["lp1plugstat"] == 1:
-                    writelp1evse(lp1solla)
+    def update(self):
+        def __thread_active(thread: Optional[threading.Thread]) -> bool:
+            if thread:
+                return thread.is_alive()
             else:
-                if Values["lp1evsell"] != 0:
-                    writelp1evse(0)
-    else:
-        if Values["lp1evsell"] != lp1solla:
-            writelp1evse(lp1solla)
-    if lp2installed:
+                return False
         try:
-            if lp2evsehres == 0:
-                lp2solla = int(float(read_from_ramdisk("llsolls1")))
-            else:
-                lp2solla = int(float(read_from_ramdisk("llsolls1"))*100)
-        except (FileNotFoundError, ValueError):
-            log_debug(2, "Error reading configured current for cp 2! Using default '0'.")
-            lp2solla = 0
-        log_debug(0, "LL lp2 Soll: " + str(lp2solla))
-        if Values["lp2evsell"] != lp2solla:
-            writelp2evse(lp2solla)
-    try:
-        u1p3ptmpstat = int(read_from_ramdisk("u1p3pstat"))
-    except (FileNotFoundError, ValueError):
-        log_debug(2, "Error reading used phases! Using default '3'.")
-        u1p3ptmpstat = 3
-    try:
-        u1p3pstat
-    except Exception:
-        u1p3pstat = 3
-    u1p3pstat = switch_phases_cp1(u1p3ptmpstat, u1p3pstat)
-    writelp1evse(lp1solla)
-    if lp2installed:
-        try:
-            u1p3plp2tmpstat = int(read_from_ramdisk("u1p3plp2stat"))
-        except (FileNotFoundError, ValueError):
-            log_debug(2, "Error reading used phases for cp 2! Using default '3'.")
-            u1p3plp2tmpstat = 3
-        try:
-            u1p3plp2stat
+            if self.local_charge_point_num == 2:
+                time.sleep(0.1)
+            phase_switch_cp_active = __thread_active(self.update_state.cp_interruption_thread) or __thread_active(
+                self.update_state.phase_switch_thread)
+            state, _ = self.module.get_values(phase_switch_cp_active)
+            log.debug("Published plug state "+str(state.plug_state))
+            self.update_values.update_values(state)
+            self.update_state.update_state()
         except Exception:
-            u1p3plp2stat = 3
-        if u1p3plp2stat != u1p3plp2tmpstat:
-            log_debug(1, "Umschaltung erfolgt auf " + str(u1p3plp2tmpstat) + " Phasen an Lp2")
-            writelp2evse(0)
-            time.sleep(1)
-            u1p3plp2stat = switch_phases_cp2(u1p3plp2tmpstat, u1p3plp2stat)
-            writelp2evse(lp2solla)
+            log.exception("Fehler bei Ladepunkt "+str(self.local_charge_point_num))
 
 
-def __switch_phases(gpio_cp: int, gpio_relay: int):
-    GPIO.output(gpio_cp, GPIO.HIGH)  # CP on
-    GPIO.output(gpio_relay, GPIO.HIGH)  # 3 on/off
-    time.sleep(2)
-    GPIO.output(gpio_relay, GPIO.LOW)  # 3 on/off
-    time.sleep(5)
-    GPIO.output(gpio_cp, GPIO.LOW)  # CP off
-    time.sleep(1)
-
-
-def switch_phases_cp1(new_phases: int, old_phases: int) -> int:
-    if (new_phases != old_phases):
-        log_debug(1, "switching phases on cp1: old=" + str(old_phases) + " new=" + str(new_phases))
-        gpio_cp = 22
-        if (new_phases == 1):
-            gpio_relay = 29
-        else:
-            gpio_relay = 37
-        __switch_phases(gpio_cp, gpio_relay)
-    else:
-        log_debug(0, "no need to switch phases on cp1: old=" + str(old_phases) + " new=" + str(new_phases))
-    return new_phases
-
-
-def switch_phases_cp2(new_phases: int, old_phases: int) -> int:
-    if (new_phases != old_phases):
-        log_debug(1, "switching phases on cp2: old=" + str(old_phases) + " new=" + str(new_phases))
-        gpio_cp = 15
-        if (new_phases == 1):
-            gpio_relay = 11
-        else:
-            gpio_relay = 13
-        __switch_phases(gpio_cp, gpio_relay)
-    else:
-        log_debug(0, "no need to switch phases on cp2: old=" + str(old_phases) + " new=" + str(new_phases))
-    return new_phases
-
-
-def writelp1evse(lla):
-    if lp1evsehres == 1:
-        mpp = pp*100
-        if lla > mpp:
-            lla = mpp
-    else:
-        if lla > pp:
-            lla = pp
-    try:
-        client.write_registers(1000, lla, unit=1)
-        log_debug(1, "Write to EVSE lp1 " + str(lla))
-    except Exception:
-        log_debug(2, "FAILED Write to EVSE lp1 " + str(lla), traceback.format_exc())
-
-
-def writelp2evse(lla):
-    try:
-        client.write_registers(1000, lla, unit=2)
-        log_debug(1, "Write to EVSE lp2 " + str(lla))
-    except Exception:
-        log_debug(2, "FAILED Write to EVSE lp2 " + str(lla), traceback.format_exc())
-
-
-# check for "openWB Buchse"
-def check_for_socket() -> Tuple[bool, int]:
-    try:
-        with open('/home/pi/ppbuchse', 'r') as value:
-            pp_value = int(value.read())
-            socket_is_configured = True
-    except (FileNotFoundError, ValueError):
-        pp_value = 32
-        socket_is_configured = False
-    log_debug(1, "check for socket: " + str(socket_is_configured) + " " + str(pp_value))
-    return [socket_is_configured, pp_value]
-
-
-# guess USB/modbus device name
-def detect_modbus_usb_port() -> str:
-    try:
-        with open("/dev/ttyUSB0"):
-            return "/dev/ttyUSB0"
-    except FileNotFoundError:
-        return "/dev/serial0"
-
-
-loglevel = 2
-try:
-    loglevel = int(read_from_ramdisk("lpdaemonloglevel"))
-except (FileNotFoundError, ValueError):
-    pass
-
-MaxEvseError = 5
-sdmid = 105
-sdm2id = 106
-actorstat = 0
-evsefailure = 0
-llmeterconfiglp1 = 0
-
-lp1evsehres = 0
-lp2evsehres = 0
-lp1solla = 0
-u1p3pstat = None
-u1p3plp2stat = None
-u1p3ptmpstat = 3
-u1p3plp2tmpstat = 3
-rfidtag = 0
-lp1countphasesinuse = 0
-lp2countphasesinuse = 0
-heartbeat = 0
-metercounter = 0
-actcooldown = 0
-actcooldowntimestamp = 0
-
-# check for openWB DUO in slave mode
-lp2installed = False
-try:
-    if int(read_from_ramdisk("issslp2act")) == 1:
-        lp2installed = True
-except (FileNotFoundError, ValueError):
-    log_debug(1, "Error reading issslp2act! Guessing cp2 is not configured.")
-init_gpio()
-init_values()
-socket_configured, pp = check_for_socket()
-seradd = detect_modbus_usb_port()
-# connect with USB/modbus device
-with ModbusSerialClient(method="rtu", port=seradd, baudrate=9600, stopbits=1, bytesize=8, timeout=1) as client:
-    # start our control loop
-    while True:
-        read_meter()
-        load_control_values()
-        time.sleep(1)
+Isss().loop()

--- a/runs/isss.py
+++ b/runs/isss.py
@@ -48,7 +48,8 @@ class UpdateValues:
     }
 
     def __init__(self, local_charge_point_num: int) -> None:
-        self.cp_num = str(Isss.get_cp_num(local_charge_point_num))
+        self.local_charge_point_num_str = str(local_charge_point_num)
+        self.cp_num_str = str(Isss.get_cp_num(local_charge_point_num))
         self.old_counter_state = None
 
     def update_values(self, counter_state: ChargepointState) -> None:
@@ -70,8 +71,9 @@ class UpdateValues:
 
     def _pub_values_to_1_9(self, key: str, value) -> None:
         def pub_value(topic: str, value):
-            pub_single("openWB/lp/"+self.cp_num+"/"+topic, payload=str(value), no_json=True)
-            pub_single("openWB/lp/"+self.cp_num+"/"+topic, payload=str(value), hostname=self.parent_wb, no_json=True)
+            pub_single("openWB/lp/"+self.local_charge_point_num_str+"/"+topic, payload=str(value), no_json=True)
+            pub_single("openWB/lp/"+self.cp_num_str+"/"+topic,
+                       payload=str(value), hostname=self.parent_wb, no_json=True)
         topic = self.MAP_KEY_TO_OLD_TOPIC[key]
         rounding = get_rounding_function_by_digits(2)
         if topic is not None:
@@ -94,13 +96,14 @@ class UpdateValues:
         if topic == "rfid" and value == "0":
             value = None
         if isinstance(value, (str, bool, type(None))):
-            pub_single("openWB/set/chargepoint/" + self.cp_num+"/get/"+topic, payload=value, hostname=self.parent_wb)
+            pub_single("openWB/set/chargepoint/" + self.cp_num_str +
+                       "/get/"+topic, payload=value, hostname=self.parent_wb)
         else:
             if isinstance(value, list):
-                pub_single("openWB/set/chargepoint/" + self.cp_num+"/get/"+topic,
+                pub_single("openWB/set/chargepoint/" + self.cp_num_str+"/get/"+topic,
                            payload=[rounding(v) for v in value], hostname=self.parent_wb)
             else:
-                pub_single("openWB/set/chargepoint/" + self.cp_num+"/get/"+topic,
+                pub_single("openWB/set/chargepoint/" + self.cp_num_str+"/get/"+topic,
                            payload=rounding(value), hostname=self.parent_wb)
 
 


### PR DESCRIPTION
Komplette Überarbeitung des ISSS-Daemons:
- Lesen und Schreiben der Ladepunkt-Daten in eigenes Modul ausgelagert. Dies kann bei der Duo für LP 1 und LP 2 initalisiert werden.
- Auslesen des SDM-Zählers erfolgt mit den Methoden aus dem Package-Modul
- neues Modul für den B32 Zähler hinzugefügt
- Lesen und Schreiben der EVSE-Register in eigenem Modul
- Phasenumschaltung und CP-Unterbrechung erfolgt in Threads und blockieren nicht mehr den Daemon.
- Die Buchse erbt die Klasse des internen Ladepunkts und fügt Methoden zum Öffnen und Schließen des Aktors hinzu.

Wenn der ISSS-Daemon stabil läuft, kann auch der redundante Code in buchse.py und autoevse.py damit ersetzt werden.