### PR TITLE
Ladelog historische Kosten

### DIFF
--- a/ladelog.sh
+++ b/ladelog.sh
@@ -233,8 +233,10 @@ processChargepoint(){
 					else
 						lademoduslogvalue=$lademodus
 					fi
-					openwbDebugLog "CHARGESTAT" 1 "start=$start; end=$jetzt; timeCharged=${ladedauer}m ($ladedauertext); energyCharged=${bishergeladen}kWh; rangeCharged=${gelr}km; averagePower=${ladegeschw}kW"
-					sed -i "1i$start,$jetzt,$gelr,$bishergeladen,$ladegeschw,$ladedauertext,$chargePointNumber,$lademoduslogvalue,$rfid" "$monthlyfile"
+					# calculate costs
+					kosten=$(echo "scale=2;$bishergeladen * $preisjekwh" |bc)
+					openwbDebugLog "CHARGESTAT" 1 "start=$start; end=$jetzt; timeCharged=${ladedauer}m ($ladedauertext); energyCharged=${bishergeladen}kWh; rangeCharged=${gelr}km; averagePower=${ladegeschw}kW; costs=${kosten}"
+					sed -i "1i$start,$jetzt,$gelr,$bishergeladen,$ladegeschw,$ladedauertext,$chargePointNumber,$lademoduslogvalue,$rfid,$kosten" "$monthlyfile"
 					# send push message if configured
 					if (( pushbenachrichtigung == 1 )) ; then
 						if (( pushbstopl == 1 )) ; then

--- a/runs/transferladelog.sh
+++ b/runs/transferladelog.sh
@@ -1,18 +1,22 @@
 #!/bin/bash
-if [ -e /var/www/html/openWB/web/ladelog ]; then
-	mkdir /var/www/html/openWB/web/logging/data/ladelog
-	oldlog="/var/www/html/openWB/web/ladelog"
+OPENWBBASEDIR=$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)
+
+if [ -e "$OPENWBBASEDIR/web/ladelog" ]; then
+	mkdir "$OPENWBBASEDIR/web/logging/data/ladelog"
+	oldlog="${OPENWBBASEDIR}/web/ladelog"
 	while IFS= read -r line
 	do
 		  #echo "$line"
-		year=$(echo $line | cut -c 7-8 )
-		month=$(echo $line | cut -c 4-5 )
+		year=$(echo "$line" | cut -c 7-8 )
+		month=$(echo "$line" | cut -c 4-5 )
 		if [[ $year == "19" ]] ||  [[ $year == "20" ]]; then
-			echo $line >> /var/www/html/openWB/web/logging/data/ladelog/20$year$month.csv 
+			echo "$line" >> "${OPENWBBASEDIR}/web/logging/data/ladelog/20$year$month.csv "
 		fi
 	  done < "$oldlog"
-	  rm /var/www/html/openWB/web/ladelog
-	  chown -R pi:pi /var/www/html/openWB/web/logging/data/ladelog/
-	  chmod 777 /var/www/html/openWB/web/logging/data/ladelog/*
-
+	  rm "${OPENWBBASEDIR}/web/ladelog"
+	  chown -R pi:pi "${OPENWBBASEDIR}/web/logging/data/ladelog/"
+	  chmod 777 "${OPENWBBASEDIR}/web/logging/data/ladelog/*"
 fi
+
+# upgrade charge log data with costs
+"${OPENWBBASEDIR}/runs/upgradeChargeLog.py" "$preisjekwh"

--- a/runs/upgradeChargeLogs.py
+++ b/runs/upgradeChargeLogs.py
@@ -1,0 +1,54 @@
+#!/usr/bin/env python3
+import csv
+import argparse
+from glob import glob
+import os
+from pathlib import Path
+from typing import Iterable
+
+parser = argparse.ArgumentParser()
+parser.add_argument("-p", "--price", type=float, default=0.3, help="price per kWh, defaults to 0.30")
+parser.add_argument("-v", "--verbose", action="store_true", help="verbose debug output")
+args = parser.parse_args()
+
+
+def debugPrint(text: str):
+    if(args.verbose):
+        print(text)
+
+
+CHARGE_LOG_PATH = Path(__file__).resolve().parents[1] / "web" / "logging" / "data" / "ladelog"
+
+print("upgrading charge logs with a price of " + str(args.price) + "€/kWh")
+
+csv_files = glob(str(CHARGE_LOG_PATH) + '/*.csv')
+print(csv_files)
+
+for current_filename in csv_files:
+    print("checking file \"" + current_filename + "\"")
+    current_file = (CHARGE_LOG_PATH / current_filename)
+    new_file = (CHARGE_LOG_PATH / (current_filename + '.new'))
+    data_modified = False
+    with current_file.open("r") as log_file:
+        data = list(csv.reader(log_file, delimiter=","))
+        for row in data:
+            if len(row) == 10:
+                debugPrint("file already upgraded")
+                break
+            if len(row) == 9:
+                costs = round(float(row[3]) * args.price, 2)
+                debugPrint("costs missing! adding calculated costs: " + str(costs))
+                row.append(costs)
+                debugPrint(row)
+                data_modified = True
+            else:
+                print("unexpected row format")
+                print(row)
+        if data_modified:
+            debugPrint("file was modified")
+            with new_file.open("w") as new_log_file:
+                writer = csv.writer(new_log_file, delimiter=",", lineterminator="\n")
+                writer.writerows(data)
+            os.remove(str(current_file))
+            os.rename(str(new_file), str(current_file))
+print("upgrading charge logs done")

--- a/web/logging/chargelog/ladelog.js
+++ b/web/logging/chargelog/ladelog.js
@@ -178,8 +178,8 @@ function putladelogtogether() {
 		}
 
 		parsedlog = parseResult(ladelogdata);
-		var totalkwh = "0";
-		var totalkm = "0";
+		var totalkwh = 0;
+		var totalkm = 0;
 		var filterrfid = 0;
 		var rfidtag = "";
 
@@ -248,8 +248,8 @@ function putladelogtogether() {
 		if ( testout.length >= 1 ) {
 			var content = '<table class="table"> <thead><tr><th scope="col">Startzeit</th><th scope="col">Endzeit</th><th scope="col" class="text-right">geladene km</th><th scope="col" class="text-right">kWh</th><th scope="col" class="text-right">mit kW</th><th scope="col" class="text-right">Ladedauer</th><th scope="col">Ladepunkt</th><th scope="col">Lademodus</th><th scope="col">RFID Tag</th><th scope="col" class="text-right">Kosten</th></tr></thead> <tbody>';
 			var rowcount=0;
-			var avgkw="0";
-			var totalprice="0";
+			var avgkw=0;
+			var totalprice=0;
 
 			testout.forEach(function(row) {
 				var price = "0"
@@ -257,7 +257,6 @@ function putladelogtogether() {
 				content += "<tr>";
 				var cellcount=0;
 				row.forEach(function(cell) {
-
 					cellcount+=1;
 					switch (cellcount){
 						case 1: // Startzeit
@@ -266,8 +265,9 @@ function putladelogtogether() {
 							content += "<td>" + dateString + "</td>";
 							break;
 						case 3: // geladene km
-							totalkm = parseFloat(totalkm) + parseFloat(cell);
-							content += "<td class=\"text-right\">" + cell + "</td>";
+							var km = parseFloat(cell);
+							totalkm += km
+							content += "<td class=\"text-right\">" + km.toLocaleString(undefined, {minimumFractionDigits: 0, maximumFractionDigits: 0}) + "</td>";
 							break;
 						case 4: // geladene kWh
 							totalkwh = parseFloat(totalkwh) + parseFloat(cell);
@@ -276,8 +276,9 @@ function putladelogtogether() {
 							content += "<td class=\"text-right\">" + parseFloat(cell).toLocaleString(undefined, {minimumFractionDigits: 2, maximumFractionDigits: 2}) + "</td>";
 							break;
 						case 5: // Ladeleistung kW
-							avgkw = parseFloat(avgkw) + parseFloat(cell);
-							content += "<td class=\"text-right\">" + parseFloat(cell).toLocaleString(undefined, {minimumFractionDigits: 2, maximumFractionDigits: 2}) + "</td>";
+							var kW = parseFloat(cell);
+							avgkw += kW
+							content += "<td class=\"text-right\">" + kW.toLocaleString(undefined, {minimumFractionDigits: 2, maximumFractionDigits: 2}) + "</td>";
 							break;
 						case 6: // Ladedauer
 							timeArray = cell.split(" ");
@@ -293,22 +294,30 @@ function putladelogtogether() {
 							}
 							content += "<td class=\"text-right\">" + hourString + ":" + minuteString + "</td>";
 							break;
+						// 7: Ladepunkt-Nummer
 						case 8: // Lademodus
-							if (cell == 2) {
-								content += "<td>" + "Nur PV" + "</td>" ;
-							} else if (cell == 0) {
-								content += "<td>" + "Sofort" + "</td>" ;
-							} else if (cell == 1) {
-								content += "<td>" + "Min+PV" + "</td>" ;
-							} else if (cell == 4) {
-								content += "<td>" + "Standby" + "</td>" ;
-							} else if (cell == 3) {
-								content += "<td>" + "Standby" + "</td>" ;
-							} else if (cell == 7) {
-								content += "<td>" + "Nachtladen" + "</td>" ;
-							} else {
-								content += "<td>" + cell + "</td>" ;
+							content += "<td>";
+							switch (cell) {
+								case 0:
+									content += "Sofort";
+									break;
+								case 1:
+									content += "Min+PV";
+									break;
+								case 2:
+									content += "Nur PV";
+									break;
+								case 3:
+								case 4:
+									content += "Standby";
+									break;
+								case 7:
+									content += "Nachtladen";
+									break;
+								default:
+									content += cell;
 							}
+							content += "</td>";
 							break;
 						default:
 							content += "<td>" + cell + "</td>";

--- a/web/logging/chargelog/ladelog.js
+++ b/web/logging/chargelog/ladelog.js
@@ -1,7 +1,5 @@
 var initialladelogread = 1;
 var ConfiguredChargePoints = 0;
-var PriceForKWh = 0.30;
-var gotprice = 0;
 var retries = 0;
 
 var clientuid = Math.random().toString(36).replace(/[^a-z]+/g, '').substr(0, 5);
@@ -46,7 +44,6 @@ var thevalues = [
 	["openWB/system/MonthLadelogData11"],
 	["openWB/system/MonthLadelogData12"],
 	["openWB/system/ConfiguredChargePoints"],
-	["openWB/system/priceForKWh"],
 	["openWB/global/rfidConfigured"],
 	["openWB/lp/1/boolChargePointConfigured"],
 	["openWB/lp/2/boolChargePointConfigured"],
@@ -84,12 +81,6 @@ function handlevar(mqttmsg, mqttpayload) {
 				showSection('#chargep' + index, false);
 				break;
 		}
-	}
-	else if ( mqttmsg == "openWB/system/priceForKWh" ) {
-		PriceForKWh = mqttpayload;
-		gotprice = 1;
-		putladelogtogether();
-
 	}
 	else if( mqttmsg.match( /^openwb\/system\/MonthLadelogData[1-9][0-9]*$/i )){
 		// respective month index
@@ -158,7 +149,7 @@ function selectladelogclick(newdate){
 }
 
 function putladelogtogether() {
-	if ( (ladelog1 == 1) && (ladelog2 == 1) && (ladelog3 == 1) && (ladelog4 == 1) && (ladelog5 == 1) && (ladelog6 == 1) && (ladelog7 == 1) && (ladelog8 == 1) && (ladelog9 == 1) && (ladelog10 == 1) && (ladelog11 == 1) && (ladelog12 == 1) && (gotprice == 1) ){
+	if ( (ladelog1 == 1) && (ladelog2 == 1) && (ladelog3 == 1) && (ladelog4 == 1) && (ladelog5 == 1) && (ladelog6 == 1) && (ladelog7 == 1) && (ladelog8 == 1) && (ladelog9 == 1) && (ladelog10 == 1) && (ladelog11 == 1) && (ladelog12 == 1) ){
 		var ladelogdata = ladelog1p + "\n" + ladelog2p + "\n" + ladelog3p + "\n" + ladelog4p + "\n" + ladelog5p + "\n" + ladelog6p + "\n" + ladelog7p + "\n" + ladelog8p + "\n" + ladelog9p + "\n" + ladelog10p + "\n" + ladelog11p + "\n" + ladelog12p;
 		ladelogdata = ladelogdata.replace(/^\s*[\n]/gm, '');
 		initialladelogread = 1 ;

--- a/web/logging/chargelog/ladelog.js
+++ b/web/logging/chargelog/ladelog.js
@@ -252,7 +252,6 @@ function putladelogtogether() {
 			var totalprice=0;
 
 			testout.forEach(function(row) {
-				var price = "0"
 				rowcount+=1;
 				content += "<tr>";
 				var cellcount=0;
@@ -270,10 +269,9 @@ function putladelogtogether() {
 							content += "<td class=\"text-right\">" + km.toLocaleString(undefined, {minimumFractionDigits: 0, maximumFractionDigits: 0}) + "</td>";
 							break;
 						case 4: // geladene kWh
-							totalkwh = parseFloat(totalkwh) + parseFloat(cell);
-							price = parseFloat(cell) * PriceForKWh;
-							totalprice = parseFloat(totalprice) + parseFloat(price);
-							content += "<td class=\"text-right\">" + parseFloat(cell).toLocaleString(undefined, {minimumFractionDigits: 2, maximumFractionDigits: 2}) + "</td>";
+							var kWh = parseFloat(cell);
+							totalkwh += kWh;
+							content += "<td class=\"text-right\">" + kWh.toLocaleString(undefined, {minimumFractionDigits: 2, maximumFractionDigits: 2}) + "</td>";
 							break;
 						case 5: // Ladeleistung kW
 							var kW = parseFloat(cell);
@@ -319,11 +317,16 @@ function putladelogtogether() {
 							}
 							content += "</td>";
 							break;
+						// 9: RFID-Tag
+						case 10:
+							var price = parseFloat(cell);
+							totalprice += price;
+							content += "<td class=\"text-right\">" + price.toLocaleString(undefined, {minimumFractionDigits: 2, maximumFractionDigits: 2}) + "€</td>" ;
+							break;
 						default:
 							content += "<td>" + cell + "</td>";
 					}
 				});
-				content += "<td class=\"text-right\">" + price.toLocaleString(undefined, {minimumFractionDigits: 2, maximumFractionDigits: 2}) + "€</td>" ;
 				content += "</tr>";
 			});
 

--- a/web/logging/chargelog/ladelog.php
+++ b/web/logging/chargelog/ladelog.php
@@ -39,7 +39,7 @@
 		<script src="js/bootstrap4-toggle/bootstrap4-toggle.min.js"></script>
 		<script src="js/mqttws31.js"></script>
 		<script src="logging/chargelog/helperFunctions.js?ver=20210202"></script>
-		<script src="logging/chargelog/ladelog.js?ver=20210202"></script>
+		<script src="logging/chargelog/ladelog.js?ver=20220720"></script>
 		<script>
 			function getCookie(cname) {
 				var name = cname + '=';


### PR DESCRIPTION
Die Kosten einer Ladung wurden bei der Anzeige im Frontend mit dem aktuell hinterlegten Preis neu berechnet. Das hatte zur Folge, dass bei einer Änderung des Preises je kWh auch die historischen Daten immer mit diesem neuen Preis berechnet und daher womöglich falsch angezeigt wurden.

Der PR verschiebt die Berechnung der Ladekosten in das Backend. Die Kosten werden in der CSV-Datei hinterlegt und im Frontend nur angezeigt. Vorhandene CSV-Dateien werden einmalig mit dem aktuellen Preis aktualisiert.