### PR TITLE
Solarmax 2 , pv leistung als unit32 lesen

### DIFF
--- a/modules/wr2_solarmax/main.sh
+++ b/modules/wr2_solarmax/main.sh
@@ -1,0 +1,15 @@
+#!/bin/bash
+OPENWBBASEDIR=$(cd "$(dirname "$0")/../../" && pwd)
+RAMDISKDIR="${OPENWBBASEDIR}/ramdisk"
+#DMOD="PV"
+DMOD="MAIN"
+
+if [ ${DMOD} == "MAIN" ]; then
+	MYLOGFILE="${RAMDISKDIR}/openWB.log"
+else
+	MYLOGFILE="${RAMDISKDIR}/nurpv.log"
+fi
+
+bash "$OPENWBBASEDIR/packages/legacy_run.sh" "modules.solarmax.device" "inverter" "${pv2ip}" "2">>"${MYLOGFILE}" 2>&1
+
+cat "$RAMDISKDIR/pv2watt"

--- a/packages/modules/solarmax/inverter.py
+++ b/packages/modules/solarmax/inverter.py
@@ -33,7 +33,7 @@ class SolarmaxInverter:
 
     def update(self) -> None:
         with self.__tcp_client:
-            power = self.__tcp_client.read_holding_registers(4152, ModbusDataType.UINT_16, unit=self.__modbus_id) * -1
+            power = self.__tcp_client.read_holding_registers(4151, ModbusDataType.UINT_32, unit=self.__modbus_id) * -1
         power = power / 10
         topic_str = "openWB/set/system/device/" + \
             str(self.__device_id)+"/component/" + \

--- a/web/settings/modulconfigpv.php
+++ b/web/settings/modulconfigpv.php
@@ -1126,6 +1126,7 @@
 									</optgroup>
 									<optgroup label="andere Hersteller">
 										<option <?php if($pv2wattmodulold == "wr2_kostalpiko") echo "selected" ?> value="wr2_kostalpiko">Kostal Piko</option>
+										<option <?php if($pv2wattmodulold == "wr2_solarmax") echo "selected" ?> value="wr2_solarmax">Solarmax</option>
 										<option <?php if($pv2wattmodulold == "wr2_kostalpikovar2") echo "selected" ?> value="wr2_kostalpikovar2">Kostal Piko alt</option>
 										<option <?php if($pv2wattmodulold == "wr2_kostalsteca") echo "selected" ?> value="wr2_kostalsteca">Kostal Piko MP oder Steca Grid Coolcept</option>
 										<option <?php if($pv2wattmodulold == "wr2_smamodbus") echo "selected" ?> value="wr2_smamodbus">SMA Wechselrichter</option>
@@ -1365,6 +1366,9 @@
 									showSection('#pv2ipdiv');
 								}
 								if($('#pv2wattmodul').val() == 'wr2_solax') {
+									showSection('#pv2ipdiv');
+								}
+								if($('#pv2wattmodul').val() == 'wr2_solarmax') {
 									showSection('#pv2ipdiv');
 								}
 								if($('#pv2wattmodul').val() == 'wr2_sungrow') {


### PR DESCRIPTION
Solarmax wird nun auch als zweiter Wr unterstützte PV Leistung wird als uint 32 ausgelesen...