### PR TITLE
Socvwid p7

### DIFF
--- a/modules/soc_vwid/main.sh
+++ b/modules/soc_vwid/main.sh
@@ -4,6 +4,7 @@ RAMDISKDIR="$OPENWBBASEDIR/ramdisk"
 MODULEDIR=$(cd `dirname $0` && pwd)
 DMOD="EVSOC"
 CHARGEPOINT=$1
+export OPENWBBASEDIR RAMDISKDIR MODULEDIR
 
 # check if config file is already in env
 if [[ -z "$debug" ]]; then

--- a/modules/soc_vwid/soc_vwid.py
+++ b/modules/soc_vwid/soc_vwid.py
@@ -10,6 +10,17 @@ import time
 import json
 import os
 import pickle
+from datetime import datetime
+
+def logDebug(msg):
+    socLogFile= '/var/www/html/openWB/ramdisk/soc.log'
+    now = datetime.now()
+    timestamp = now.strftime("%Y-%m-%d %H:%M:%S")
+    line = timestamp + ": " + msg + "\n"
+    f = open(socLogFile, 'a')
+    f.write(line)
+    f.close()
+    return
 
 async def main():
 #    logging.basicConfig(level=logging.DEBUG)
@@ -42,9 +53,11 @@ async def main():
             tf = open(tokensFile, "rb")     # try to open tokens file
             w.tokens = pickle.load(tf)      # initialize tokens in vwid
             tokens_old = pickle.dumps(w.tokens) # remember current tokens
-            w.headers[Authorization] = Bearer %s % w.tokens["accessToken"]
+            w.headers['Authorization'] = 'Bearer %s' % w.tokens["accessToken"]
             tf.close()
         except Exception as e:
+            logDebug("tokens initialization exception: e="+str(e))
+            logDebug("tokens initialization exception: set tokens_old to initial value")
             tokens_old = bytearray(1)   # if no old token found set tokens_old to dummy value
 
         data = await w.get_status()
@@ -52,18 +65,21 @@ async def main():
             print (data['data']['batteryStatus']['currentSOC_pct'])
             try:
                 f = open(replyFile, 'w', encoding='utf-8')
-            except:
+            except Exception as e:
+                logDebug("replyFile open exception: e="+str(e))
+                logDebug("replyFile open Exception, remove existing file")
                 os.system("sudo rm "+replyFile)
                 f = open(replyFile, 'w', encoding='utf-8')
             json.dump(data, f, ensure_ascii=False, indent=4)
             f.close()
+            os.chmod(replyFile, 0o777)
             tokens_new = pickle.dumps(w.tokens)
             if ( tokens_new != tokens_old ):    # check for modified tokens
+                logDebug("tokens_new != tokens_old, rewrite tokens file")
                 tf = open(tokensFile, "wb") 
                 pickle.dump(w.tokens, tf) # write tokens file
                 tf.close()
-                os.system("sudo chown pi "+tokensFile)
-                os.system("sudo chgrp pi "+tokensFile)
+                os.chmod(tokensFile, 0o777)
 
 loop = asyncio.get_event_loop()
 loop.run_until_complete(main())

--- a/modules/soc_vwid/soc_vwid.py
+++ b/modules/soc_vwid/soc_vwid.py
@@ -59,13 +59,11 @@ async def main():
             f.close()
             tokens_new = pickle.dumps(w.tokens)
             if ( tokens_new != tokens_old ):    # check for modified tokens
-                try:
-                    tf = open(tokensFile, "wb") 
-                except:
-                    os.system("sudo rm "+tokensFile)
-                    tf = open(tokensFile, "wb") 
+                tf = open(tokensFile, "wb") 
                 pickle.dump(w.tokens, tf) # write tokens file
                 tf.close()
+                os.system("sudo chown pi "+tokensFile)
+                os.system("sudo chgrp pi "+tokensFile)
 
 loop = asyncio.get_event_loop()
 loop.run_until_complete(main())

--- a/modules/soc_vwid/soc_vwid.py
+++ b/modules/soc_vwid/soc_vwid.py
@@ -59,7 +59,11 @@ async def main():
             f.close()
             tokens_new = pickle.dumps(w.tokens)
             if ( tokens_new != tokens_old ):    # check for modified tokens
-                tf = open(tokensFile, "wb") 
+                try:
+                    tf = open(tokensFile, "wb") 
+                except:
+                    os.system("sudo rm "+tokensFile)
+                    tf = open(tokensFile, "wb") 
                 pickle.dump(w.tokens, tf) # write tokens file
                 tf.close()
 

--- a/modules/soc_vwid/soc_vwid.py
+++ b/modules/soc_vwid/soc_vwid.py
@@ -11,12 +11,15 @@ import json
 import os
 import pickle
 from datetime import datetime
+import getpass
 
-def logDebug(msg):
-    socLogFile= '/var/www/html/openWB/ramdisk/soc.log'
+def logDebug(cp,msg):
+    RAMDISKDIR=os.environ.get("RAMDISKDIR", "undefined")
+    socLogFile= RAMDISKDIR+'/soc.log'
     now = datetime.now()
     timestamp = now.strftime("%Y-%m-%d %H:%M:%S")
-    line = timestamp + ": " + msg + "\n"
+    pid=os.getpid()
+    line = timestamp + ": PID: " + str(pid) + ": Lp" + cp + ": " + msg + "\n"
     f = open(socLogFile, 'a')
     f.write(line)
     f.close()
@@ -41,8 +44,10 @@ async def main():
     id=args['user']
     pw=args['password']
     chargepoint=args['chargepoint']
-    replyFile= '/var/www/html/openWB/ramdisk/soc_vwid_replylp'+chargepoint
-    tokensFile= '/var/www/html/openWB/ramdisk/soc_vwid_tokens'+chargepoint
+    OPENWBBASEDIR=os.environ.get("OPENWBBASEDIR", "undefined")
+    RAMDISKDIR=os.environ.get("RAMDISKDIR", "undefined")
+    replyFile = RAMDISKDIR+'/soc_vwid_replylp'+chargepoint
+    tokensFile = RAMDISKDIR+'/soc_vwid_tokenslp'+chargepoint
 
     async with aiohttp.ClientSession() as session:
         w = libvwid.vwid(session)
@@ -56,8 +61,8 @@ async def main():
             w.headers['Authorization'] = 'Bearer %s' % w.tokens["accessToken"]
             tf.close()
         except Exception as e:
-            logDebug("tokens initialization exception: e="+str(e))
-            logDebug("tokens initialization exception: set tokens_old to initial value")
+            logDebug(chargepoint, "tokens initialization exception: e="+str(e))
+            logDebug(chargepoint, "tokens initialization exception: set tokens_old to initial value")
             tokens_old = bytearray(1)   # if no old token found set tokens_old to dummy value
 
         data = await w.get_status()
@@ -66,20 +71,30 @@ async def main():
             try:
                 f = open(replyFile, 'w', encoding='utf-8')
             except Exception as e:
-                logDebug("replyFile open exception: e="+str(e))
-                logDebug("replyFile open Exception, remove existing file")
+                logDebug(chargepoint, "replyFile open exception: e="+str(e)+"user: "+getpass.getuser())
+                logDebug(chargepoint, "replyFile open Exception, remove existing file")
                 os.system("sudo rm "+replyFile)
                 f = open(replyFile, 'w', encoding='utf-8')
             json.dump(data, f, ensure_ascii=False, indent=4)
             f.close()
-            os.chmod(replyFile, 0o777)
+            try:
+                os.chmod(replyFile, 0o777)
+            except Exception as e:
+                logDebug(chargepoint, "chmod replyFile exception, e="+str(e))
+                logDebug(chargepoint, "use sudo, user: "+getpass.getuser())
+                os.system("sudo chmod 0777 "+replyFile)
+
             tokens_new = pickle.dumps(w.tokens)
             if ( tokens_new != tokens_old ):    # check for modified tokens
-                logDebug("tokens_new != tokens_old, rewrite tokens file")
+                logDebug(chargepoint, "tokens_new != tokens_old, rewrite tokens file")
                 tf = open(tokensFile, "wb") 
                 pickle.dump(w.tokens, tf) # write tokens file
                 tf.close()
-                os.chmod(tokensFile, 0o777)
+                try:
+                    os.chmod(tokensFile, 0o777)
+                except Exception as e:
+                    logDebug(chargepoint, "chmod tokensFile exception, use sudo, e="+str(e)+"user: "+getpass.getuser())
+                    os.system("sudo chmod 0777 "+tokensFile)
 
 loop = asyncio.get_event_loop()
 loop.run_until_complete(main())


### PR DESCRIPTION
Current approach forces a new login in the VW Servers on each inquiry of the SOC.
This may cause a reaction on VW side in form of additional measures to make programmatic access from non-VW clients more difficult.
The unrequired login also costs about 50% of the total runtime.

Each login returns a new set of tokens.

The PR stores the tokens to a file in ramdisk (soc_vwid_tokensX (X=number of Ladepunkt).
On each query the tokens file is restored to the tokens in the vwid object and the tokens are reused until they become invalid.
If invalid the new tokens are stored in the file.

Tests done:
- Run without existing tokens file: works, SoC is returned, new file is created.
- Run with existing and valid tokens file: works, SoC is returned
- Run with existing but invalid tokens file: SoC is returned, new file is created.
- Run with tokens file owned by root: permission error is handled

Credits to gvz for the hint: https://openwb.de/forum/viewtopic.php?p=68055#p68055
