### PR TITLE
remove top-level `__init__.py` (directory "packages" is not a package - it contains packages)

### DIFF
--- a/packages/helpermodules/exceptions/registry_test.py
+++ b/packages/helpermodules/exceptions/registry_test.py
@@ -32,7 +32,7 @@ class ErrorF(ErrorD):
 
 
 @pytest.mark.parametrize("exception,expected_message", [
-    [ErrorRoot, "<class 'packages.helpermodules.exceptions.registry_test.ErrorRoot'> ErrorRoot"],
+    [ErrorRoot, "<class 'helpermodules.exceptions.registry_test.ErrorRoot'> ErrorRoot"],
     [ErrorB, "B"],
     [ErrorC, "A"],
     [ErrorD, "B"],


### PR DESCRIPTION
> For example, the following file system layout defines a top level parent package with three subpackages:
> ```
> parent/
>     __init__.py
>     one/
>         __init__.py
>     two/
>         __init__.py
>     three/
>         __init__.py
> ```

https://docs.python.org/3/reference/import.html#regular-packages

In unserem Fall heißt es `packages` und nicht `parent`. Dadurch gibt es ein Paket mit dem Namen `packages`. Das führt dazu, dass alle Klassen in zwei Paketen vorkommen. Folgende Zeilen funktionieren *beide*:
```python
from packages.modules.alpha_ess.config import AlphaEssBatSetup
from modules.alpha_ess.config import AlphaEssBatSetup
```

Das ist nicht gewollt. Der Ordner `packages` enthält Pakete, ist aber selbst kein Paket. Daher muss die `__init__.py` da weg.