### PR TITLE
fix solaredge modbus contextmanager

### DIFF
--- a/packages/modules/solaredge/bat.py
+++ b/packages/modules/solaredge/bat.py
@@ -38,11 +38,10 @@ class SolaredgeBat:
 
     def read_state(self):
         unit = self.component_config["configuration"]["modbus_id"]
-        with self.__tcp_client:
-            soc = self.__tcp_client.read_holding_registers(
-                62852, ModbusDataType.FLOAT_32, wordorder=Endian.Little, unit=unit)
-            power = self.__tcp_client.read_holding_registers(
-                62836, ModbusDataType.FLOAT_32, wordorder=Endian.Little, unit=unit)
+        soc = self.__tcp_client.read_holding_registers(
+            62852, ModbusDataType.FLOAT_32, wordorder=Endian.Little, unit=unit)
+        power = self.__tcp_client.read_holding_registers(
+            62836, ModbusDataType.FLOAT_32, wordorder=Endian.Little, unit=unit)
 
         topic_str = "openWB/set/system/device/" + str(
             self.__device_id)+"/component/"+str(self.component_config["id"])+"/"

--- a/packages/modules/solaredge/counter.py
+++ b/packages/modules/solaredge/counter.py
@@ -26,51 +26,50 @@ class SolaredgeCounter:
         self.component_info = ComponentInfo.from_component_config(component_config)
 
     def update(self):
-        with self.__tcp_client:
-            def read_scaled_int16(address: int, count: int):
-                return scale_registers(
-                    self.__tcp_client.read_holding_registers(
-                        address,
-                        [ModbusDataType.INT_16] * (count+1),
-                        unit=self.component_config["configuration"]["modbus_id"])
-                )
+        def read_scaled_int16(address: int, count: int):
+            return scale_registers(
+                self.__tcp_client.read_holding_registers(
+                    address,
+                    [ModbusDataType.INT_16] * (count+1),
+                    unit=self.component_config["configuration"]["modbus_id"])
+            )
 
-            def read_scaled_uint32(address: int, count: int):
-                return scale_registers(
-                    self.__tcp_client.read_holding_registers(
-                        address,
-                        [ModbusDataType.UINT_32] * (count)+[ModbusDataType.INT_16],
-                        unit=self.component_config["configuration"]["modbus_id"])
-                )
+        def read_scaled_uint32(address: int, count: int):
+            return scale_registers(
+                self.__tcp_client.read_holding_registers(
+                    address,
+                    [ModbusDataType.UINT_32] * (count)+[ModbusDataType.INT_16],
+                    unit=self.component_config["configuration"]["modbus_id"])
+            )
 
-            # 40206: Total Real Power (sum of active phases)
-            # 40207/40208/40209: Real Power by phase
-            # 40210: AC Real Power Scale Factor
-            powers = [-power for power in read_scaled_int16(40206, 4)]
+        # 40206: Total Real Power (sum of active phases)
+        # 40207/40208/40209: Real Power by phase
+        # 40210: AC Real Power Scale Factor
+        powers = [-power for power in read_scaled_int16(40206, 4)]
 
-            # 40191/40192/40193: AC Current by phase
-            # 40194: AC Current Scale Factor
-            currents = read_scaled_int16(40191, 3)
+        # 40191/40192/40193: AC Current by phase
+        # 40194: AC Current Scale Factor
+        currents = read_scaled_int16(40191, 3)
 
-            # 40196/40197/40198: Voltage per phase
-            # 40203: AC Voltage Scale Factor
-            voltages = read_scaled_int16(40196, 7)[:3]
+        # 40196/40197/40198: Voltage per phase
+        # 40203: AC Voltage Scale Factor
+        voltages = read_scaled_int16(40196, 7)[:3]
 
-            # 40204: AC Frequency
-            # 40205: AC Frequency Scale Factor
-            frequency = read_scaled_int16(40204, 1)[0]
+        # 40204: AC Frequency
+        # 40205: AC Frequency Scale Factor
+        frequency = read_scaled_int16(40204, 1)[0]
 
-            # 40222/40223/40224: Power factor by phase (unit=%)
-            # 40225: AC Power Factor Scale Factor
-            power_factors = [power_factor / 100 for power_factor in read_scaled_int16(40222, 3)]
+        # 40222/40223/40224: Power factor by phase (unit=%)
+        # 40225: AC Power Factor Scale Factor
+        power_factors = [power_factor / 100 for power_factor in read_scaled_int16(40222, 3)]
 
-            # 40226: Total Exported Real Energy
-            # 40228/40230/40232: Total Exported Real Energy Phase (not used)
-            # 40234: Total Imported Real Energy
-            # 40236/40238/40240: Total Imported Real Energy Phase (not used)
-            # 40242: Real Energy Scale Factor
-            counter_values = read_scaled_uint32(40226, 8)
-            counter_exported, counter_imported = [counter_values[i] for i in [0, 4]]
+        # 40226: Total Exported Real Energy
+        # 40228/40230/40232: Total Exported Real Energy Phase (not used)
+        # 40234: Total Imported Real Energy
+        # 40236/40238/40240: Total Imported Real Energy Phase (not used)
+        # 40242: Real Energy Scale Factor
+        counter_values = read_scaled_uint32(40226, 8)
+        counter_exported, counter_imported = [counter_values[i] for i in [0, 4]]
 
         counter_state = CounterState(
             imported=counter_imported,

--- a/packages/modules/solaredge/external_inverter.py
+++ b/packages/modules/solaredge/external_inverter.py
@@ -45,11 +45,10 @@ class SolaredgeExternalInverter:
                     unit=self.component_config["configuration"]["modbus_id"])
             )
 
-        with self.__tcp_client:
-            # 40380 = "Meter 2/Total Real Power (sum of active phases)" (Watt)
-            # 40381/40382/40383: Real Power per Phase (not used)
-            # 40384 = Power Scale Factor
-            power = read_scaled_int16(40380, 4)[0]
+        # 40380 = "Meter 2/Total Real Power (sum of active phases)" (Watt)
+        # 40381/40382/40383: Real Power per Phase (not used)
+        # 40384 = Power Scale Factor
+        power = read_scaled_int16(40380, 4)[0]
         topic_str = "openWB/set/system/device/" + str(self.__device_id) + \
             "/component/" + str(self.component_config["id"])+"/"
         _, exported = self.__sim_count.sim_count(power, topic=topic_str, data=self.simulation, prefix="pv")

--- a/packages/modules/solaredge/inverter.py
+++ b/packages/modules/solaredge/inverter.py
@@ -52,17 +52,16 @@ class SolaredgeInverter:
                     [ModbusDataType.UINT_32] * (count)+[ModbusDataType.INT_16],
                     unit=self.component_config["configuration"]["modbus_id"])
             )
-        with self.__tcp_client:
-            # 40083 = AC Power value (Watt)
-            # 40084 = AC Power scale factor
-            power = read_scaled_int16(40083, 1)[0] * -1
+        # 40083 = AC Power value (Watt)
+        # 40084 = AC Power scale factor
+        power = read_scaled_int16(40083, 1)[0] * -1
 
-            # 40093 = AC Lifetime Energy production (Watt hours)
-            # 40095 = AC Lifetime scale factor
-            exported = read_scaled_uint32(40093, 1)[0]
-            # 40072/40073/40074 = AC Phase A/B/C Current value (Amps)
-            # 40075 = AC Current scale factor
-            currents = read_scaled_uint16(40072, 3)
+        # 40093 = AC Lifetime Energy production (Watt hours)
+        # 40095 = AC Lifetime scale factor
+        exported = read_scaled_uint32(40093, 1)[0]
+        # 40072/40073/40074 = AC Phase A/B/C Current value (Amps)
+        # 40075 = AC Current scale factor
+        currents = read_scaled_uint16(40072, 3)
 
         return InverterState(
             power=power,


### PR DESCRIPTION
Fix zu [https://openwb.de/forum/viewtopic.php?p=67867#p67867](https://openwb.de/forum/viewtopic.php?p=67867#p67867)
Das Auslesen der WR-Daten in Z.244 funktioniert, die Speicherdaten in Z. 255 sind ohne Timeout nicht abfragbar.