### PR TITLE
undo workaround component info

### DIFF
--- a/packages/modules/alpha_ess/bat.py
+++ b/packages/modules/alpha_ess/bat.py
@@ -1,10 +1,10 @@
 #!/usr/bin/env python3
 import logging
 import time
-from typing import Dict
+from typing import Dict, Union
 
-from modules.alpha_ess.config import AlphaEssBatSetup, AlphaEssConfiguration
 from dataclass_utils import dataclass_from_dict
+from modules.alpha_ess.config import AlphaEssBatSetup, AlphaEssConfiguration
 from modules.common import modbus
 from modules.common import simcount
 from modules.common.component_state import BatState
@@ -18,7 +18,7 @@ log = logging.getLogger(__name__)
 
 class AlphaEssBat:
     def __init__(self, device_id: int,
-                 component_config: Dict,
+                 component_config: Union[Dict, AlphaEssBatSetup],
                  tcp_client: modbus.ModbusTcpClient_,
                  device_config: AlphaEssConfiguration) -> None:
         self.__device_id = device_id
@@ -27,7 +27,7 @@ class AlphaEssBat:
         self.__sim_count = simcount.SimCountFactory().get_sim_counter()()
         self.simulation = {}
         self.__store = get_bat_value_store(self.component_config.id)
-        self.component_info = ComponentInfo.from_component_config(component_config)
+        self.component_info = ComponentInfo.from_component_config(self.component_config)
 
     def update(self, unit_id: int) -> None:
         # keine Unterschiede zwischen den Versionen

--- a/packages/modules/alpha_ess/counter.py
+++ b/packages/modules/alpha_ess/counter.py
@@ -1,9 +1,9 @@
 #!/usr/bin/env python3
 import time
-from typing import Callable, Dict
+from typing import Callable, Dict, Union
 
-from modules.alpha_ess.config import AlphaEssConfiguration, AlphaEssCounterSetup
 from dataclass_utils import dataclass_from_dict
+from modules.alpha_ess.config import AlphaEssConfiguration, AlphaEssCounterSetup
 from modules.common import modbus
 from modules.common.component_state import CounterState
 from modules.common.component_type import ComponentDescriptor
@@ -13,14 +13,15 @@ from modules.common.store import get_counter_value_store
 
 
 class AlphaEssCounter:
-    def __init__(self, device_id: int,
-                 component_config: Dict,
+    def __init__(self,
+                 device_id: int,
+                 component_config: Union[Dict, AlphaEssCounterSetup],
                  tcp_client: modbus.ModbusTcpClient_,
                  device_config: AlphaEssConfiguration) -> None:
         self.component_config = dataclass_from_dict(AlphaEssCounterSetup, component_config)
         self.__tcp_client = tcp_client
         self.__store = get_counter_value_store(self.component_config.id)
-        self.component_info = ComponentInfo.from_component_config(component_config)
+        self.component_info = ComponentInfo.from_component_config(self.component_config)
         self.__device_config = device_config
 
     def update(self, unit_id: int):

--- a/packages/modules/alpha_ess/inverter.py
+++ b/packages/modules/alpha_ess/inverter.py
@@ -1,5 +1,8 @@
 #!/usr/bin/env python3
-from typing import Dict
+from typing import Dict, Union
+
+from dataclass_utils import dataclass_from_dict
+from modules.alpha_ess.config import AlphaEssConfiguration, AlphaEssInverterSetup
 from modules.common import modbus
 from modules.common import simcount
 from modules.common.component_state import InverterState
@@ -8,13 +11,10 @@ from modules.common.fault_state import ComponentInfo
 from modules.common.modbus import ModbusDataType, Number
 from modules.common.store import get_inverter_value_store
 
-from modules.alpha_ess.config import AlphaEssConfiguration, AlphaEssInverterSetup
-from dataclass_utils import dataclass_from_dict
-
 
 class AlphaEssInverter:
     def __init__(self, device_id: int,
-                 component_config: Dict,
+                 component_config: Union[Dict, AlphaEssInverterSetup],
                  tcp_client: modbus.ModbusTcpClient_,
                  device_config: AlphaEssConfiguration) -> None:
         self.__device_id = device_id
@@ -23,7 +23,7 @@ class AlphaEssInverter:
         self.__sim_count = simcount.SimCountFactory().get_sim_counter()()
         self.simulation = {}
         self.__store = get_inverter_value_store(self.component_config.id)
-        self.component_info = ComponentInfo.from_component_config(component_config)
+        self.component_info = ComponentInfo.from_component_config(self.component_config)
         self.__device_config = device_config
 
     def update(self, unit_id: int) -> None:

--- a/packages/modules/batterx/bat.py
+++ b/packages/modules/batterx/bat.py
@@ -17,7 +17,7 @@ class BatterXBat:
         self.__sim_count = simcount.SimCountFactory().get_sim_counter()()
         self.__simulation = {}
         self.__store = get_bat_value_store(self.component_config.id)
-        self.component_info = ComponentInfo.from_component_config(component_config)
+        self.component_info = ComponentInfo.from_component_config(self.component_config)
 
     def update(self, resp: Dict) -> None:
         power = resp["1121"]["1"]

--- a/packages/modules/batterx/counter.py
+++ b/packages/modules/batterx/counter.py
@@ -20,7 +20,7 @@ class BatterXCounter:
         self.__sim_count = simcount.SimCountFactory().get_sim_counter()()
         self.simulation = {}
         self.__store = get_counter_value_store(self.component_config.id)
-        self.component_info = ComponentInfo.from_component_config(component_config)
+        self.component_info = ComponentInfo.from_component_config(self.component_config)
 
     def update(self, resp: Dict) -> None:
         power = resp["2913"]["0"]

--- a/packages/modules/batterx/inverter.py
+++ b/packages/modules/batterx/inverter.py
@@ -17,7 +17,7 @@ class BatterXInverter:
         self.__sim_count = simcount.SimCountFactory().get_sim_counter()()
         self.simulation = {}
         self.__store = get_inverter_value_store(self.component_config.id)
-        self.component_info = ComponentInfo.from_component_config(component_config)
+        self.component_info = ComponentInfo.from_component_config(self.component_config)
 
     def update(self, resp: Dict) -> None:
         power = resp["1634"]["0"] * -1

--- a/packages/modules/byd/bat.py
+++ b/packages/modules/byd/bat.py
@@ -24,7 +24,7 @@ class BYDBat:
         self.__sim_count = simcount.SimCountFactory().get_sim_counter()()
         self.simulation = {}
         self.__store = get_bat_value_store(self.component_config.id)
-        self.component_info = ComponentInfo.from_component_config(component_config)
+        self.component_info = ComponentInfo.from_component_config(self.component_config)
 
     def update(self) -> None:
         power, soc = self.get_values()

--- a/packages/modules/carlo_gavazzi/counter.py
+++ b/packages/modules/carlo_gavazzi/counter.py
@@ -24,7 +24,7 @@ class CarloGavazziCounter:
         self.__sim_count = simcount.SimCountFactory().get_sim_counter()()
         self.simulation = {}
         self.__store = get_counter_value_store(self.component_config.id)
-        self.component_info = ComponentInfo.from_component_config(component_config)
+        self.component_info = ComponentInfo.from_component_config(self.component_config)
 
     def update(self):
         unit = 1

--- a/packages/modules/common/fault_state.py
+++ b/packages/modules/common/fault_state.py
@@ -1,7 +1,7 @@
 from enum import IntEnum
 import logging
 import traceback
-from typing import Dict, Optional, Type, Union
+from typing import Optional, Type
 
 from helpermodules import compatibility, exceptions, pub
 from modules.common import component_type
@@ -23,11 +23,8 @@ class ComponentInfo:
         self.hostname = hostname
 
     @staticmethod
-    def from_component_config(component_config: Union[Dict, Type], hostname: str = "localhost"):
-        if isinstance(component_config, Dict):
-            return ComponentInfo(component_config["id"], component_config["name"], component_config["type"], hostname)
-        else:
-            return ComponentInfo(component_config.id, component_config.name, component_config.type, hostname)
+    def from_component_config(component_config: Type, hostname: str = "localhost"):
+        return ComponentInfo(component_config.id, component_config.name, component_config.type, hostname)
 
 
 class FaultState(Exception):

--- a/packages/modules/fronius/bat.py
+++ b/packages/modules/fronius/bat.py
@@ -23,7 +23,7 @@ class FroniusBat:
         self.__sim_count = simcount.SimCountFactory().get_sim_counter()()
         self.simulation = {}
         self.__store = get_bat_value_store(self.component_config.id)
-        self.component_info = ComponentInfo.from_component_config(component_config)
+        self.component_info = ComponentInfo.from_component_config(self.component_config)
 
     def update(self) -> None:
         meter_id = str(self.component_config.configuration.meter_id)

--- a/packages/modules/fronius/counter_s0.py
+++ b/packages/modules/fronius/counter_s0.py
@@ -22,7 +22,7 @@ class FroniusS0Counter:
         self.__sim_count = simcount.SimCountFactory().get_sim_counter()()
         self.simulation = {}
         self.__store = get_counter_value_store(self.component_config.id)
-        self.component_info = ComponentInfo.from_component_config(component_config)
+        self.component_info = ComponentInfo.from_component_config(self.component_config)
 
     def update(self) -> None:
         session = req.get_http_session()

--- a/packages/modules/fronius/counter_sm.py
+++ b/packages/modules/fronius/counter_sm.py
@@ -27,7 +27,7 @@ class FroniusSmCounter:
         self.__sim_count = simcount.SimCountFactory().get_sim_counter()()
         self.simulation = {}
         self.__store = get_counter_value_store(self.component_config.id)
-        self.component_info = ComponentInfo.from_component_config(component_config)
+        self.component_info = ComponentInfo.from_component_config(self.component_config)
 
     def update(self) -> None:
 

--- a/packages/modules/fronius/inverter.py
+++ b/packages/modules/fronius/inverter.py
@@ -23,7 +23,7 @@ class FroniusInverter:
         self.__sim_count = simcount.SimCountFactory().get_sim_counter()()
         self.simulation = {}
         self.__store = get_inverter_value_store(self.component_config.id)
-        self.component_info = ComponentInfo.from_component_config(component_config)
+        self.component_info = ComponentInfo.from_component_config(self.component_config)
 
     def read_power(self) -> float:
         # Rückgabewert ist die aktuelle Wirkleistung in [W].

--- a/packages/modules/good_we/bat.py
+++ b/packages/modules/good_we/bat.py
@@ -20,7 +20,7 @@ class GoodWeBat:
         self.component_config = dataclass_from_dict(GoodWeBatSetup, component_config)
         self.__tcp_client = tcp_client
         self.__store = get_bat_value_store(self.component_config.id)
-        self.component_info = ComponentInfo.from_component_config(component_config)
+        self.component_info = ComponentInfo.from_component_config(self.component_config)
 
     def update(self) -> None:
         with self.__tcp_client:

--- a/packages/modules/good_we/counter.py
+++ b/packages/modules/good_we/counter.py
@@ -20,7 +20,7 @@ class GoodWeCounter:
         self.component_config = dataclass_from_dict(GoodWeCounterSetup, component_config)
         self.__tcp_client = tcp_client
         self.__store = get_counter_value_store(self.component_config.id)
-        self.component_info = ComponentInfo.from_component_config(component_config)
+        self.component_info = ComponentInfo.from_component_config(self.component_config)
 
     def update(self):
         with self.__tcp_client:

--- a/packages/modules/good_we/inverter.py
+++ b/packages/modules/good_we/inverter.py
@@ -20,7 +20,7 @@ class GoodWeInverter:
         self.component_config = dataclass_from_dict(GoodWeInverterSetup, component_config)
         self.__tcp_client = tcp_client
         self.__store = get_inverter_value_store(self.component_config.id)
-        self.component_info = ComponentInfo.from_component_config(component_config)
+        self.component_info = ComponentInfo.from_component_config(self.component_config)
 
     def update(self) -> None:
         with self.__tcp_client:

--- a/packages/modules/http/bat.py
+++ b/packages/modules/http/bat.py
@@ -18,7 +18,7 @@ class HttpBat:
         self.__sim_count = simcount.SimCountFactory().get_sim_counter()()
         self.simulation = {}
         self.__store = get_bat_value_store(self.component_config.id)
-        self.component_info = ComponentInfo.from_component_config(component_config)
+        self.component_info = ComponentInfo.from_component_config(self.component_config)
 
         self.__get_power = create_request_function(url, self.component_config.configuration.power_path)
         self.__get_imported = create_request_function(url, self.component_config.configuration.imported_path)

--- a/packages/modules/http/counter.py
+++ b/packages/modules/http/counter.py
@@ -18,7 +18,7 @@ class HttpCounter:
         self.__sim_count = simcount.SimCountFactory().get_sim_counter()()
         self.simulation = {}
         self.__store = get_counter_value_store(self.component_config.id)
-        self.component_info = ComponentInfo.from_component_config(component_config)
+        self.component_info = ComponentInfo.from_component_config(self.component_config)
 
         self.__get_power = create_request_function(url, self.component_config.configuration.power_path)
         self.__get_imported = create_request_function(url, self.component_config.configuration.imported_path)

--- a/packages/modules/http/inverter.py
+++ b/packages/modules/http/inverter.py
@@ -20,7 +20,7 @@ class HttpInverter:
         self.__sim_count = simcount.SimCountFactory().get_sim_counter()()
         self.simulation = {}
         self.__store = get_inverter_value_store(self.component_config.id)
-        self.component_info = ComponentInfo.from_component_config(component_config)
+        self.component_info = ComponentInfo.from_component_config(self.component_config)
         self.__get_power = create_request_function(url, self.component_config.configuration.power_path)
         self.__get_exported = create_request_function(url, self.component_config.configuration.exported_path)
 

--- a/packages/modules/huawei/bat.py
+++ b/packages/modules/huawei/bat.py
@@ -26,7 +26,7 @@ class HuaweiBat:
         self.__sim_count = simcount.SimCountFactory().get_sim_counter()()
         self.simulation = {}
         self.__store = get_bat_value_store(self.component_config.id)
-        self.component_info = ComponentInfo.from_component_config(component_config)
+        self.component_info = ComponentInfo.from_component_config(self.component_config)
 
     def update(self) -> None:
         time.sleep(0.1)

--- a/packages/modules/huawei/counter.py
+++ b/packages/modules/huawei/counter.py
@@ -26,7 +26,7 @@ class HuaweiCounter:
         self.__sim_count = simcount.SimCountFactory().get_sim_counter()()
         self.simulation = {}
         self.__store = get_counter_value_store(self.component_config.id)
-        self.component_info = ComponentInfo.from_component_config(component_config)
+        self.component_info = ComponentInfo.from_component_config(self.component_config)
 
     def update(self):
         time.sleep(0.1)

--- a/packages/modules/huawei/inverter.py
+++ b/packages/modules/huawei/inverter.py
@@ -26,7 +26,7 @@ class HuaweiInverter:
         self.__sim_count = simcount.SimCountFactory().get_sim_counter()()
         self.simulation = {}
         self.__store = get_inverter_value_store(self.component_config.id)
-        self.component_info = ComponentInfo.from_component_config(component_config)
+        self.component_info = ComponentInfo.from_component_config(self.component_config)
 
     def update(self) -> None:
         time.sleep(0.1)

--- a/packages/modules/janitza/counter.py
+++ b/packages/modules/janitza/counter.py
@@ -23,7 +23,7 @@ class JanitzaCounter:
         self.__sim_count = simcount.SimCountFactory().get_sim_counter()()
         self.simulation = {}
         self.__store = get_counter_value_store(self.component_config.id)
-        self.component_info = ComponentInfo.from_component_config(component_config)
+        self.component_info = ComponentInfo.from_component_config(self.component_config)
 
     def update(self):
         with self.__tcp_client:

--- a/packages/modules/json/bat.py
+++ b/packages/modules/json/bat.py
@@ -18,7 +18,7 @@ class JsonBat:
         self.__sim_count = simcount.SimCountFactory().get_sim_counter()()
         self.simulation = {}
         self.__store = get_bat_value_store(self.component_config.id)
-        self.component_info = ComponentInfo.from_component_config(component_config)
+        self.component_info = ComponentInfo.from_component_config(self.component_config)
 
     def update(self, response) -> None:
         config = self.component_config.configuration

--- a/packages/modules/json/counter.py
+++ b/packages/modules/json/counter.py
@@ -18,7 +18,7 @@ class JsonCounter:
         self.__sim_count = simcount.SimCountFactory().get_sim_counter()()
         self.simulation = {}
         self.__store = get_counter_value_store(self.component_config.id)
-        self.component_info = ComponentInfo.from_component_config(component_config)
+        self.component_info = ComponentInfo.from_component_config(self.component_config)
 
     def update(self, response):
         config = self.component_config.configuration

--- a/packages/modules/json/inverter.py
+++ b/packages/modules/json/inverter.py
@@ -18,7 +18,7 @@ class JsonInverter:
         self.__sim_count = simcount.SimCountFactory().get_sim_counter()()
         self.simulation = {}
         self.__store = get_inverter_value_store(self.component_config.id)
-        self.component_info = ComponentInfo.from_component_config(component_config)
+        self.component_info = ComponentInfo.from_component_config(self.component_config)
 
     def update(self, response) -> None:
         config = self.component_config.configuration

--- a/packages/modules/kostal_piko/counter.py
+++ b/packages/modules/kostal_piko/counter.py
@@ -22,7 +22,7 @@ class KostalPikoCounter:
         self.__sim_count = simcount.SimCountFactory().get_sim_counter()()
         self.simulation = {}
         self.__store = get_counter_value_store(self.component_config.id)
-        self.component_info = ComponentInfo.from_component_config(component_config)
+        self.component_info = ComponentInfo.from_component_config(self.component_config)
 
     def get_values(self) -> Tuple[float, List[float]]:
         params = (('dxsEntries', ['83887106', '83887362', '83887618']),)

--- a/packages/modules/kostal_piko/inverter.py
+++ b/packages/modules/kostal_piko/inverter.py
@@ -18,7 +18,7 @@ class KostalPikoInverter:
         self.component_config = dataclass_from_dict(KostalPikoInverterSetup, component_config)
         self.ip_address = ip_address
         self.__store = get_inverter_value_store(self.component_config.id)
-        self.component_info = ComponentInfo.from_component_config(component_config)
+        self.component_info = ComponentInfo.from_component_config(self.component_config)
 
     def get_values(self) -> Tuple[float, float]:
         params = (('dxsEntries', ['67109120', '251658753']),)

--- a/packages/modules/lg/bat.py
+++ b/packages/modules/lg/bat.py
@@ -18,7 +18,7 @@ class LgBat:
         self.__sim_count = simcount.SimCountFactory().get_sim_counter()()
         self.__simulation = {}
         self.__store = get_bat_value_store(self.component_config.id)
-        self.component_info = ComponentInfo.from_component_config(component_config)
+        self.component_info = ComponentInfo.from_component_config(self.component_config)
 
     def update(self, response) -> None:
         power = float(response["statistics"]["batconv_power"])

--- a/packages/modules/lg/counter.py
+++ b/packages/modules/lg/counter.py
@@ -17,7 +17,7 @@ class LgCounter:
         self.__sim_count = simcount.SimCountFactory().get_sim_counter()()
         self.simulation = {}
         self.__store = get_counter_value_store(self.component_config.id)
-        self.component_info = ComponentInfo.from_component_config(component_config)
+        self.component_info = ComponentInfo.from_component_config(self.component_config)
 
     def update(self, response) -> None:
         power = float(response["statistics"]["grid_power"])

--- a/packages/modules/lg/inverter.py
+++ b/packages/modules/lg/inverter.py
@@ -17,7 +17,7 @@ class LgInverter:
         self.__sim_count = simcount.SimCountFactory().get_sim_counter()()
         self.__simulation = {}
         self.__store = get_inverter_value_store(self.component_config.id)
-        self.component_info = ComponentInfo.from_component_config(component_config)
+        self.component_info = ComponentInfo.from_component_config(self.component_config)
 
     def update(self, response: Dict) -> None:
         power = float(response["statistics"]["pcs_pv_total_power"]) * -1

--- a/packages/modules/openwb_flex/bat.py
+++ b/packages/modules/openwb_flex/bat.py
@@ -29,7 +29,7 @@ class BatKitFlex:
         self.__sim_count = simcount.SimCountFactory().get_sim_counter()()
         self.simulation = {}
         self.__store = get_bat_value_store(self.component_config.id)
-        self.component_info = ComponentInfo.from_component_config(component_config)
+        self.component_info = ComponentInfo.from_component_config(self.component_config)
 
     def update(self):
         # TCP-Verbindung schließen möglichst bevor etwas anderes gemacht wird, um im Fehlerfall zu verhindern,

--- a/packages/modules/openwb_flex/counter.py
+++ b/packages/modules/openwb_flex/counter.py
@@ -29,7 +29,7 @@ class EvuKitFlex:
         self.__sim_count = simcount.SimCountFactory().get_sim_counter()()
         self.simulation = {}
         self.__store = get_counter_value_store(self.component_config.id)
-        self.component_info = ComponentInfo.from_component_config(component_config)
+        self.component_info = ComponentInfo.from_component_config(self.component_config)
 
     def update(self):
         # TCP-Verbindung schließen möglichst bevor etwas anderes gemacht wird, um im Fehlerfall zu verhindern,

--- a/packages/modules/openwb_flex/inverter.py
+++ b/packages/modules/openwb_flex/inverter.py
@@ -27,7 +27,7 @@ class PvKitFlex:
         self.__sim_count = simcount.SimCountFactory().get_sim_counter()()
         self.simulation = {}
         self.__store = get_inverter_value_store(self.component_config.id)
-        self.component_info = ComponentInfo.from_component_config(component_config)
+        self.component_info = ComponentInfo.from_component_config(self.component_config)
 
     def update(self) -> None:
         """ liest die Werte des Moduls aus.

--- a/packages/modules/powerdog/counter.py
+++ b/packages/modules/powerdog/counter.py
@@ -26,7 +26,7 @@ class PowerdogCounter:
         self.__sim_count = simcount.SimCountFactory().get_sim_counter()()
         self.simulation = {}
         self.__store = get_counter_value_store(self.component_config.id)
-        self.component_info = ComponentInfo.from_component_config(component_config)
+        self.component_info = ComponentInfo.from_component_config(self.component_config)
 
     def update(self):
         with self.__tcp_client:

--- a/packages/modules/powerdog/inverter.py
+++ b/packages/modules/powerdog/inverter.py
@@ -26,7 +26,7 @@ class PowerdogInverter:
         self.__sim_count = simcount.SimCountFactory().get_sim_counter()()
         self.simulation = {}
         self.__store = get_inverter_value_store(self.component_config.id)
-        self.component_info = ComponentInfo.from_component_config(component_config)
+        self.component_info = ComponentInfo.from_component_config(self.component_config)
 
     def update(self) -> float:
         with self.__tcp_client:

--- a/packages/modules/saxpower/bat.py
+++ b/packages/modules/saxpower/bat.py
@@ -23,7 +23,7 @@ class SaxpowerBat:
         self.__sim_count = simcount.SimCountFactory().get_sim_counter()()
         self.simulation = {}
         self.__store = get_bat_value_store(self.component_config.id)
-        self.component_info = ComponentInfo.from_component_config(component_config)
+        self.component_info = ComponentInfo.from_component_config(self.component_config)
 
     def update(self) -> None:
         with self.__tcp_client:

--- a/packages/modules/siemens/bat.py
+++ b/packages/modules/siemens/bat.py
@@ -23,7 +23,7 @@ class SiemensBat:
         self.__sim_count = simcount.SimCountFactory().get_sim_counter()()
         self.simulation = {}
         self.__store = get_bat_value_store(self.component_config.id)
-        self.component_info = ComponentInfo.from_component_config(component_config)
+        self.component_info = ComponentInfo.from_component_config(self.component_config)
 
     def update(self) -> None:
         with self.__tcp_client:

--- a/packages/modules/siemens/counter.py
+++ b/packages/modules/siemens/counter.py
@@ -23,7 +23,7 @@ class SiemensCounter:
         self.__sim_count = simcount.SimCountFactory().get_sim_counter()()
         self.simulation = {}
         self.__store = get_counter_value_store(self.component_config.id)
-        self.component_info = ComponentInfo.from_component_config(component_config)
+        self.component_info = ComponentInfo.from_component_config(self.component_config)
 
     def update(self):
 

--- a/packages/modules/siemens/inverter.py
+++ b/packages/modules/siemens/inverter.py
@@ -23,7 +23,7 @@ class SiemensInverter:
         self.__sim_count = simcount.SimCountFactory().get_sim_counter()()
         self.simulation = {}
         self.__store = get_inverter_value_store(self.component_config.id)
-        self.component_info = ComponentInfo.from_component_config(component_config)
+        self.component_info = ComponentInfo.from_component_config(self.component_config)
 
     def update(self) -> None:
         with self.__tcp_client:

--- a/packages/modules/sma_sunny_boy/bat.py
+++ b/packages/modules/sma_sunny_boy/bat.py
@@ -18,7 +18,7 @@ class SunnyBoyBat:
         self.component_config = dataclass_from_dict(SmaSunnyBoyBatSetup, component_config)
         self.__tcp_client = tcp_client
         self.__store = get_bat_value_store(self.component_config.id)
-        self.component_info = ComponentInfo.from_component_config(component_config)
+        self.component_info = ComponentInfo.from_component_config(self.component_config)
 
     def read(self) -> BatState:
         unit = 3

--- a/packages/modules/sma_sunny_boy/bat_smart_energy.py
+++ b/packages/modules/sma_sunny_boy/bat_smart_energy.py
@@ -22,7 +22,7 @@ class SunnyBoySmartEnergyBat:
         self.__sim_count = simcount.SimCountFactory().get_sim_counter()()
         self.simulation = {}
         self.__store = get_bat_value_store(self.component_config.id)
-        self.component_info = ComponentInfo.from_component_config(component_config)
+        self.component_info = ComponentInfo.from_component_config(self.component_config)
 
     def update(self) -> None:
         self.__store.set(self.read())

--- a/packages/modules/sma_sunny_boy/counter.py
+++ b/packages/modules/sma_sunny_boy/counter.py
@@ -23,7 +23,7 @@ class SmaSunnyBoyCounter:
         self.__sim_count = simcount.SimCountFactory().get_sim_counter()()
         self.simulation = {}
         self.__store = get_counter_value_store(self.component_config.id)
-        self.component_info = ComponentInfo.from_component_config(component_config)
+        self.component_info = ComponentInfo.from_component_config(self.component_config)
 
     def update(self):
         with self.__tcp_client:

--- a/packages/modules/sma_sunny_boy/inverter.py
+++ b/packages/modules/sma_sunny_boy/inverter.py
@@ -28,7 +28,7 @@ class SmaSunnyBoyInverter:
         self.component_config = dataclass_from_dict(SmaSunnyBoyInverterSetup, component_config)
         self.__tcp_client = tcp_client
         self.__store = get_inverter_value_store(self.component_config.id)
-        self.component_info = ComponentInfo.from_component_config(component_config)
+        self.component_info = ComponentInfo.from_component_config(self.component_config)
 
     def update(self) -> None:
         self.__store.set(self.read())

--- a/packages/modules/sma_sunny_island/bat.py
+++ b/packages/modules/sma_sunny_island/bat.py
@@ -18,7 +18,7 @@ class SunnyIslandBat:
         self.component_config = dataclass_from_dict(SmaSunnyIslandBatSetup, component_config)
         self.__tcp_client = tcp_client
         self.__store = get_bat_value_store(self.component_config.id)
-        self.component_info = ComponentInfo.from_component_config(component_config)
+        self.component_info = ComponentInfo.from_component_config(self.component_config)
 
     def read(self) -> BatState:
         unit = 3

--- a/packages/modules/sma_webbox/inverter.py
+++ b/packages/modules/sma_webbox/inverter.py
@@ -15,7 +15,7 @@ class SmaWebboxInverter:
         self.__device_address = device_address
         self.component_config = dataclass_from_dict(SmaWebboxInverterSetup, component_config)
         self.__store = get_inverter_value_store(self.component_config.id)
-        self.component_info = ComponentInfo.from_component_config(component_config)
+        self.component_info = ComponentInfo.from_component_config(self.component_config)
 
     def update(self) -> None:
         self.__store.set(self.read())

--- a/packages/modules/solaredge/bat.py
+++ b/packages/modules/solaredge/bat.py
@@ -27,7 +27,7 @@ class SolaredgeBat:
         self.__sim_count = simcount.SimCountFactory().get_sim_counter()()
         self.simulation = {}
         self.__store = get_bat_value_store(self.component_config.id)
-        self.component_info = ComponentInfo.from_component_config(component_config)
+        self.component_info = ComponentInfo.from_component_config(self.component_config)
 
     def update(self, state: BatState) -> None:
         self.__store.set(state)

--- a/packages/modules/solaredge/counter.py
+++ b/packages/modules/solaredge/counter.py
@@ -20,7 +20,7 @@ class SolaredgeCounter:
         self.component_config = dataclass_from_dict(SolaredgeCounterSetup, component_config)
         self.__tcp_client = tcp_client
         self.__store = get_counter_value_store(self.component_config.id)
-        self.component_info = ComponentInfo.from_component_config(component_config)
+        self.component_info = ComponentInfo.from_component_config(self.component_config)
 
     def update(self):
         def read_scaled_int16(address: int, count: int):

--- a/packages/modules/solaredge/external_inverter.py
+++ b/packages/modules/solaredge/external_inverter.py
@@ -23,7 +23,7 @@ class SolaredgeExternalInverter:
         self.__sim_count = simcount.SimCountFactory().get_sim_counter()()
         self.simulation = {}
         self.__store = get_inverter_value_store(self.component_config.id)
-        self.component_info = ComponentInfo.from_component_config(component_config)
+        self.component_info = ComponentInfo.from_component_config(self.component_config)
 
     def update(self, state: InverterState) -> None:
         self.__store.set(state)

--- a/packages/modules/solaredge/inverter.py
+++ b/packages/modules/solaredge/inverter.py
@@ -20,7 +20,7 @@ class SolaredgeInverter:
         self.component_config = dataclass_from_dict(SolaredgeInverterSetup, component_config)
         self.__tcp_client = tcp_client
         self.__store = get_inverter_value_store(self.component_config.id)
-        self.component_info = ComponentInfo.from_component_config(component_config)
+        self.component_info = ComponentInfo.from_component_config(self.component_config)
 
     def update(self, state: InverterState) -> None:
         self.__store.set(state)

--- a/packages/modules/solarmax/inverter.py
+++ b/packages/modules/solarmax/inverter.py
@@ -25,7 +25,7 @@ class SolarmaxInverter:
         self.__sim_count = simcount.SimCountFactory().get_sim_counter()()
         self.simulation = {}
         self.__store = get_inverter_value_store(self.component_config.id)
-        self.component_info = ComponentInfo.from_component_config(component_config)
+        self.component_info = ComponentInfo.from_component_config(self.component_config)
 
     def update(self) -> None:
         with self.__tcp_client:

--- a/packages/modules/solax/bat.py
+++ b/packages/modules/solax/bat.py
@@ -25,7 +25,7 @@ class SolaxBat:
         self.__sim_count = simcount.SimCountFactory().get_sim_counter()()
         self.simulation = {}
         self.__store = get_bat_value_store(self.component_config.id)
-        self.component_info = ComponentInfo.from_component_config(component_config)
+        self.component_info = ComponentInfo.from_component_config(self.component_config)
 
     def update(self) -> None:
         with self.__tcp_client:

--- a/packages/modules/solax/counter.py
+++ b/packages/modules/solax/counter.py
@@ -23,7 +23,7 @@ class SolaxCounter:
         self.__modbus_id = modbus_id
         self.__tcp_client = tcp_client
         self.__store = get_counter_value_store(self.component_config.id)
-        self.component_info = ComponentInfo.from_component_config(component_config)
+        self.component_info = ComponentInfo.from_component_config(self.component_config)
 
     def update(self):
         with self.__tcp_client:

--- a/packages/modules/solax/inverter.py
+++ b/packages/modules/solax/inverter.py
@@ -22,7 +22,7 @@ class SolaxInverter:
         self.__modbus_id = modbus_id
         self.__tcp_client = tcp_client
         self.__store = get_inverter_value_store(self.component_config.id)
-        self.component_info = ComponentInfo.from_component_config(component_config)
+        self.component_info = ComponentInfo.from_component_config(self.component_config)
 
     def update(self) -> None:
         with self.__tcp_client:

--- a/packages/modules/sonnenbatterie/bat.py
+++ b/packages/modules/sonnenbatterie/bat.py
@@ -28,7 +28,7 @@ class SonnenbatterieBat:
         self.__sim_count = simcount.SimCountFactory().get_sim_counter()()
         self.simulation = {}
         self.__store = get_bat_value_store(self.component_config.id)
-        self.component_info = ComponentInfo.from_component_config(component_config)
+        self.component_info = ComponentInfo.from_component_config(self.component_config)
 
     def __read_variant_0(self):
         return req.get_http_session().get('http://' + self.__device_address + ':7979/rest/devices/battery',

--- a/packages/modules/sonnenbatterie/counter.py
+++ b/packages/modules/sonnenbatterie/counter.py
@@ -28,7 +28,7 @@ class SonnenbatterieCounter:
         self.__sim_count = simcount.SimCountFactory().get_sim_counter()()
         self.simulation = {}
         self.__store = get_counter_value_store(self.component_config.id)
-        self.component_info = ComponentInfo.from_component_config(component_config)
+        self.component_info = ComponentInfo.from_component_config(self.component_config)
 
     def __read_variant_1(self):
         return req.get_http_session().get("http://" + self.__device_address + "/api/v1/status", timeout=5).json()

--- a/packages/modules/sonnenbatterie/inverter.py
+++ b/packages/modules/sonnenbatterie/inverter.py
@@ -28,7 +28,7 @@ class SonnenbatterieInverter:
         self.__sim_count = simcount.SimCountFactory().get_sim_counter()()
         self.simulation = {}
         self.__store = get_inverter_value_store(self.component_config.id)
-        self.component_info = ComponentInfo.from_component_config(component_config)
+        self.component_info = ComponentInfo.from_component_config(self.component_config)
 
     def __read_variant_1(self):
         return req.get_http_session().get("http://" + self.__device_address + "/api/v1/status", timeout=5).json()

--- a/packages/modules/studer/bat.py
+++ b/packages/modules/studer/bat.py
@@ -18,7 +18,7 @@ class StuderBat:
         self.component_config = dataclass_from_dict(StuderBatSetup, component_config)
         self.__tcp_client = tcp_client
         self.__store = get_bat_value_store(self.component_config.id)
-        self.component_info = ComponentInfo.from_component_config(component_config)
+        self.component_info = ComponentInfo.from_component_config(self.component_config)
 
     def update(self) -> None:
         unit = 60

--- a/packages/modules/studer/inverter.py
+++ b/packages/modules/studer/inverter.py
@@ -18,7 +18,7 @@ class StuderInverter:
         self.component_config = dataclass_from_dict(StuderInverterSetup, component_config)
         self.__tcp_client = tcp_client
         self.__store = get_inverter_value_store(self.component_config.id)
-        self.component_info = ComponentInfo.from_component_config(component_config)
+        self.component_info = ComponentInfo.from_component_config(self.component_config)
 
     def update(self) -> None:
         vc_count = self.component_config.configuration.vc_count

--- a/packages/modules/sungrow/bat.py
+++ b/packages/modules/sungrow/bat.py
@@ -23,7 +23,7 @@ class SungrowBat:
         self.__sim_count = simcount.SimCountFactory().get_sim_counter()()
         self.simulation = {}
         self.__store = get_bat_value_store(self.component_config.id)
-        self.component_info = ComponentInfo.from_component_config(component_config)
+        self.component_info = ComponentInfo.from_component_config(self.component_config)
 
     def update(self) -> None:
         unit = 1

--- a/packages/modules/sungrow/counter.py
+++ b/packages/modules/sungrow/counter.py
@@ -23,7 +23,7 @@ class SungrowCounter:
         self.__sim_count = simcount.SimCountFactory().get_sim_counter()()
         self.simulation = {}
         self.__store = get_counter_value_store(self.component_config.id)
-        self.component_info = ComponentInfo.from_component_config(component_config)
+        self.component_info = ComponentInfo.from_component_config(self.component_config)
 
     def update(self):
         unit = 1

--- a/packages/modules/sungrow/inverter.py
+++ b/packages/modules/sungrow/inverter.py
@@ -23,7 +23,7 @@ class SungrowInverter:
         self.__sim_count = simcount.SimCountFactory().get_sim_counter()()
         self.simulation = {}
         self.__store = get_inverter_value_store(self.component_config.id)
-        self.component_info = ComponentInfo.from_component_config(component_config)
+        self.component_info = ComponentInfo.from_component_config(self.component_config)
 
     def update(self) -> None:
         with self.__tcp_client:

--- a/packages/modules/sunways/inverter.py
+++ b/packages/modules/sunways/inverter.py
@@ -27,7 +27,7 @@ class SunwaysInverter:
         self.ip_address = ip_address
         self.password = password
         self.__store = get_inverter_value_store(self.component_config.id)
-        self.component_info = ComponentInfo.from_component_config(component_config)
+        self.component_info = ComponentInfo.from_component_config(self.component_config)
 
     def update(self) -> None:
         params = (

--- a/packages/modules/tesla/bat.py
+++ b/packages/modules/tesla/bat.py
@@ -14,7 +14,7 @@ class TeslaBat:
     def __init__(self, component_config: Union[Dict, TeslaBatSetup]) -> None:
         self.component_config = dataclass_from_dict(TeslaBatSetup, component_config)
         self.__store = get_bat_value_store(self.component_config.id)
-        self.component_info = ComponentInfo.from_component_config(component_config)
+        self.component_info = ComponentInfo.from_component_config(self.component_config)
 
     def update(self, client: PowerwallHttpClient, aggregate) -> None:
         self.__store.set(BatState(

--- a/packages/modules/tesla/counter.py
+++ b/packages/modules/tesla/counter.py
@@ -18,7 +18,7 @@ class TeslaCounter:
     def __init__(self, component_config: Union[Dict, TeslaCounterSetup]) -> None:
         self.component_config = dataclass_from_dict(TeslaCounterSetup, component_config)
         self.__store = get_counter_value_store(self.component_config.id)
-        self.component_info = ComponentInfo.from_component_config(component_config)
+        self.component_info = ComponentInfo.from_component_config(self.component_config)
 
     def update(self, client: PowerwallHttpClient, aggregate):
         # read firmware version

--- a/packages/modules/tesla/inverter.py
+++ b/packages/modules/tesla/inverter.py
@@ -14,7 +14,7 @@ class TeslaInverter:
     def __init__(self, component_config: Union[Dict, TeslaInverterSetup]) -> None:
         self.component_config = dataclass_from_dict(TeslaInverterSetup, component_config)
         self.__store = get_inverter_value_store(self.component_config.id)
-        self.component_info = ComponentInfo.from_component_config(component_config)
+        self.component_info = ComponentInfo.from_component_config(self.component_config)
 
     def update(self, client: PowerwallHttpClient, aggregate) -> None:
         pv_watt = aggregate["solar"]["instant_power"]

--- a/packages/modules/victron/bat.py
+++ b/packages/modules/victron/bat.py
@@ -23,7 +23,7 @@ class VictronBat:
         self.__sim_count = simcount.SimCountFactory().get_sim_counter()()
         self.simulation = {}
         self.__store = get_bat_value_store(self.component_config.id)
-        self.component_info = ComponentInfo.from_component_config(component_config)
+        self.component_info = ComponentInfo.from_component_config(self.component_config)
 
     def update(self) -> None:
         modbus_id = self.component_config.configuration.modbus_id

--- a/packages/modules/victron/counter.py
+++ b/packages/modules/victron/counter.py
@@ -23,7 +23,7 @@ class VictronCounter:
         self.__sim_count = simcount.SimCountFactory().get_sim_counter()()
         self.simulation = {}
         self.__store = get_counter_value_store(self.component_config.id)
-        self.component_info = ComponentInfo.from_component_config(component_config)
+        self.component_info = ComponentInfo.from_component_config(self.component_config)
 
     def update(self):
         unit = self.component_config.configuration.modbus_id

--- a/packages/modules/victron/inverter.py
+++ b/packages/modules/victron/inverter.py
@@ -26,7 +26,7 @@ class VictronInverter:
         self.__sim_count = simcount.SimCountFactory().get_sim_counter()()
         self.simulation = {}
         self.__store = get_inverter_value_store(self.component_config.id)
-        self.component_info = ComponentInfo.from_component_config(component_config)
+        self.component_info = ComponentInfo.from_component_config(self.component_config)
 
     def update(self) -> None:
         modbus_id = self.component_config.configuration.modbus_id


### PR DESCRIPTION
Während der Umstellung auf Konfigurations-Klassen konnte die Komponenten-Info aus dem Dictionary und der Klasse erzeugt werden, jetzt nur noch aus der Klasse.