### PR TITLE
fix SMA Inverter: energy is read via modbus twice, first requested value is ignored

### DIFF
--- a/packages/modules/sma_sunny_boy/inverter.py
+++ b/packages/modules/sma_sunny_boy/inverter.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python3
-from typing import Dict, Union
 import logging
+from typing import Dict, Union
 
 from dataclass_utils import dataclass_from_dict
 from modules.common import modbus
@@ -11,7 +11,6 @@ from modules.common.modbus import ModbusDataType
 from modules.common.store import get_inverter_value_store
 from modules.sma_sunny_boy.config import SmaSunnyBoyInverterSetup
 from modules.sma_sunny_boy.inverter_version import SmaInverterVersion
-
 
 log = logging.getLogger(__name__)
 
@@ -58,9 +57,6 @@ class SmaSunnyBoyInverter:
                     power_total = 0
             else:
                 power_total = 0
-
-            # Gesamtertrag (Wh) [E-Total]
-            energy = self.__tcp_client.read_holding_registers(30529, ModbusDataType.UINT_32, unit=3)
 
             return InverterState(
                 power=-max(power_total, 0),


### PR DESCRIPTION
Mir ist zufällig aufgefallen, dass bei SMA in der Klasse SmaSunnyBoyInverter in [Zeile 42](https://github.com/snaptec/openWB/blob/a7dc53d7665257dfac1baeaf881d07c894021b8e/packages/modules/sma_sunny_boy/inverter.py#L42) und in [Zeile 47](https://github.com/snaptec/openWB/blob/a7dc53d7665257dfac1baeaf881d07c894021b8e/packages/modules/sma_sunny_boy/inverter.py#L47) ein Wert für `energy` per Modbus ausgelesen wird, dieser Wert jedoch nie verwendet wird. Stattdessen wird der Wert in [Zeile 63](https://github.com/snaptec/openWB/blob/a7dc53d7665257dfac1baeaf881d07c894021b8e/packages/modules/sma_sunny_boy/inverter.py#L63) von einem anderen Wert ersetzt.

Reingekommen ist die Zeile 63 durch #2245 (@JanFellner).

Grob geschätzt würde ich sagen dass der Core2 jetzt kaputt ist und die Zeile 63 ersatzlos gestrichen werden kann und damit wieder alles gut ist. Da das ganze aber nur geraten und ob tatsächlich Fehlverhalten vorliegt und ob der Register vom Core2 so jetzt besser ist kann ich nicht mit Sicherheit sagen, weil ich keinen Core2 habe.