### PR TITLE
run update.sh as user pi

### DIFF
--- a/runs/update.sh
+++ b/runs/update.sh
@@ -16,8 +16,7 @@ chmod 777 /var/www/html/openWB/ramdisk/mqttlastregelungaktiv
 # The update might replace a number of files which might currently be in use by the continuously running legacy-run
 # server. If we replace the source files while the process is running, funny things might happen.
 # Thus we shut-down the legacy run server before performing the update.
-# We need sudo, because this script may run as user www-data when executed from PHP:
-sudo pkill -f "$OPENWBBASEDIR/packages/legacy_run_server.py"
+pkill -f "$OPENWBBASEDIR/packages/legacy_run_server.py"
 
 if [[ "$releasetrain" == "stable" ]]; then
 	train=stable17
@@ -67,8 +66,8 @@ cp modules/soc_eq/soc_eq_acc_lp2 /tmp/soc_eq_acc_lp2
 cp openwb.conf /tmp/openwb.conf
 
 # fetch new release from GitHub
-sudo git fetch origin
-sudo git reset --hard origin/$train
+git fetch origin
+git reset --hard origin/$train
 
 # set permissions
 cd /var/www/html/

--- a/web/settings/updatePerformNow.php
+++ b/web/settings/updatePerformNow.php
@@ -3,5 +3,4 @@ if ($_SERVER['REQUEST_METHOD'] !== 'POST') {
 	error_log('Diese Seite muss als HTTP-POST aufgerufen werden.');
 	exit('Diese Seite muss als HTTP-POST aufgerufen werden.');
 }
-exec("/var/www/html/openWB/runs/update.sh > /dev/null &");
-?>
+exec("sudo -u pi /var/www/html/openWB/runs/update.sh > /dev/null &");


### PR DESCRIPTION
Fixup für #2311

In der 2311 bin ich davon ausgegangen, dass die `update.sh` als `pi` läuft. Tut sie aber nicht. Sie läuft als `www-data`. Dadurch dass ich das `sudo` rausgenommen habe, fehlen dem Script jetzt wichtige Rechte, damit es korrekt läuft.

Dieser PR behebt das Problem, indem es das Skript als `pi` laufen lässt, der alle nötigen Rechte hat. Dabei habe ich noch 3 weitere unnötige sudo-Aufrufe entfernt, die nicht mehr nötig sind, wenn das Skript als `pi` läuft.