### PR TITLE
fix: `request_value` is never called with "none", result is always float

### DIFF
--- a/packages/modules/http/api.py
+++ b/packages/modules/http/api.py
@@ -15,6 +15,6 @@ def _request_value(url: str) -> float:
 
 def create_request_function(url: str, path: Optional[str]) -> Callable[[], float]:
     if path == "none" or path is None:
-        return lambda: 0.0
+        return lambda: None
     else:
         return functools.partial(_request_value, url + path)

--- a/packages/modules/http/api.py
+++ b/packages/modules/http/api.py
@@ -7,18 +7,14 @@ from modules.common import req
 log = logging.getLogger(__name__)
 
 
-def request_value(url: str) -> Optional[float]:
-    if "none" == url:
-        return None
-    else:
-        response = req.get_http_session().get(url, timeout=5)
-        response.encoding = 'utf-8'
-        log.debug("Antwort auf "+str(url)+" "+str(response.text))
-        return float(response.text.replace("\n", ""))
+def _request_value(url: str) -> float:
+    response_text = req.get_http_session().get(url, timeout=5).text
+    log.debug("Antwort auf %s: %s", url, response_text)
+    return float(response_text.replace("\n", ""))
 
 
-def create_request_function(url: str, path: str) -> Callable[[], Optional[float]]:
+def create_request_function(url: str, path: Optional[str]) -> Callable[[], float]:
     if path == "none" or path is None:
-        return lambda: 0
+        return lambda: 0.0
     else:
-        return functools.partial(request_value, url + path)
+        return functools.partial(_request_value, url + path)


### PR DESCRIPTION
Zufällig ist mir im HTTP-Modul merkwürdiges aufgefallen:
- Die Funktion `request_value` sagt:
    ```python
    if "none" == url:
        return None
    ```
    Aber diese Funktion wird niemals mit "none" aufgerufen. Der einzige Ort von dem aus die Funktion aufgerufen wird ist aus `create_request_function`. Diese überprüft den Pfad bereits vor dem Aufruf. Denkbar wäre lediglich dass jemand zum Beispiel `create_request_function("No", "ne")` aufruft. Aber der Fall erscheint mir eher abwegig. Insofern ist dieser Test unnötig und das Ergebnis ist immer garantiert ein `float` und niemals `None`.
    
    Das `if` ist seit #1832 unnötig. Da habe ich wohl übersehen das `if` zu entfernen.
    
    In #2200 bzw. genau genommen in commit af6b1dc779e8eafaf5dfdd7e0b5e5bb77560aa44 kam die Änderung rein, dass die Funktion `None` statt `0` zurückgibt. Leider sagt weder die Beschreibung des PR noch die commit message etwas darüber aus, was eigentlich das Problem war. Eventuell sollte zwischen "unbekannten Wert" und "0" unterschieden werden, was durchaus Sinn ergeben würde. Das wird so allerdings nicht erreicht.
- Seit 9a977210676cc68a668ec54d52aa03ba1e0b4c75 akzeptiert die Funktion `create_request_function` auch `None` als `path`. Das ist in der Type-Annotation nicht korrekt wiedergegeben.
- Der Aufruf
    ```python
    response.encoding = 'utf-8'
    ```
    Ist nicht sinnvoll. Das Encoding wird vom Server per HTTP-Header auf den tatsächlichen Wert gesetzt. Hiermit wird das encoding überschrieben. In den allermeisten Fällen wird UTF-8 wohl gut gehen und der requests-Decoder ist auch so eingestellt, dass er Fehler "verzeiht", so dass es dadurch zwar selten zum Schaden kommen dürfte, aber sinnvoll ist das deswegen trotzdem nicht. Ich habe die Zeile gestrichen.
- Der Logaufruf
    ```python
    log.debug("Antwort auf "+str(url)+" "+str(response.text))
    ```
    ist unnötig kompliziert. Der Logging-Framework unterstützt direkt Formatierung. Das hat auch den Vorteil, dass der Log-String nicht gebaut werden muss, wenn es wegen den Loglevel nicht zur Logausgabe kommt. (Wobei man auch überlegen könnte das logging ganz sein zu lassen, denn zumindest der Response body (nicht jedoch die request-URL) wird bereits in einem hook von der http-session geloggt).
- In af6b1dc779e8eafaf5dfdd7e0b5e5bb77560aa44 wurde aus `def create_request_function(domain: str, path: str) -> Callable[[], Union[int, float]]` -> `def create_request_function(domain: str, path: str) -> Callable[[], Optional[float]]:`. Ist aber nicht richtig, denn es kann so wie es jetzt ist nicht `None` sein, aber es kann auch ein `int` sein, also wie vorher beschrieben. Ich habe es jetzt auf "nur float" geändert.