### PR TITLE
do not run atreboot.sh as root

### DIFF
--- a/openwb-install.sh
+++ b/openwb-install.sh
@@ -57,17 +57,6 @@ else
 	echo "...created"
 fi
 
-echo "check for crontab"
-if grep -Fxq "@reboot /var/www/html/openWB/runs/atreboot.sh &" /var/spool/cron/crontabs/root
-then
-	echo "...ok"
-else
-	echo "@reboot /var/www/html/openWB/runs/atreboot.sh &" >> /tmp/tocrontab
-	crontab -l -u root | cat - /tmp/tocrontab | crontab -u root -
-	rm /tmp/tocrontab
-	echo "...added"
-fi
-
 # start mosquitto
 sudo service mosquitto start
 
@@ -124,4 +113,4 @@ chmod +x /var/www/html/openWB/runs/*
 chmod +x /var/www/html/openWB/*.sh
 touch /var/log/openWB.log
 chmod 777 /var/log/openWB.log
-/var/www/html/openWB/runs/atreboot.sh
+sudo -u pi /var/www/html/openWB/runs/atreboot.sh

--- a/runs/update.sh
+++ b/runs/update.sh
@@ -92,4 +92,4 @@ sudo chmod 777 /var/www/html/openWB/web/lade.log
 sleep 2
 
 # now treat system as in booting state
-nohup sudo /var/www/html/openWB/runs/atreboot.sh >> /var/log/openWB.log 2>&1 &
+nohup /var/www/html/openWB/runs/atreboot.sh >> /var/log/openWB.log 2>&1 &


### PR DESCRIPTION
Ich habe vor kurzem ein Update meiner openWB auf die aktuelle Nightly gemacht. Jetzt fällt mir auf, dass der Verbrauch meiner Klimaanlage nicht mehr angezeigt wird. Im smarthome-log finde ich:
```
2022-07-21 11:06:39: EVU Bezug(-)/Einspeisung(+): 225 max Speicherladung: 0
2022-07-21 11:06:39: Uberschuss: 225 Uberschuss mit Offset: 225
2022-07-21 11:06:39: Speicher Entladung(-)/Ladung(+): 0 SpeicherSoC: 100
2022-07-21 11:06:39: (1) Leistungsmessung durch sdm120
Traceback (most recent call last):
  File "/var/www/html/openWB/modules/smarthome/sdm120/sdm120.py", line 31, in <module>
    f1 = open('/var/www/html/openWB/ramdisk/smarthome_device_ret' + str(devicenumber), 'w')
PermissionError: [Errno 13] Permission denied: '/var/www/html/openWB/ramdisk/smarthome_device_ret1'
2022-07-21 11:06:40: Device none1Klimaanlage Fehlermeldung: [Errno 13] Permission denied: '/var/www/html/openWB/ramdisk/device1_watt'
2022-07-21 11:06:40: (2) Leistungsmessung durch http
2022-07-21 11:06:40: (2) ELW rel: 0 oncnt/onstandby/time: 0/0/0 Status: 10 akt: 45 Z Hw: 0
2022-07-21 11:06:40: Total Watt abschaltbarer smarthomedevices: 0
2022-07-21 11:06:40: Total Watt nichtabschaltbarer smarthomedevices: 225
2022-07-21 11:06:40: Total Watt nicht im Hausverbrauch: 225
```
Wenn ich mal die Berechtigungen nachschaue steht dort:
```
$ ls -l /var/www/html/openWB/ramdisk/device1_watt
-rw-r--r-- 1 root root 3 Jul 18 20:34 /var/www/html/openWB/ramdisk/device1_watt
```
Warum gehört diese Datei root?

Geschrieben wird die Datei [hier](https://github.com/snaptec/openWB/blob/fc22252d4843711a23866a06946b2ae4b6be2adc/runs/smarthomehandler.py#L92) und [hier](https://github.com/snaptec/openWB/blob/fc22252d4843711a23866a06946b2ae4b6be2adc/runs/smarthomehandler.py#L828) in der `smarthomehandler.py`.

Die `smarthomehandler.py` wiederrrum wird aufgerufen in der [atreboot.sh](https://github.com/snaptec/openWB/blob/5d3f02905112363ee74430704ef0b2e70f21c037/runs/atreboot.sh#L126) und der [cron5min.sh](https://github.com/snaptec/openWB/blob/eae1f6a61b14c530ced7b4cb35d5cadf6e189296/runs/cron5min.sh#L330).

`ps aux` zeigt mir, dass da eine atreboot.sh als root läuft. Seit drei Tagen!
```
root     25125  0.0  0.2   3360  2444 ?        S    Jul18   0:00 /bin/bash /var/www/html/openWB/runs/atreboot.sh
```
Das gehört doch sicherlich auch nicht so. Solange geht das log nicht zurück, da kann ich nicht nachschauen was da los ist.

`crontab -l` zeigt mir, dass sowohl die `atreboot.sh` als auch die `cron5min.sh` für den Nutzer `pi` konfiguriert sind und entsprechend als dieser Nutzer laufen sollten und NICHT als root. Einmal abgepasst zeigt mir, dass `cron5min.sh` auch wirklich als `pi` läuft.

In der [openwb-install.sh](https://github.com/snaptec/openWB/blob/9e25be256b9614385c39c63c873e99f8c283df72/openwb-install.sh#L61-L69) wird das `atreboot.sh` auch für den Nutzer root angelegt. Wird allerdings in der [atreboot.sh](https://github.com/snaptec/openWB/blob/3ebaf9c2439a01a44c7e285362151544d3a8912f/runs/atreboot.sh#L152-L159) auch direkt wieder entfernt. Etwas unnötig dann ;-). Auch immernoch in der [openwb-install.sh](https://github.com/snaptec/openWB/blob/9e25be256b9614385c39c63c873e99f8c283df72/openwb-install.sh#L127) wird die `atreboot.sh` als root aufgerufen, vorrausgesetzt das Script selbst läuft bereits als root, was der Fall sein müsste, denn sonst dürften das `apt-get install` ganz oben nicht tun.

In der [update.sh](https://github.com/snaptec/openWB/blob/6c8ed117801d6e7334c5bd3de134138734537f3f/runs/update.sh#L95) wird die `atreboot.sh` als `root` ausgeführt. Das sollte wohl auch nicht sein?


Dieser PR entfernt das Anlagen von @reboot als root (nicht nötig, der korrekte Eintrag erfolgt in der [atreboot.sh](https://github.com/snaptec/openWB/blob/3ebaf9c2439a01a44c7e285362151544d3a8912f/runs/atreboot.sh#L190-L193) und diese wird auch am Ende der openwb-install.sh aufgerufen. Außerdem entfernt es das `sudo` für die `atreboot.sh` in der `update.sh`.