### PR TITLE
add missing type annotations for methods that never return, but only raise

### DIFF
--- a/packages/modules/common/lovato.py
+++ b/packages/modules/common/lovato.py
@@ -1,8 +1,9 @@
 #!/usr/bin/env python3
 
-from modules.common.fault_state import FaultState
+from typing import List, Tuple, NoReturn
+
 from modules.common import modbus
-from typing import List, Tuple
+from modules.common.fault_state import FaultState
 from modules.common.modbus import ModbusDataType
 
 
@@ -11,7 +12,7 @@ class Lovato:
         self.client = client
         self.id = modbus_id
 
-    def __process_error(self, e):
+    def __process_error(self, e) -> NoReturn:
         if isinstance(e, FaultState):
             raise
         else:

--- a/packages/modules/common/mpm3pm.py
+++ b/packages/modules/common/mpm3pm.py
@@ -1,8 +1,9 @@
 #!/usr/bin/env python3
-from modules.common.fault_state import FaultState
+from typing import List, Tuple, NoReturn
+
 from modules.common import modbus
+from modules.common.fault_state import FaultState
 from modules.common.modbus import ModbusDataType
-from typing import List, Tuple
 
 
 class Mpm3pm:
@@ -10,7 +11,7 @@ class Mpm3pm:
         self.client = client
         self.id = modbus_id
 
-    def __process_error(self, e):
+    def __process_error(self, e) -> NoReturn:
         if isinstance(e, FaultState):
             raise
         else:

--- a/packages/modules/common/sdm.py
+++ b/packages/modules/common/sdm.py
@@ -1,8 +1,9 @@
 #!/usr/bin/env python3
+from typing import List, Tuple, NoReturn
+
 from modules.common import modbus
 from modules.common.fault_state import FaultState
 from modules.common.modbus import ModbusDataType
-from typing import List, Tuple
 
 
 class Sdm:
@@ -10,7 +11,7 @@ class Sdm:
         self.client = client
         self.id = modbus_id
 
-    def process_error(self, e):
+    def process_error(self, e) -> NoReturn:
         if isinstance(e, FaultState):
             raise
         else:

--- a/packages/modules/common/simcount.py
+++ b/packages/modules/common/simcount.py
@@ -3,9 +3,10 @@ Berechnet die importierte und exportierte Leistung, wenn der Zähler / PV-Modul 
 """
 import logging
 import os
-import paho.mqtt.client as mqtt
 import time
 import typing
+
+import paho.mqtt.client as mqtt
 
 from helpermodules import compatibility
 from helpermodules import pub
@@ -15,7 +16,7 @@ from modules.common.fault_state import FaultState
 log = logging.getLogger(__name__)
 
 
-def process_error(e):
+def process_error(e) -> typing.NoReturn:
     raise FaultState.error(__name__+" "+str(type(e))+" "+str(e)) from e
 
 


### PR DESCRIPTION
> For a checked function, the default annotation for arguments and for the return type is Any.

Quelle: https://peps.python.org/pep-0484/#the-meaning-of-annotations

> The typing module provides a special type NoReturn to annotate functions that never return normally. For example, a function that unconditionally raises an exception

Quelle: https://peps.python.org/pep-0484/#the-noreturn-type

MyPy [sieht das auch so](https://github.com/python/mypy/issues/8964).

Daher fügt dieser PR die entsprechenden Type-Annotations für Funktionen hinzu, die immer Exceptions werfen.