### PR TITLE
Gemeinsame Superklasse `ComponentSetup`

### DIFF
--- a/packages/modules/alpha_ess/config.py
+++ b/packages/modules/alpha_ess/config.py
@@ -1,5 +1,7 @@
 from typing import Optional
 
+from modules.common.component_setup import ComponentSetup
+
 
 class AlphaEssConfiguration:
     def __init__(self, source: int = 0, ip_address: Optional[str] = None, version: int = 1):
@@ -25,16 +27,13 @@ class AlphaEssBatConfiguration:
         pass
 
 
-class AlphaEssBatSetup:
+class AlphaEssBatSetup(ComponentSetup[AlphaEssBatConfiguration]):
     def __init__(self,
                  name: str = "Alpha ESS Speicher",
                  type: str = "bat",
                  id: int = 0,
                  configuration: AlphaEssBatConfiguration = None) -> None:
-        self.name = name
-        self.type = type
-        self.id = id
-        self.configuration = configuration or AlphaEssBatConfiguration()
+        super().__init__(name, type, id, configuration or AlphaEssBatConfiguration())
 
 
 class AlphaEssCounterConfiguration:
@@ -42,16 +41,13 @@ class AlphaEssCounterConfiguration:
         pass
 
 
-class AlphaEssCounterSetup:
+class AlphaEssCounterSetup(ComponentSetup[AlphaEssCounterConfiguration]):
     def __init__(self,
                  name: str = "Alpha ESS Zähler",
                  type: str = "counter",
                  id: int = 0,
                  configuration: AlphaEssCounterConfiguration = None) -> None:
-        self.name = name
-        self.type = type
-        self.id = id
-        self.configuration = configuration or AlphaEssCounterConfiguration()
+        super().__init__(name, type, id, configuration or AlphaEssCounterConfiguration())
 
 
 class AlphaEssInverterConfiguration:
@@ -59,13 +55,10 @@ class AlphaEssInverterConfiguration:
         pass
 
 
-class AlphaEssInverterSetup:
+class AlphaEssInverterSetup(ComponentSetup[AlphaEssInverterConfiguration]):
     def __init__(self,
                  name: str = "Alpha ESS Wechselrichter",
                  type: str = "inverter",
                  id: int = 0,
                  configuration: AlphaEssInverterConfiguration = None) -> None:
-        self.name = name
-        self.type = type
-        self.id = id
-        self.configuration = configuration or AlphaEssInverterConfiguration()
+        super().__init__(name, type, id, configuration or AlphaEssInverterConfiguration())

--- a/packages/modules/batterx/config.py
+++ b/packages/modules/batterx/config.py
@@ -1,5 +1,7 @@
 from typing import Optional
 
+from modules.common.component_setup import ComponentSetup
+
 
 class BatterXConfiguration:
     def __init__(self, ip_address: Optional[str] = None):
@@ -23,16 +25,13 @@ class BatterXBatConfiguration:
         pass
 
 
-class BatterXBatSetup:
+class BatterXBatSetup(ComponentSetup[BatterXBatConfiguration]):
     def __init__(self,
                  name: str = "BatterX Speicher",
                  type: str = "bat",
                  id: int = 0,
                  configuration: BatterXBatConfiguration = None) -> None:
-        self.name = name
-        self.type = type
-        self.id = id
-        self.configuration = configuration or BatterXBatConfiguration()
+        super().__init__(name, type, id, configuration or BatterXBatConfiguration())
 
 
 class BatterXCounterConfiguration:
@@ -40,16 +39,13 @@ class BatterXCounterConfiguration:
         pass
 
 
-class BatterXCounterSetup:
+class BatterXCounterSetup(ComponentSetup[BatterXCounterConfiguration]):
     def __init__(self,
                  name: str = "BatterX Zähler",
                  type: str = "counter",
                  id: int = 0,
                  configuration: BatterXCounterConfiguration = None) -> None:
-        self.name = name
-        self.type = type
-        self.id = id
-        self.configuration = configuration or BatterXCounterConfiguration()
+        super().__init__(name, type, id, configuration or BatterXCounterConfiguration())
 
 
 class BatterXInverterConfiguration:
@@ -57,13 +53,10 @@ class BatterXInverterConfiguration:
         pass
 
 
-class BatterXInverterSetup:
+class BatterXInverterSetup(ComponentSetup[BatterXInverterConfiguration]):
     def __init__(self,
                  name: str = "BatterX Wechselrichter",
                  type: str = "inverter",
                  id: int = 0,
                  configuration: BatterXInverterConfiguration = None) -> None:
-        self.name = name
-        self.type = type
-        self.id = id
-        self.configuration = configuration or BatterXInverterConfiguration()
+        super().__init__(name, type, id, configuration or BatterXInverterConfiguration())

--- a/packages/modules/byd/config.py
+++ b/packages/modules/byd/config.py
@@ -1,5 +1,7 @@
 from typing import Optional
 
+from modules.common.component_setup import ComponentSetup
+
 
 class BYDConfiguration:
     def __init__(self,
@@ -28,13 +30,10 @@ class BYDBatConfiguration:
         pass
 
 
-class BYDBatSetup:
+class BYDBatSetup(ComponentSetup[BYDBatConfiguration]):
     def __init__(self,
                  name: str = "BYD Speicher",
                  type: str = "bat",
                  id: int = 0,
                  configuration: BYDBatConfiguration = None) -> None:
-        self.name = name
-        self.type = type
-        self.id = id
-        self.configuration = configuration or BYDBatConfiguration()
+        super().__init__(name, type, id, configuration or BYDBatConfiguration())

--- a/packages/modules/carlo_gavazzi/config.py
+++ b/packages/modules/carlo_gavazzi/config.py
@@ -1,5 +1,7 @@
 from typing import Optional
 
+from modules.common.component_setup import ComponentSetup
+
 
 class CarloGavazziConfiguration:
     def __init__(self, ip_address: Optional[str] = None):
@@ -23,13 +25,10 @@ class CarloGavazziCounterConfiguration:
         pass
 
 
-class CarloGavazziCounterSetup:
+class CarloGavazziCounterSetup(ComponentSetup[CarloGavazziCounterConfiguration]):
     def __init__(self,
                  name: str = "Carlo Gavazzi Zähler",
                  type: str = "counter",
                  id: int = 0,
                  configuration: CarloGavazziCounterConfiguration = None) -> None:
-        self.name = name
-        self.type = type
-        self.id = id
-        self.configuration = configuration or CarloGavazziCounterConfiguration()
+        super().__init__(name, type, id, configuration or CarloGavazziCounterConfiguration())

--- a/packages/modules/common/component_setup.py
+++ b/packages/modules/common/component_setup.py
@@ -1,0 +1,11 @@
+from typing import Generic, TypeVar
+
+T = TypeVar("T")
+
+
+class ComponentSetup(Generic[T]):
+    def __init__(self, name: str, type: str, id: int, configuration: T) -> None:
+        self.name = name
+        self.type = type
+        self.id = id
+        self.configuration = configuration

--- a/packages/modules/common/fault_state.py
+++ b/packages/modules/common/fault_state.py
@@ -1,10 +1,11 @@
-from enum import IntEnum
 import logging
 import traceback
-from typing import Optional, Type
+from enum import IntEnum
+from typing import Optional
 
 from helpermodules import compatibility, exceptions, pub
 from modules.common import component_type
+from modules.common.component_setup import ComponentSetup
 
 log = logging.getLogger("soc."+__name__)
 
@@ -23,7 +24,7 @@ class ComponentInfo:
         self.hostname = hostname
 
     @staticmethod
-    def from_component_config(component_config: Type, hostname: str = "localhost"):
+    def from_component_config(component_config: ComponentSetup, hostname: str = "localhost"):
         return ComponentInfo(component_config.id, component_config.name, component_config.type, hostname)
 
 

--- a/packages/modules/discovergy/config.py
+++ b/packages/modules/discovergy/config.py
@@ -1,5 +1,7 @@
 from typing import Optional
 
+from modules.common.component_setup import ComponentSetup
+
 
 class DiscovergyConfiguration:
     def __init__(self, user: Optional[str] = None, password: Optional[str] = None):
@@ -41,13 +43,10 @@ class DiscovergyInverterConfiguration:
         self.meter_id = meter_id
 
 
-class DiscovergyInverterSetup:
+class DiscovergyInverterSetup(ComponentSetup[DiscovergyInverterConfiguration]):
     def __init__(self,
                  name: str = "Discovergy Wechselrichter",
                  type: str = "inverter",
                  id: int = 0,
                  configuration: DiscovergyInverterConfiguration = None) -> None:
-        self.name = name
-        self.type = type
-        self.id = id
-        self.configuration = configuration or DiscovergyInverterConfiguration()
+        super().__init__(name, type, id, configuration or DiscovergyInverterConfiguration())

--- a/packages/modules/fronius/config.py
+++ b/packages/modules/fronius/config.py
@@ -2,6 +2,8 @@
 from enum import Enum
 from typing import Optional
 
+from modules.common.component_setup import ComponentSetup
+
 
 class MeterLocation(Enum):
     # 0...grid interconnection point (primary meter)
@@ -40,16 +42,13 @@ class FroniusBatConfiguration:
         self.meter_id = meter_id
 
 
-class FroniusBatSetup:
+class FroniusBatSetup(ComponentSetup[FroniusBatConfiguration]):
     def __init__(self,
                  name: str = "Fronius Speicher",
                  type: str = "bat",
                  id: int = 0,
                  configuration: FroniusBatConfiguration = None) -> None:
-        self.name = name
-        self.type = type
-        self.id = id
-        self.configuration = configuration or FroniusBatConfiguration()
+        super().__init__(name, type, id, configuration or FroniusBatConfiguration())
 
 
 class FroniusS0CounterConfiguration:
@@ -57,16 +56,13 @@ class FroniusS0CounterConfiguration:
         pass
 
 
-class FroniusS0CounterSetup:
+class FroniusS0CounterSetup(ComponentSetup[FroniusS0CounterConfiguration]):
     def __init__(self,
                  name: str = "Fronius S0 Zähler",
                  type: str = "counter_s0",
                  id: int = 0,
                  configuration: FroniusS0CounterConfiguration = None) -> None:
-        self.name = name
-        self.type = type
-        self.id = id
-        self.configuration = configuration or FroniusS0CounterConfiguration()
+        super().__init__(name, type, id, configuration or FroniusS0CounterConfiguration())
 
 
 class FroniusSmCounterConfiguration:
@@ -75,16 +71,13 @@ class FroniusSmCounterConfiguration:
         self.variant = variant
 
 
-class FroniusSmCounterSetup:
+class FroniusSmCounterSetup(ComponentSetup[FroniusSmCounterConfiguration]):
     def __init__(self,
                  name: str = "Fronius SM Zähler",
                  type: str = "counter_sm",
                  id: int = 0,
                  configuration: FroniusSmCounterConfiguration = None) -> None:
-        self.name = name
-        self.type = type
-        self.id = id
-        self.configuration = configuration or FroniusSmCounterConfiguration()
+        super().__init__(name, type, id, configuration or FroniusSmCounterConfiguration())
 
 
 class FroniusInverterConfiguration:
@@ -92,13 +85,10 @@ class FroniusInverterConfiguration:
         pass
 
 
-class FroniusInverterSetup:
+class FroniusInverterSetup(ComponentSetup[FroniusInverterConfiguration]):
     def __init__(self,
                  name: str = "Fronius Wechselrichter",
                  type: str = "inverter",
                  id: int = 0,
                  configuration: FroniusInverterConfiguration = None) -> None:
-        self.name = name
-        self.type = type
-        self.id = id
-        self.configuration = configuration or FroniusInverterConfiguration()
+        super().__init__(name, type, id, configuration or FroniusInverterConfiguration())

--- a/packages/modules/good_we/config.py
+++ b/packages/modules/good_we/config.py
@@ -1,5 +1,7 @@
 from typing import Optional
 
+from modules.common.component_setup import ComponentSetup
+
 
 class GoodWeConfiguration:
     def __init__(self, ip_address: Optional[str] = None, id: int = 247):
@@ -24,16 +26,13 @@ class GoodWeBatConfiguration:
         pass
 
 
-class GoodWeBatSetup:
+class GoodWeBatSetup(ComponentSetup[GoodWeBatConfiguration]):
     def __init__(self,
                  name: str = "GoodWe Speicher",
                  type: str = "bat",
                  id: int = 0,
                  configuration: GoodWeBatConfiguration = None) -> None:
-        self.name = name
-        self.type = type
-        self.id = id
-        self.configuration = configuration or GoodWeBatConfiguration()
+        super().__init__(name, type, id, configuration or GoodWeBatConfiguration())
 
 
 class GoodWeCounterConfiguration:
@@ -41,16 +40,13 @@ class GoodWeCounterConfiguration:
         pass
 
 
-class GoodWeCounterSetup:
+class GoodWeCounterSetup(ComponentSetup[GoodWeCounterConfiguration]):
     def __init__(self,
                  name: str = "GoodWe Zähler",
                  type: str = "counter",
                  id: int = 0,
                  configuration: GoodWeCounterConfiguration = None) -> None:
-        self.name = name
-        self.type = type
-        self.id = id
-        self.configuration = configuration or GoodWeCounterConfiguration()
+        super().__init__(name, type, id, configuration or GoodWeCounterConfiguration())
 
 
 class GoodWeInverterConfiguration:
@@ -58,13 +54,10 @@ class GoodWeInverterConfiguration:
         pass
 
 
-class GoodWeInverterSetup:
+class GoodWeInverterSetup(ComponentSetup[GoodWeInverterConfiguration]):
     def __init__(self,
                  name: str = "GoodWe Wechselrichter",
                  type: str = "inverter",
                  id: int = 0,
                  configuration: GoodWeInverterConfiguration = None) -> None:
-        self.name = name
-        self.type = type
-        self.id = id
-        self.configuration = configuration or GoodWeInverterConfiguration()
+        super().__init__(name, type, id, configuration or GoodWeInverterConfiguration())

--- a/packages/modules/http/config.py
+++ b/packages/modules/http/config.py
@@ -1,3 +1,6 @@
+from modules.common.component_setup import ComponentSetup
+
+
 class HTTPConfiguration:
     def __init__(self, url=None):
         self.url = url
@@ -23,16 +26,13 @@ class HttpBatConfiguration:
         self.exported_path = exported_path
 
 
-class HttpBatSetup:
+class HttpBatSetup(ComponentSetup[HttpBatConfiguration]):
     def __init__(self,
                  name: str = "HTTP Speicher",
                  type: str = "bat",
                  id: int = 0,
                  configuration: HttpBatConfiguration = None) -> None:
-        self.name = name
-        self.type = type
-        self.id = id
-        self.configuration = configuration or HttpBatConfiguration()
+        super().__init__(name, type, id, configuration or HttpBatConfiguration())
 
 
 class HttpCounterConfiguration:
@@ -51,16 +51,13 @@ class HttpCounterConfiguration:
         self.power_path = power_path
 
 
-class HttpCounterSetup:
+class HttpCounterSetup(ComponentSetup[HttpCounterConfiguration]):
     def __init__(self,
                  name: str = "HTTP Zähler",
                  type: str = "counter",
                  id: int = 0,
                  configuration: HttpCounterConfiguration = None) -> None:
-        self.name = name
-        self.type = type
-        self.id = id
-        self.configuration = configuration or HttpCounterConfiguration()
+        super().__init__(name, type, id, configuration or HttpCounterConfiguration())
 
 
 class HttpInverterConfiguration:
@@ -69,13 +66,10 @@ class HttpInverterConfiguration:
         self.exported_path = exported_path
 
 
-class HttpInverterSetup:
+class HttpInverterSetup(ComponentSetup[HttpInverterConfiguration]):
     def __init__(self,
                  name: str = "HTTP Wechselrichter",
                  type: str = "inverter",
                  id: int = 0,
                  configuration: HttpInverterConfiguration = None) -> None:
-        self.name = name
-        self.type = type
-        self.id = id
-        self.configuration = configuration or HttpInverterConfiguration()
+        super().__init__(name, type, id, configuration or HttpInverterConfiguration())

--- a/packages/modules/huawei/config.py
+++ b/packages/modules/huawei/config.py
@@ -1,5 +1,7 @@
 from typing import Optional
 
+from modules.common.component_setup import ComponentSetup
+
 
 class HuaweiConfiguration:
     def __init__(self, modbus_id: int = 1, ip_address: Optional[str] = None,):
@@ -24,16 +26,13 @@ class HuaweiBatConfiguration:
         pass
 
 
-class HuaweiBatSetup:
+class HuaweiBatSetup(ComponentSetup[HuaweiBatConfiguration]):
     def __init__(self,
                  name: str = "Huawei Speicher",
                  type: str = "bat",
                  id: int = 0,
                  configuration: HuaweiBatConfiguration = None) -> None:
-        self.name = name
-        self.type = type
-        self.id = id
-        self.configuration = configuration or HuaweiBatConfiguration()
+        super().__init__(name, type, id, configuration or HuaweiBatConfiguration())
 
 
 class HuaweiCounterConfiguration:
@@ -41,16 +40,13 @@ class HuaweiCounterConfiguration:
         pass
 
 
-class HuaweiCounterSetup:
+class HuaweiCounterSetup(ComponentSetup[HuaweiCounterConfiguration]):
     def __init__(self,
                  name: str = "Huawei Zähler",
                  type: str = "counter",
                  id: int = 0,
                  configuration: HuaweiCounterConfiguration = None) -> None:
-        self.name = name
-        self.type = type
-        self.id = id
-        self.configuration = configuration or HuaweiCounterConfiguration()
+        super().__init__(name, type, id, configuration or HuaweiCounterConfiguration())
 
 
 class HuaweiInverterConfiguration:
@@ -58,13 +54,10 @@ class HuaweiInverterConfiguration:
         pass
 
 
-class HuaweiInverterSetup:
+class HuaweiInverterSetup(ComponentSetup[HuaweiInverterConfiguration]):
     def __init__(self,
                  name: str = "Huawei Wechselrichter",
                  type: str = "inverter",
                  id: int = 0,
                  configuration: HuaweiInverterConfiguration = None) -> None:
-        self.name = name
-        self.type = type
-        self.id = id
-        self.configuration = configuration or HuaweiInverterConfiguration()
+        super().__init__(name, type, id, configuration or HuaweiInverterConfiguration())

--- a/packages/modules/janitza/config.py
+++ b/packages/modules/janitza/config.py
@@ -1,5 +1,7 @@
 from typing import Optional
 
+from modules.common.component_setup import ComponentSetup
+
 
 class JanitzaConfiguration:
     def __init__(self, ip_address: Optional[str] = None):
@@ -23,13 +25,10 @@ class JanitzaCounterConfiguration:
         pass
 
 
-class JanitzaCounterSetup:
+class JanitzaCounterSetup(ComponentSetup[JanitzaCounterConfiguration]):
     def __init__(self,
                  name: str = "Janitza Zähler",
                  type: str = "counter",
                  id: int = 0,
                  configuration: JanitzaCounterConfiguration = None) -> None:
-        self.name = name
-        self.type = type
-        self.id = id
-        self.configuration = configuration or JanitzaCounterConfiguration()
+        super().__init__(name, type, id, configuration or JanitzaCounterConfiguration())

--- a/packages/modules/json/config.py
+++ b/packages/modules/json/config.py
@@ -1,3 +1,6 @@
+from modules.common.component_setup import ComponentSetup
+
+
 class JsonConfiguration:
     def __init__(self, url=None):
         self.url = url
@@ -23,16 +26,13 @@ class JsonBatConfiguration:
         self.jq_power = jq_power
 
 
-class JsonBatSetup:
+class JsonBatSetup(ComponentSetup[JsonBatConfiguration]):
     def __init__(self,
                  name: str = "Json Speicher",
                  type: str = "bat",
                  id: int = 0,
                  configuration: JsonBatConfiguration = None) -> None:
-        self.name = name
-        self.type = type
-        self.id = id
-        self.configuration = configuration or JsonBatConfiguration()
+        super().__init__(name, type, id, configuration or JsonBatConfiguration())
 
 
 class JsonCounterConfiguration:
@@ -42,16 +42,13 @@ class JsonCounterConfiguration:
         self.jq_imported = jq_imported
 
 
-class JsonCounterSetup:
+class JsonCounterSetup(ComponentSetup[JsonCounterConfiguration]):
     def __init__(self,
                  name: str = "Json Zähler",
                  type: str = "counter",
                  id: int = 0,
                  configuration: JsonCounterConfiguration = None) -> None:
-        self.name = name
-        self.type = type
-        self.id = id
-        self.configuration = configuration or JsonCounterConfiguration()
+        super().__init__(name, type, id, configuration or JsonCounterConfiguration())
 
 
 class JsonInverterConfiguration:
@@ -60,13 +57,10 @@ class JsonInverterConfiguration:
         self.jq_exported = jq_exported
 
 
-class JsonInverterSetup:
+class JsonInverterSetup(ComponentSetup[JsonInverterConfiguration]):
     def __init__(self,
                  name: str = "Json Wechselrichter",
                  type: str = "inverter",
                  id: int = 0,
                  configuration: JsonInverterConfiguration = None) -> None:
-        self.name = name
-        self.type = type
-        self.id = id
-        self.configuration = configuration or JsonInverterConfiguration()
+        super().__init__(name, type, id, configuration or JsonInverterConfiguration())

--- a/packages/modules/kostal_piko/config.py
+++ b/packages/modules/kostal_piko/config.py
@@ -1,5 +1,7 @@
 from typing import Optional
 
+from modules.common.component_setup import ComponentSetup
+
 
 class KostalPikoConfiguration:
     def __init__(self, ip_address: Optional[str] = None):
@@ -23,16 +25,13 @@ class KostalPikoCounterConfiguration:
         pass
 
 
-class KostalPikoCounterSetup:
+class KostalPikoCounterSetup(ComponentSetup[KostalPikoCounterConfiguration]):
     def __init__(self,
                  name: str = "Kostal Piko Zähler",
                  type: str = "counter",
                  id: int = 0,
                  configuration: KostalPikoCounterConfiguration = None) -> None:
-        self.name = name
-        self.type = type
-        self.id = id
-        self.configuration = configuration or KostalPikoCounterConfiguration()
+        super().__init__(name, type, id, configuration or KostalPikoCounterConfiguration())
 
 
 class KostalPikoInverterConfiguration:
@@ -40,13 +39,10 @@ class KostalPikoInverterConfiguration:
         pass
 
 
-class KostalPikoInverterSetup:
+class KostalPikoInverterSetup(ComponentSetup[KostalPikoInverterConfiguration]):
     def __init__(self,
                  name: str = "Kostal Piko Wechselrichter",
                  type: str = "inverter",
                  id: int = 0,
                  configuration: KostalPikoInverterConfiguration = None) -> None:
-        self.name = name
-        self.type = type
-        self.id = id
-        self.configuration = configuration or KostalPikoInverterConfiguration()
+        super().__init__(name, type, id, configuration or KostalPikoInverterConfiguration())

--- a/packages/modules/lg/config.py
+++ b/packages/modules/lg/config.py
@@ -1,5 +1,7 @@
 from typing import Optional
 
+from modules.common.component_setup import ComponentSetup
+
 
 class LgConfiguration:
     def __init__(self, ip_address: Optional[str] = None, password: Optional[str] = None):
@@ -24,16 +26,13 @@ class LgBatConfiguration:
         pass
 
 
-class LgBatSetup:
+class LgBatSetup(ComponentSetup[LgBatConfiguration]):
     def __init__(self,
                  name: str = "LG ESS V1.0 Speicher",
                  type: str = "bat",
                  id: int = 0,
                  configuration: LgBatConfiguration = None) -> None:
-        self.name = name
-        self.type = type
-        self.id = id
-        self.configuration = configuration or LgBatConfiguration()
+        super().__init__(name, type, id, configuration or LgBatConfiguration())
 
 
 class LgCounterConfiguration:
@@ -41,16 +40,13 @@ class LgCounterConfiguration:
         pass
 
 
-class LgCounterSetup:
+class LgCounterSetup(ComponentSetup[LgCounterConfiguration]):
     def __init__(self,
                  name: str = "LG ESS V1.0 Zähler",
                  type: str = "counter",
                  id: int = 0,
                  configuration: LgCounterConfiguration = None) -> None:
-        self.name = name
-        self.type = type
-        self.id = id
-        self.configuration = configuration or LgCounterConfiguration()
+        super().__init__(name, type, id, configuration or LgCounterConfiguration())
 
 
 class LgInverterConfiguration:
@@ -58,13 +54,10 @@ class LgInverterConfiguration:
         pass
 
 
-class LgInverterSetup:
+class LgInverterSetup(ComponentSetup[LgInverterConfiguration]):
     def __init__(self,
                  name: str = "LG ESS V1.0 Wechselrichter",
                  type: str = "inverter",
                  id: int = 0,
                  configuration: LgInverterConfiguration = None) -> None:
-        self.name = name
-        self.type = type
-        self.id = id
-        self.configuration = configuration or LgInverterConfiguration()
+        super().__init__(name, type, id, configuration or LgInverterConfiguration())

--- a/packages/modules/openwb_bat_kit/config.py
+++ b/packages/modules/openwb_bat_kit/config.py
@@ -1,3 +1,6 @@
+from modules.common.component_setup import ComponentSetup
+
+
 class BatKitConfiguration:
     def __init__(self):
         pass
@@ -20,13 +23,10 @@ class BatKitBatConfiguration:
         self.version = version
 
 
-class BatKitBatSetup:
+class BatKitBatSetup(ComponentSetup[BatKitBatConfiguration]):
     def __init__(self,
                  name: str = "Speicher-Kit",
                  type: str = "bat",
                  id: int = 0,
                  configuration: BatKitBatConfiguration = None) -> None:
-        self.name = name
-        self.type = type
-        self.id = id
-        self.configuration = configuration or BatKitBatConfiguration()
+        super().__init__(name, type, id, configuration or BatKitBatConfiguration())

--- a/packages/modules/openwb_evu_kit/config.py
+++ b/packages/modules/openwb_evu_kit/config.py
@@ -1,7 +1,3 @@
-from modules.openwb_bat_kit.config import BatKitBatSetup
-from modules.openwb_pv_kit.config import PvKitInverterSetup
-
-
 class EvuKitConfiguration:
     def __init__(self):
         pass
@@ -24,7 +20,7 @@ class EvuKitBatConfiguration:
         self.version = version
 
 
-class EvuKitBatSetup(BatKitBatSetup):
+class EvuKitBatSetup:
     def __init__(self,
                  name: str = "Speicher-Zähler an EVU-Kit",
                  type: str = "bat",
@@ -58,7 +54,7 @@ class EvuKitInverterConfiguration:
         self.version = version
 
 
-class EvuKitInverterSetup(PvKitInverterSetup):
+class EvuKitInverterSetup:
     def __init__(self,
                  name: str = "PV-Zähler an EVU-Kit",
                  type: str = "inverter",

--- a/packages/modules/openwb_evu_kit/config.py
+++ b/packages/modules/openwb_evu_kit/config.py
@@ -1,3 +1,6 @@
+from modules.common.component_setup import ComponentSetup
+
+
 class EvuKitConfiguration:
     def __init__(self):
         pass
@@ -20,16 +23,13 @@ class EvuKitBatConfiguration:
         self.version = version
 
 
-class EvuKitBatSetup:
+class EvuKitBatSetup(ComponentSetup[EvuKitBatConfiguration]):
     def __init__(self,
                  name: str = "Speicher-Zähler an EVU-Kit",
                  type: str = "bat",
                  id: int = 0,
                  configuration: EvuKitBatConfiguration = None) -> None:
-        self.name = name
-        self.type = type
-        self.id = id
-        self.configuration = configuration or EvuKitBatConfiguration()
+        super().__init__(name, type, id, configuration or EvuKitBatConfiguration())
 
 
 class EvuKitCounterConfiguration:
@@ -37,16 +37,13 @@ class EvuKitCounterConfiguration:
         self.version = version
 
 
-class EvuKitCounterSetup:
+class EvuKitCounterSetup(ComponentSetup[EvuKitCounterConfiguration]):
     def __init__(self,
                  name: str = "EVU-Kit",
                  type: str = "counter",
                  id: int = 0,
                  configuration: EvuKitCounterConfiguration = None) -> None:
-        self.name = name
-        self.type = type
-        self.id = id
-        self.configuration = configuration or EvuKitCounterConfiguration()
+        super().__init__(name, type, id, configuration or EvuKitCounterConfiguration())
 
 
 class EvuKitInverterConfiguration:
@@ -54,13 +51,10 @@ class EvuKitInverterConfiguration:
         self.version = version
 
 
-class EvuKitInverterSetup:
+class EvuKitInverterSetup(ComponentSetup[EvuKitInverterConfiguration]):
     def __init__(self,
                  name: str = "PV-Zähler an EVU-Kit",
                  type: str = "inverter",
                  id: int = 0,
                  configuration: EvuKitInverterConfiguration = None) -> None:
-        self.name = name
-        self.type = type
-        self.id = id
-        self.configuration = configuration or EvuKitInverterConfiguration()
+        super().__init__(name, type, id, configuration or EvuKitInverterConfiguration())

--- a/packages/modules/openwb_flex/config.py
+++ b/packages/modules/openwb_flex/config.py
@@ -1,5 +1,6 @@
 from typing import Optional, Union, overload
 
+from modules.common.component_setup import ComponentSetup
 from modules.openwb_bat_kit.config import BatKitBatSetup
 from modules.openwb_evu_kit.config import EvuKitCounterSetup
 from modules.openwb_pv_kit.config import PvKitInverterSetup
@@ -29,16 +30,13 @@ class BatKitFlexConfiguration:
         self.version = version
 
 
-class BatKitFlexSetup:
+class BatKitFlexSetup(ComponentSetup[BatKitFlexConfiguration]):
     def __init__(self,
                  name: str = "Speicher-Kit flex",
                  type: str = "bat",
                  id: int = 0,
                  configuration: BatKitFlexConfiguration = None) -> None:
-        self.name = name
-        self.type = type
-        self.id = id
-        self.configuration = configuration or BatKitFlexConfiguration()
+        super().__init__(name, type, id, configuration or BatKitFlexConfiguration())
 
 
 class EvuKitFlexConfiguration:
@@ -47,16 +45,13 @@ class EvuKitFlexConfiguration:
         self.version = version
 
 
-class EvuKitFlexSetup:
+class EvuKitFlexSetup(ComponentSetup[EvuKitFlexConfiguration]):
     def __init__(self,
                  name: str = "EVU-Kit flex",
                  type: str = "counter",
                  id: int = 0,
                  configuration: EvuKitFlexConfiguration = None) -> None:
-        self.name = name
-        self.type = type
-        self.id = id
-        self.configuration = configuration or EvuKitFlexConfiguration()
+        super().__init__(name, type, id, configuration or EvuKitFlexConfiguration())
 
 
 class PvKitFlexConfiguration:
@@ -65,16 +60,13 @@ class PvKitFlexConfiguration:
         self.version = version
 
 
-class PvKitFlexSetup:
+class PvKitFlexSetup(ComponentSetup[PvKitFlexConfiguration]):
     def __init__(self,
                  name: str = "PV-Kit flex",
                  type: str = "inverter",
                  id: int = 0,
                  configuration: PvKitFlexConfiguration = None) -> None:
-        self.name = name
-        self.type = type
-        self.id = id
-        self.configuration = configuration or PvKitFlexConfiguration()
+        super().__init__(name, type, id, configuration or PvKitFlexConfiguration())
 
 
 @overload

--- a/packages/modules/openwb_pv_kit/config.py
+++ b/packages/modules/openwb_pv_kit/config.py
@@ -1,3 +1,6 @@
+from modules.common.component_setup import ComponentSetup
+
+
 class PvKitConfiguration:
     def __init__(self):
         pass
@@ -20,13 +23,10 @@ class PvKitInverterConfiguration:
         self.version = version
 
 
-class PvKitInverterSetup:
+class PvKitInverterSetup(ComponentSetup[PvKitInverterConfiguration]):
     def __init__(self,
                  name: str = "PV-Kit",
                  type: str = "inverter",
                  id: int = 0,
                  configuration: PvKitInverterConfiguration = None) -> None:
-        self.name = name
-        self.type = type
-        self.id = id
-        self.configuration = configuration or PvKitInverterConfiguration()
+        super().__init__(name, type, id, configuration or PvKitInverterConfiguration())

--- a/packages/modules/powerdog/config.py
+++ b/packages/modules/powerdog/config.py
@@ -1,5 +1,7 @@
 from typing import Optional
 
+from modules.common.component_setup import ComponentSetup
+
 
 class PowerdogConfiguration:
     def __init__(self, ip_address: Optional[str] = None):
@@ -23,16 +25,13 @@ class PowerdogCounterConfiguration:
         pass
 
 
-class PowerdogCounterSetup:
+class PowerdogCounterSetup(ComponentSetup[PowerdogCounterConfiguration]):
     def __init__(self,
                  name: str = "Powerdog Zähler",
                  type: str = "counter",
                  id: int = 0,
                  configuration: PowerdogCounterConfiguration = None) -> None:
-        self.name = name
-        self.type = type
-        self.id = id
-        self.configuration = configuration or PowerdogCounterConfiguration()
+        super().__init__(name, type, id, configuration or PowerdogCounterConfiguration())
 
 
 class PowerdogInverterConfiguration:
@@ -40,13 +39,10 @@ class PowerdogInverterConfiguration:
         pass
 
 
-class PowerdogInverterSetup:
+class PowerdogInverterSetup(ComponentSetup[PowerdogInverterConfiguration]):
     def __init__(self,
                  name: str = "Powerdog Wechselrichter",
                  type: str = "inverter",
                  id: int = 0,
                  configuration: PowerdogInverterConfiguration = None) -> None:
-        self.name = name
-        self.type = type
-        self.id = id
-        self.configuration = configuration or PowerdogInverterConfiguration()
+        super().__init__(name, type, id, configuration or PowerdogInverterConfiguration())

--- a/packages/modules/saxpower/config.py
+++ b/packages/modules/saxpower/config.py
@@ -1,5 +1,7 @@
 from typing import Optional
 
+from modules.common.component_setup import ComponentSetup
+
 
 class SaxpowerConfiguration:
     def __init__(self, ip_address: Optional[str] = None):
@@ -23,13 +25,10 @@ class SaxpowerBatConfiguration:
         pass
 
 
-class SaxpowerBatSetup:
+class SaxpowerBatSetup(ComponentSetup[SaxpowerBatConfiguration]):
     def __init__(self,
                  name: str = "Saxpower Speicher",
                  type: str = "bat",
                  id: int = 0,
                  configuration: SaxpowerBatConfiguration = None) -> None:
-        self.name = name
-        self.type = type
-        self.id = id
-        self.configuration = configuration or SaxpowerBatConfiguration()
+        super().__init__(name, type, id, configuration or SaxpowerBatConfiguration())

--- a/packages/modules/siemens/config.py
+++ b/packages/modules/siemens/config.py
@@ -1,5 +1,7 @@
 from typing import Optional
 
+from modules.common.component_setup import ComponentSetup
+
 
 class SiemensConfiguration:
     def __init__(self, ip_address: Optional[str] = None):
@@ -23,16 +25,13 @@ class SiemensBatConfiguration:
         pass
 
 
-class SiemensBatSetup:
+class SiemensBatSetup(ComponentSetup[SiemensBatConfiguration]):
     def __init__(self,
                  name: str = "Siemens Speicher",
                  type: str = "bat",
                  id: int = 0,
                  configuration: SiemensBatConfiguration = None) -> None:
-        self.name = name
-        self.type = type
-        self.id = id
-        self.configuration = configuration or SiemensBatConfiguration()
+        super().__init__(name, type, id, configuration or SiemensBatConfiguration())
 
 
 class SiemensCounterConfiguration:
@@ -40,16 +39,13 @@ class SiemensCounterConfiguration:
         pass
 
 
-class SiemensCounterSetup:
+class SiemensCounterSetup(ComponentSetup[SiemensCounterConfiguration]):
     def __init__(self,
                  name: str = "Siemens Zähler",
                  type: str = "counter",
                  id: int = 0,
                  configuration: SiemensCounterConfiguration = None) -> None:
-        self.name = name
-        self.type = type
-        self.id = id
-        self.configuration = configuration or SiemensCounterConfiguration()
+        super().__init__(name, type, id, configuration or SiemensCounterConfiguration())
 
 
 class SiemensInverterConfiguration:
@@ -57,13 +53,10 @@ class SiemensInverterConfiguration:
         pass
 
 
-class SiemensInverterSetup:
+class SiemensInverterSetup(ComponentSetup[SiemensInverterConfiguration]):
     def __init__(self,
                  name: str = "Siemens Wechselrichter",
                  type: str = "inverter",
                  id: int = 0,
                  configuration: SiemensInverterConfiguration = None) -> None:
-        self.name = name
-        self.type = type
-        self.id = id
-        self.configuration = configuration or SiemensInverterConfiguration()
+        super().__init__(name, type, id, configuration or SiemensInverterConfiguration())

--- a/packages/modules/sma_shm/config.py
+++ b/packages/modules/sma_shm/config.py
@@ -1,3 +1,6 @@
+from modules.common.component_setup import ComponentSetup
+
+
 class SpeedwireComponentConfiguration:
     def __init__(self):
         pass
@@ -20,16 +23,13 @@ class SmaHomeManagerCounterConfiguration:
         self.serials = serials
 
 
-class SmaHomeManagerCounterSetup:
+class SmaHomeManagerCounterSetup(ComponentSetup[SmaHomeManagerCounterConfiguration]):
     def __init__(self,
                  name: str = "SMA Home Manager Zähler",
                  type: str = "counter",
                  id: int = 0,
                  configuration: SmaHomeManagerCounterConfiguration = None) -> None:
-        self.name = name
-        self.type = type
-        self.id = id
-        self.configuration = configuration or SmaHomeManagerCounterConfiguration()
+        super().__init__(name, type, id, configuration or SmaHomeManagerCounterConfiguration())
 
 
 class SmaHomeManagerInverterConfiguration:
@@ -37,13 +37,10 @@ class SmaHomeManagerInverterConfiguration:
         self.serials = serials
 
 
-class SmaHomeManagerInverterSetup:
+class SmaHomeManagerInverterSetup(ComponentSetup[SmaHomeManagerInverterConfiguration]):
     def __init__(self,
                  name: str = "SMA Home Manager Wechselrichter",
                  type: str = "inverter",
                  id: int = 0,
                  configuration: SmaHomeManagerInverterConfiguration = None) -> None:
-        self.name = name
-        self.type = type
-        self.id = id
-        self.configuration = configuration or SmaHomeManagerInverterConfiguration()
+        super().__init__(name, type, id, configuration or SmaHomeManagerInverterConfiguration())

--- a/packages/modules/sma_sunny_boy/config.py
+++ b/packages/modules/sma_sunny_boy/config.py
@@ -1,5 +1,6 @@
 from typing import Optional
 
+from modules.common.component_setup import ComponentSetup
 from modules.sma_sunny_boy.inv_version import SmaInverterVersion
 
 
@@ -25,16 +26,13 @@ class SmaSunnyBoyBatConfiguration:
         pass
 
 
-class SmaSunnyBoyBatSetup:
+class SmaSunnyBoyBatSetup(ComponentSetup[SmaSunnyBoyBatConfiguration]):
     def __init__(self,
                  name: str = "Sma Sunny Boy Speicher",
                  type: str = "bat",
                  id: int = 0,
                  configuration: SmaSunnyBoyBatConfiguration = None) -> None:
-        self.name = name
-        self.type = type
-        self.id = id
-        self.configuration = configuration or SmaSunnyBoyBatConfiguration()
+        super().__init__(name, type, id, configuration or SmaSunnyBoyBatConfiguration())
 
 
 class SmaSunnyBoySmartEnergyBatConfiguration:
@@ -42,16 +40,13 @@ class SmaSunnyBoySmartEnergyBatConfiguration:
         pass
 
 
-class SmaSunnyBoySmartEnergyBatSetup:
+class SmaSunnyBoySmartEnergyBatSetup(ComponentSetup[SmaSunnyBoySmartEnergyBatConfiguration]):
     def __init__(self,
                  name: str = "Sma Sunny Boy Smart Energy Speicher",
                  type: str = "bat_smart_energy",
                  id: int = 0,
                  configuration: SmaSunnyBoySmartEnergyBatConfiguration = None) -> None:
-        self.name = name
-        self.type = type
-        self.id = id
-        self.configuration = configuration or SmaSunnyBoySmartEnergyBatConfiguration()
+        super().__init__(name, type, id, configuration or SmaSunnyBoySmartEnergyBatConfiguration())
 
 
 class SmaSunnyBoyCounterConfiguration:
@@ -59,16 +54,13 @@ class SmaSunnyBoyCounterConfiguration:
         pass
 
 
-class SmaSunnyBoyCounterSetup:
+class SmaSunnyBoyCounterSetup(ComponentSetup[SmaSunnyBoyCounterConfiguration]):
     def __init__(self,
                  name: str = "Sma Sunny Boy Zähler",
                  type: str = "counter",
                  id: int = 0,
                  configuration: SmaSunnyBoyCounterConfiguration = None) -> None:
-        self.name = name
-        self.type = type
-        self.id = id
-        self.configuration = configuration or SmaSunnyBoyCounterConfiguration()
+        super().__init__(name, type, id, configuration or SmaSunnyBoyCounterConfiguration())
 
 
 class SmaSunnyBoyInverterConfiguration:
@@ -77,13 +69,10 @@ class SmaSunnyBoyInverterConfiguration:
         self.version = version
 
 
-class SmaSunnyBoyInverterSetup:
+class SmaSunnyBoyInverterSetup(ComponentSetup[SmaSunnyBoyInverterConfiguration]):
     def __init__(self,
                  name: str = "Sma Sunny Boy/Tripower Wechselrichter",
                  type: str = "inverter",
                  id: int = 0,
                  configuration: SmaSunnyBoyInverterConfiguration = None) -> None:
-        self.name = name
-        self.type = type
-        self.id = id
-        self.configuration = configuration or SmaSunnyBoyInverterConfiguration()
+        super().__init__(name, type, id, configuration or SmaSunnyBoyInverterConfiguration())

--- a/packages/modules/sma_sunny_island/config.py
+++ b/packages/modules/sma_sunny_island/config.py
@@ -1,5 +1,7 @@
 from typing import Optional
 
+from modules.common.component_setup import ComponentSetup
+
 
 class SmaSunnyIslandConfiguration:
     def __init__(self, ip_address: Optional[str] = None):
@@ -23,13 +25,10 @@ class SmaSunnyIslandBatConfiguration:
         pass
 
 
-class SmaSunnyIslandBatSetup:
+class SmaSunnyIslandBatSetup(ComponentSetup[SmaSunnyIslandBatConfiguration]):
     def __init__(self,
                  name: str = "SMA Sunny Island Speicher",
                  type: str = "bat",
                  id: int = 0,
                  configuration: SmaSunnyIslandBatConfiguration = None) -> None:
-        self.name = name
-        self.type = type
-        self.id = id
-        self.configuration = configuration or SmaSunnyIslandBatConfiguration()
+        super().__init__(name, type, id, configuration or SmaSunnyIslandBatConfiguration())

--- a/packages/modules/sma_webbox/config.py
+++ b/packages/modules/sma_webbox/config.py
@@ -1,5 +1,7 @@
 from typing import Optional
 
+from modules.common.component_setup import ComponentSetup
+
 
 class SmaWWebboxConfiguration:
     def __init__(self, ip_address: Optional[str] = None):
@@ -23,13 +25,10 @@ class SmaWebboxInverterConfiguration:
         pass
 
 
-class SmaWebboxInverterSetup:
+class SmaWebboxInverterSetup(ComponentSetup[SmaWebboxInverterConfiguration]):
     def __init__(self,
                  name: str = "SMA Wechselrichter Webbox",
                  type: str = "inverter",
                  id: int = 0,
                  configuration: SmaWebboxInverterConfiguration = None) -> None:
-        self.name = name
-        self.type = type
-        self.id = id
-        self.configuration = configuration or SmaWebboxInverterConfiguration()
+        super().__init__(name, type, id, configuration or SmaWebboxInverterConfiguration())

--- a/packages/modules/solaredge/config.py
+++ b/packages/modules/solaredge/config.py
@@ -1,3 +1,6 @@
+from modules.common.component_setup import ComponentSetup
+
+
 class SolaredgeConfiguration:
     def __init__(self,
                  port: int = 502,
@@ -25,16 +28,13 @@ class SolaredgeBatConfiguration:
         self.modbus_id = modbus_id
 
 
-class SolaredgeBatSetup:
+class SolaredgeBatSetup(ComponentSetup[SolaredgeBatConfiguration]):
     def __init__(self,
                  name: str = "SolarEdge Speicher",
                  type: str = "bat",
                  id: int = 0,
                  configuration: SolaredgeBatConfiguration = None) -> None:
-        self.name = name
-        self.type = type
-        self.id = id
-        self.configuration = configuration or SolaredgeBatConfiguration()
+        super().__init__(name, type, id, configuration or SolaredgeBatConfiguration())
 
 
 class SolaredgeCounterConfiguration:
@@ -42,16 +42,13 @@ class SolaredgeCounterConfiguration:
         self.modbus_id = modbus_id
 
 
-class SolaredgeCounterSetup:
+class SolaredgeCounterSetup(ComponentSetup[SolaredgeCounterConfiguration]):
     def __init__(self,
                  name: str = "SolarEdge Zähler",
                  type: str = "counter",
                  id: int = 0,
                  configuration: SolaredgeCounterConfiguration = None) -> None:
-        self.name = name
-        self.type = type
-        self.id = id
-        self.configuration = configuration or SolaredgeCounterConfiguration()
+        super().__init__(name, type, id, configuration or SolaredgeCounterConfiguration())
 
 
 class SolaredgeExternalInverterConfiguration:
@@ -59,16 +56,13 @@ class SolaredgeExternalInverterConfiguration:
         self.modbus_id = modbus_id
 
 
-class SolaredgeExternalInverterSetup:
+class SolaredgeExternalInverterSetup(ComponentSetup[SolaredgeExternalInverterConfiguration]):
     def __init__(self,
                  name: str = "SolarEdge externer Wechselrichter",
                  type: str = "external_inverter",
                  id: int = 0,
                  configuration: SolaredgeExternalInverterConfiguration = None) -> None:
-        self.name = name
-        self.type = type
-        self.id = id
-        self.configuration = configuration or SolaredgeExternalInverterConfiguration()
+        super().__init__(name, type, id, configuration or SolaredgeExternalInverterConfiguration())
 
 
 class SolaredgeInverterConfiguration:
@@ -76,13 +70,10 @@ class SolaredgeInverterConfiguration:
         self.modbus_id = modbus_id
 
 
-class SolaredgeInverterSetup:
+class SolaredgeInverterSetup(ComponentSetup[SolaredgeInverterConfiguration]):
     def __init__(self,
                  name: str = "Solaredge Wechselrichter",
                  type: str = "inverter",
                  id: int = 0,
                  configuration: SolaredgeInverterConfiguration = None) -> None:
-        self.name = name
-        self.type = type
-        self.id = id
-        self.configuration = configuration or SolaredgeInverterConfiguration()
+        super().__init__(name, type, id, configuration or SolaredgeInverterConfiguration())

--- a/packages/modules/solarmax/config.py
+++ b/packages/modules/solarmax/config.py
@@ -1,5 +1,7 @@
 from typing import Optional
 
+from modules.common.component_setup import ComponentSetup
+
 
 class SolarmaxConfiguration:
     def __init__(self, ip_address: Optional[str] = None, modbus_id: int = 1):
@@ -24,13 +26,10 @@ class SolarmaxInverterConfiguration:
         pass
 
 
-class SolarmaxInverterSetup:
+class SolarmaxInverterSetup(ComponentSetup[SolarmaxInverterConfiguration]):
     def __init__(self,
                  name: str = "Solarmax Wechselrichter",
                  type: str = "inverter",
                  id: int = 0,
                  configuration: SolarmaxInverterConfiguration = None) -> None:
-        self.name = name
-        self.type = type
-        self.id = id
-        self.configuration = configuration or SolarmaxInverterConfiguration()
+        super().__init__(name, type, id, configuration or SolarmaxInverterConfiguration())

--- a/packages/modules/solax/config.py
+++ b/packages/modules/solax/config.py
@@ -1,5 +1,7 @@
 from typing import Optional
 
+from modules.common.component_setup import ComponentSetup
+
 
 class SolaxConfiguration:
     def __init__(self, modbus_id: int = 1, ip_address: Optional[str] = None,):
@@ -24,16 +26,13 @@ class SolaxBatConfiguration:
         pass
 
 
-class SolaxBatSetup:
+class SolaxBatSetup(ComponentSetup[SolaxBatConfiguration]):
     def __init__(self,
                  name: str = "Solax Speicher",
                  type: str = "bat",
                  id: int = 0,
                  configuration: SolaxBatConfiguration = None) -> None:
-        self.name = name
-        self.type = type
-        self.id = id
-        self.configuration = configuration or SolaxBatConfiguration()
+        super().__init__(name, type, id, configuration or SolaxBatConfiguration())
 
 
 class SolaxCounterConfiguration:
@@ -41,16 +40,13 @@ class SolaxCounterConfiguration:
         pass
 
 
-class SolaxCounterSetup:
+class SolaxCounterSetup(ComponentSetup[SolaxCounterConfiguration]):
     def __init__(self,
                  name: str = "Solax Zähler",
                  type: str = "counter",
                  id: int = 0,
                  configuration: SolaxCounterConfiguration = None) -> None:
-        self.name = name
-        self.type = type
-        self.id = id
-        self.configuration = configuration or SolaxCounterConfiguration()
+        super().__init__(name, type, id, configuration or SolaxCounterConfiguration())
 
 
 class SolaxInverterConfiguration:
@@ -58,13 +54,10 @@ class SolaxInverterConfiguration:
         pass
 
 
-class SolaxInverterSetup:
+class SolaxInverterSetup(ComponentSetup[SolaxInverterConfiguration]):
     def __init__(self,
                  name: str = "Solax Wechselrichter",
                  type: str = "inverter",
                  id: int = 0,
                  configuration: SolaxInverterConfiguration = None) -> None:
-        self.name = name
-        self.type = type
-        self.id = id
-        self.configuration = configuration or SolaxInverterConfiguration()
+        super().__init__(name, type, id, configuration or SolaxInverterConfiguration())

--- a/packages/modules/sonnenbatterie/config.py
+++ b/packages/modules/sonnenbatterie/config.py
@@ -1,5 +1,7 @@
 from typing import Optional
 
+from modules.common.component_setup import ComponentSetup
+
 
 class SonnenBatterieConfiguration:
     def __init__(self, variant: int = 0, ip_address: Optional[str] = None):
@@ -24,16 +26,13 @@ class SonnenbatterieBatConfiguration:
         pass
 
 
-class SonnenbatterieBatSetup:
+class SonnenbatterieBatSetup(ComponentSetup[SonnenbatterieBatConfiguration]):
     def __init__(self,
                  name: str = "SonnenBatterie Speicher",
                  type: str = "bat",
                  id: int = 0,
                  configuration: SonnenbatterieBatConfiguration = None) -> None:
-        self.name = name
-        self.type = type
-        self.id = id
-        self.configuration = configuration or SonnenbatterieBatConfiguration()
+        super().__init__(name, type, id, configuration or SonnenbatterieBatConfiguration())
 
 
 class SonnenbatterieCounterConfiguration:
@@ -41,16 +40,13 @@ class SonnenbatterieCounterConfiguration:
         pass
 
 
-class SonnenbatterieCounterSetup:
+class SonnenbatterieCounterSetup(ComponentSetup[SonnenbatterieCounterConfiguration]):
     def __init__(self,
                  name: str = "SonnenBatterie Zähler",
                  type: str = "counter",
                  id: int = 0,
                  configuration: SonnenbatterieCounterConfiguration = None) -> None:
-        self.name = name
-        self.type = type
-        self.id = id
-        self.configuration = configuration or SonnenbatterieCounterConfiguration()
+        super().__init__(name, type, id, configuration or SonnenbatterieCounterConfiguration())
 
 
 class SonnenbatterieInverterConfiguration:
@@ -58,13 +54,10 @@ class SonnenbatterieInverterConfiguration:
         pass
 
 
-class SonnenbatterieInverterSetup:
+class SonnenbatterieInverterSetup(ComponentSetup[SonnenbatterieInverterConfiguration]):
     def __init__(self,
                  name: str = "SonnenBatterie Wechselrichter",
                  type: str = "inverter",
                  id: int = 0,
                  configuration: SonnenbatterieInverterConfiguration = None) -> None:
-        self.name = name
-        self.type = type
-        self.id = id
-        self.configuration = configuration or SonnenbatterieInverterConfiguration()
+        super().__init__(name, type, id, configuration or SonnenbatterieInverterConfiguration())

--- a/packages/modules/studer/config.py
+++ b/packages/modules/studer/config.py
@@ -1,5 +1,7 @@
 from typing import Optional
 
+from modules.common.component_setup import ComponentSetup
+
 
 class StuderConfiguration:
     def __init__(self, ip_address: Optional[str] = None):
@@ -23,16 +25,13 @@ class StuderBatConfiguration:
         pass
 
 
-class StuderBatSetup:
+class StuderBatSetup(ComponentSetup[StuderBatConfiguration]):
     def __init__(self,
                  name: str = "Studer Speicher",
                  type: str = "bat",
                  id: int = 0,
                  configuration: StuderBatConfiguration = None) -> None:
-        self.name = name
-        self.type = type
-        self.id = id
-        self.configuration = configuration or StuderBatConfiguration()
+        super().__init__(name, type, id, configuration or StuderBatConfiguration())
 
 
 class StuderInverterConfiguration:
@@ -41,13 +40,10 @@ class StuderInverterConfiguration:
         self.vc_type = vc_type  # studer_vc_type (MPPT type VS or VT))
 
 
-class StuderInverterSetup:
+class StuderInverterSetup(ComponentSetup[StuderInverterConfiguration]):
     def __init__(self,
                  name: str = "Studer Wechselrichter",
                  type: str = "inverter",
                  id: int = 0,
                  configuration: StuderInverterConfiguration = None) -> None:
-        self.name = name
-        self.type = type
-        self.id = id
-        self.configuration = configuration or StuderInverterConfiguration()
+        super().__init__(name, type, id, configuration or StuderInverterConfiguration())

--- a/packages/modules/sungrow/config.py
+++ b/packages/modules/sungrow/config.py
@@ -1,5 +1,7 @@
 from typing import Optional
 
+from modules.common.component_setup import ComponentSetup
+
 
 class SungrowConfiguration:
     def __init__(self, ip_address: Optional[str] = None, port: int = 502, modbus_id: int = 1):
@@ -25,16 +27,13 @@ class SungrowBatConfiguration:
         pass
 
 
-class SungrowBatSetup:
+class SungrowBatSetup(ComponentSetup[SungrowBatConfiguration]):
     def __init__(self,
                  name: str = "Sungrow Speicher",
                  type: str = "bat",
                  id: int = 0,
                  configuration: SungrowBatConfiguration = None) -> None:
-        self.name = name
-        self.type = type
-        self.id = id
-        self.configuration = configuration or SungrowBatConfiguration()
+        super().__init__(name, type, id, configuration or SungrowBatConfiguration())
 
 
 class SungrowCounterConfiguration:
@@ -42,16 +41,13 @@ class SungrowCounterConfiguration:
         self.version = version
 
 
-class SungrowCounterSetup:
+class SungrowCounterSetup(ComponentSetup[SungrowCounterConfiguration]):
     def __init__(self,
                  name: str = "Sungrow Zähler",
                  type: str = "counter",
                  id: int = 0,
                  configuration: SungrowCounterConfiguration = None) -> None:
-        self.name = name
-        self.type = type
-        self.id = id
-        self.configuration = configuration or SungrowCounterConfiguration()
+        super().__init__(name, type, id, configuration or SungrowCounterConfiguration())
 
 
 class SungrowInverterConfiguration:
@@ -59,13 +55,10 @@ class SungrowInverterConfiguration:
         pass
 
 
-class SungrowInverterSetup:
+class SungrowInverterSetup(ComponentSetup[SungrowInverterConfiguration]):
     def __init__(self,
                  name: str = "Sungrow Wechselrichter",
                  type: str = "inverter",
                  id: int = 0,
                  configuration: SungrowInverterConfiguration = None) -> None:
-        self.name = name
-        self.type = type
-        self.id = id
-        self.configuration = configuration or SungrowInverterConfiguration()
+        super().__init__(name, type, id, configuration or SungrowInverterConfiguration())

--- a/packages/modules/sunways/config.py
+++ b/packages/modules/sunways/config.py
@@ -1,5 +1,7 @@
 from typing import Optional
 
+from modules.common.component_setup import ComponentSetup
+
 
 class SunwaysConfiguration:
     def __init__(self, password: Optional[str] = None, ip_address: Optional[str] = None):
@@ -24,13 +26,10 @@ class SunwaysInverterConfiguration:
         pass
 
 
-class SunwaysInverterSetup:
+class SunwaysInverterSetup(ComponentSetup[SunwaysInverterConfiguration]):
     def __init__(self,
                  name: str = "Sunways Wechselrichter",
                  type: str = "inverter",
                  id: int = 0,
                  configuration: SunwaysInverterConfiguration = None) -> None:
-        self.name = name
-        self.type = type
-        self.id = id
-        self.configuration = configuration or SunwaysInverterConfiguration()
+        super().__init__(name, type, id, configuration or SunwaysInverterConfiguration())

--- a/packages/modules/tesla/config.py
+++ b/packages/modules/tesla/config.py
@@ -1,5 +1,7 @@
 from typing import Optional
 
+from modules.common.component_setup import ComponentSetup
+
 
 class TeslaConfiguration:
     def __init__(self, password: Optional[str] = None, email: Optional[str] = None, ip_address: Optional[str] = None):
@@ -25,16 +27,13 @@ class TeslaBatConfiguration:
         pass
 
 
-class TeslaBatSetup:
+class TeslaBatSetup(ComponentSetup[TeslaBatConfiguration]):
     def __init__(self,
                  name: str = "Tesla Speicher",
                  type: str = "bat",
                  id: int = 0,
                  configuration: TeslaBatConfiguration = None) -> None:
-        self.name = name
-        self.type = type
-        self.id = id
-        self.configuration = configuration or TeslaBatConfiguration()
+        super().__init__(name, type, id, configuration or TeslaBatConfiguration())
 
 
 class TeslaCounterConfiguration:
@@ -42,16 +41,13 @@ class TeslaCounterConfiguration:
         pass
 
 
-class TeslaCounterSetup:
+class TeslaCounterSetup(ComponentSetup[TeslaCounterConfiguration]):
     def __init__(self,
                  name: str = "Tesla Zähler",
                  type: str = "counter",
                  id: int = 0,
                  configuration: TeslaCounterConfiguration = None) -> None:
-        self.name = name
-        self.type = type
-        self.id = id
-        self.configuration = configuration or TeslaCounterConfiguration()
+        super().__init__(name, type, id, configuration or TeslaCounterConfiguration())
 
 
 class TeslaInverterConfiguration:
@@ -59,13 +55,10 @@ class TeslaInverterConfiguration:
         pass
 
 
-class TeslaInverterSetup:
+class TeslaInverterSetup(ComponentSetup[TeslaInverterConfiguration]):
     def __init__(self,
                  name: str = "Tesla Wechselrichter",
                  type: str = "inverter",
                  id: int = 0,
                  configuration: TeslaInverterConfiguration = None) -> None:
-        self.name = name
-        self.type = type
-        self.id = id
-        self.configuration = configuration or TeslaInverterConfiguration()
+        super().__init__(name, type, id, configuration or TeslaInverterConfiguration())

--- a/packages/modules/victron/config.py
+++ b/packages/modules/victron/config.py
@@ -1,5 +1,7 @@
 from typing import Optional
 
+from modules.common.component_setup import ComponentSetup
+
 
 class VictronConfiguration:
     def __init__(self, ip_address: Optional[str] = None):
@@ -23,16 +25,13 @@ class VictronBatConfiguration:
         self.modbus_id = modbus_id
 
 
-class VictronBatSetup:
+class VictronBatSetup(ComponentSetup[VictronBatConfiguration]):
     def __init__(self,
                  name: str = "Victron Speicher",
                  type: str = "bat",
                  id: int = 0,
                  configuration: VictronBatConfiguration = None) -> None:
-        self.name = name
-        self.type = type
-        self.id = id
-        self.configuration = configuration or VictronBatConfiguration()
+        super().__init__(name, type, id, configuration or VictronBatConfiguration())
 
 
 class VictronCounterConfiguration:
@@ -41,16 +40,13 @@ class VictronCounterConfiguration:
         self.modbus_id = modbus_id
 
 
-class VictronCounterSetup:
+class VictronCounterSetup(ComponentSetup[VictronCounterConfiguration]):
     def __init__(self,
                  name: str = "Victron Zähler",
                  type: str = "counter",
                  id: int = 0,
                  configuration: VictronCounterConfiguration = None) -> None:
-        self.name = name
-        self.type = type
-        self.id = id
-        self.configuration = configuration or VictronCounterConfiguration()
+        super().__init__(name, type, id, configuration or VictronCounterConfiguration())
 
 
 class VictronInverterConfiguration:
@@ -59,13 +55,10 @@ class VictronInverterConfiguration:
         self.modbus_id = modbus_id
 
 
-class VictronInverterSetup:
+class VictronInverterSetup(ComponentSetup[VictronInverterConfiguration]):
     def __init__(self,
                  name: str = "Victron Wechselrichter",
                  type: str = "inverter",
                  id: int = 0,
                  configuration: VictronInverterConfiguration = None) -> None:
-        self.name = name
-        self.type = type
-        self.id = id
-        self.configuration = configuration or VictronInverterConfiguration()
+        super().__init__(name, type, id, configuration or VictronInverterConfiguration())


### PR DESCRIPTION
Die Funktion `ComponentInfo.from_component_config` hat aktuell eine falsche Type-annotation für den Parameter `component_config`. So wie es aktuell aussieht bleibt einem nichts anderes übrig als den Typ auf `Any` zu setzen. Das allerdings macht die Vorschrift, dass in der Konfiguration die Eigenschaften mit den Namen `id`, `name` und `type` vorkommen müssen unsichtbar. Eine Abweichung davon wird dann erst zur Laufzeit bemerkt. Besser wäre es das mit richtigen Type-Annotations zu lösen.

Auf der Suche nach einer besseren Lösung ist mir aufgefallen, dass die `xxxSetup`-Klassen alle nahezu identisch sind. So ähnlich, dass ich mit dem Regex:
```regex
class ([A-Za-z0-9]+Setup):\s*def __init__\(self,\s*name: str = "([^"]+)",\s*type: str = "([^"]+)",\s*id: int = 0,\s*configuration: ([a-zA-Z0-9]+) = None\) -> None:(?:\s*self.*){4}
```
76 Ergebnisse finde. Mit `class [A-Za-z0-9]+Setup:` finde ich nur 1 weitere Klasse: Die `DiscovergyCounterSetup`, denn bei der ist `id` ein `Optional[int]` statt wie bei allen anderen Klassen ein `int`. Da könnte man auch noch drüber nachdenken ob das nicht mit in das Schema gebracht werden kann/soll.

Ersetzt habe ich das obige Pattern durch:
```python
class $1(ComponentSetup[$4]):
    def __init__(self,
                 name: str = "$2",
                 type: str = "$3",
                 id: int = 0,
                 configuration: $4 = None) -> None:
        super().__init__(name, type, id, configuration or $4())
```

Wenn der einzige Unterschied zwischen 76 verschiedenen Klassen, die Standardwerte für die Parameter sind, dann schreit das danach diese zu vereinen. Das würde den Code nicht nur schlanker machen, sondern die offensichtliche Vorschrift wie die Eigenschaften heißen sollen transparenter und weniger fehleranfällig machen, was man dann direkt anhand der Funktion `ComponentInfo.from_component_config` sieht.

Es steht die Frage im Raum ob dies die bestmögliche Lösung ist. Denn obwohl diese Herangehensweise kommuniziert welche Eigenschaften zu erwarten sind und das ganze typsicher angewandt werden kann, bedeutet das immernoch eine ganze Menge an Klassen, die sich ausschließlich durch die Default-Werte der init-Methode unterscheiden. Allerdings hat dieses Vorgehen den Charme, dass es einfach so umgesetzt werden kann ohne, dass sich die API in irgendeiner Weise ändert. Kein sonstiger bestehender Code muss angepasst werden.

Dieser PR enthält auch #2338. Wenn dieser hier genommen wird, ist der #2338 entsprechend gegenstandslos.