### PR TITLE
add charge log upgrade for data before 3/2020

### DIFF
--- a/runs/upgradeChargeLogs.py
+++ b/runs/upgradeChargeLogs.py
@@ -35,16 +35,19 @@ for current_file in csv_files:
         data = list(csv.reader(log_file, delimiter=","))
         for row in data:
             if len(row) == 10:
-                log.debug("file \"" + current_file.name + "\" already upgraded")
-                break
-            if len(row) == 9:
+                log.debug("file \"" + current_file.name + "\" row already upgraded")
+            if len(row) == 8:  # format until 2020/02 without rfid tag
+                log.debug("rfid tag missing! adding \"0\" as default tag")
+                row.append(0)
+                data_modified = True
+            if len(row) == 9:  # format until 2022/07 without costs
                 costs = round(float(row[3]) * args.price, 2)
                 log.debug("costs missing! adding calculated costs: " + str(costs))
                 row.append(costs)
                 log.debug(row)
                 data_modified = True
             else:
-                if len(row) != 0:
+                if len(row) not in [0, 10]:
                     log.error("file \"" + current_file.name + "\": unexpected row format: " + str(row))
         if data_modified:
             log.debug("file was modified")


### PR DESCRIPTION
- charge log entries before 03/2020 had no rfid tag and were not upgraded as the expected row length did not match
- add case to upgrade rows with 8 values
- do not break after first row matches new length of 10 values to also upgrade already partial modified files