### PR TITLE
fix rfid null tag

### DIFF
--- a/modules/extopenwb/main.sh
+++ b/modules/extopenwb/main.sh
@@ -5,23 +5,23 @@ RAMDISKDIR="${OPENWBBASEDIR}/ramdisk"
 chargep=$1
 ip=$2
 chargepcp=$3
-outputname="extopenwb${chargep}temp"
-timeout 1 mosquitto_sub -v -h "$ip" -t "openWB/lp/$chargepcp/#" > "$RAMDISKDIR/$outputname"
+outputname="$RAMDISKDIR/extopenwb${chargep}temp"
+timeout 1 mosquitto_sub -v -h "$ip" -t "openWB/lp/$chargepcp/#" > "$outputname"
 myipaddress=$(<"$RAMDISKDIR/ipaddress")
 
-if [[ $(wc -l <"$RAMDISKDIR/$outputname") -ge 5 ]]; then
+if [[ $(wc -l <"$outputname") -ge 5 ]]; then
 
-	watt=$(grep "\/W" "$RAMDISKDIR/$outputname" |head -1 | awk '{print $2}') 
-	VPhase1=$(grep "VPhase1" "$RAMDISKDIR/$outputname" |head -1 | awk '{print $2}') 
-	VPhase2=$(grep "VPhase2" "$RAMDISKDIR/$outputname" |head -1 | awk '{print $2}') 
-	VPhase3=$(grep "VPhase3" "$RAMDISKDIR/$outputname" |head -1 | awk '{print $2}') 
-	APhase1=$(grep "APhase1 ""$RAMDISKDIR/$outputname" |head -1 | awk '{print $2}') 
-	APhase2=$(grep "APhase2" "$RAMDISKDIR/$outputname" |head -1 | awk '{print $2}') 
-	APhase3=$(grep "APhase3" "$RAMDISKDIR/$outputname" |head -1 | awk '{print $2}')
-	boolChargeStat=$(grep "boolChargeStat" "$RAMDISKDIR/$outputname" |head -1 | awk '{print $2}') 
-	boolPlugStat=$(grep "boolPlugStat" "$RAMDISKDIR/$outputname" |head -1 | awk '{print $2}') 
-	kWhCounter=$(grep "kWhCounter" "$RAMDISKDIR/$outputname" |head -1 | awk '{print $2}')
-	LastScannedRfidTag=$(grep "LastScannedRfidTag" "$RAMDISKDIR/$outputname" |head -1 | awk '{print $2}')
+	watt=$(grep "\/W" "$outputname" |head -1 | awk '{print $2}') 
+	VPhase1=$(grep "VPhase1" "$outputname" |head -1 | awk '{print $2}') 
+	VPhase2=$(grep "VPhase2" "$outputname" |head -1 | awk '{print $2}') 
+	VPhase3=$(grep "VPhase3" "$outputname" |head -1 | awk '{print $2}') 
+	APhase1=$(grep "APhase1 ""$outputname" |head -1 | awk '{print $2}') 
+	APhase2=$(grep "APhase2" "$outputname" |head -1 | awk '{print $2}') 
+	APhase3=$(grep "APhase3" "$outputname" |head -1 | awk '{print $2}')
+	boolChargeStat=$(grep "boolChargeStat" "$outputname" |head -1 | awk '{print $2}') 
+	boolPlugStat=$(grep "boolPlugStat" "$outputname" |head -1 | awk '{print $2}') 
+	kWhCounter=$(grep "kWhCounter" "$outputname" |head -1 | awk '{print $2}')
+	LastScannedRfidTag=$(grep "LastScannedRfidTag" "$outputname" |head -1 | awk '{print $2}')
 
 	if (( chargep == "1" ));then
 		echo "$VPhase1" > "$RAMDISKDIR/llv1"

--- a/modules/extopenwb/main.sh
+++ b/modules/extopenwb/main.sh
@@ -1,108 +1,101 @@
 #!/bin/bash
+OPENWBBASEDIR=$(cd "$(dirname "$0")/../../" && pwd)
+RAMDISKDIR="${OPENWBBASEDIR}/ramdisk"
+
 chargep=$1
 ip=$2
 chargepcp=$3
-outputname="extopenwb"$chargep"temp"
-timeout 1 mosquitto_sub -v -h $ip -t openWB/lp/$chargepcp/# > /var/www/html/openWB/ramdisk/$outputname
-myipaddress=$(</var/www/html/openWB/ramdisk/ipaddress)
-#values=$(</var/www/html/openWB/ramdisk/extopenwb$chargeptemp)
-#echo -e $values
-#watt=$(mosquitto_sub -C 1 -h $ip -t openWB/lp/1/W) 
-#VPhase1=$(mosquitto_sub -C 1 -h $ip -t openWB/lp/1/VPhase1) 
-#VPhase2=$(mosquitto_sub -C 1 -h $ip -t openWB/lp/1/VPhase2 ) 
-#VPhase3=$(mosquitto_sub -C 1 -h $ip -t openWB/lp/1/VPhase3 ) 
-#APhase1=$(mosquitto_sub -C 1 -h $ip -t openWB/lp/1/APhase1 ) 
-#APhase2=$(mosquitto_sub -C 1 -h $ip -t openWB/lp/1/APhase2 ) 
-#APhase3=$(mosquitto_sub -C 1 -h $ip -t openWB/lp/1/APhase3 ) 
-#kWhCounter=$(mosquitto_sub -C 1 -h $ip -t openWB/lp/1/kWhCounter ) 
+outputname="extopenwb${chargep}temp"
+timeout 1 mosquitto_sub -v -h "$ip" -t "openWB/lp/$chargepcp/#" > "$RAMDISKDIR/$outputname"
+myipaddress=$(<"$RAMDISKDIR/ipaddress")
 
-if [[ $(wc -l </var/www/html/openWB/ramdisk/$outputname) -ge 5 ]]; then
+if [[ $(wc -l <"$RAMDISKDIR/$outputname") -ge 5 ]]; then
 
-	watt=$(grep \/W /var/www/html/openWB/ramdisk/$outputname |head -1 | awk '{print $2}') 
-	VPhase1=$(grep VPhase1 /var/www/html/openWB/ramdisk/$outputname |head -1 | awk '{print $2}') 
-	VPhase2=$(grep VPhase2 /var/www/html/openWB/ramdisk/$outputname |head -1 | awk '{print $2}') 
-	VPhase3=$(grep VPhase3 /var/www/html/openWB/ramdisk/$outputname |head -1 | awk '{print $2}') 
-	APhase1=$(grep APhase1 /var/www/html/openWB/ramdisk/$outputname |head -1 | awk '{print $2}') 
-	APhase2=$(grep APhase2 /var/www/html/openWB/ramdisk/$outputname |head -1 | awk '{print $2}') 
-	APhase3=$(grep APhase3 /var/www/html/openWB/ramdisk/$outputname |head -1 | awk '{print $2}')
-	boolChargeStat=$(grep boolChargeStat /var/www/html/openWB/ramdisk/$outputname |head -1 | awk '{print $2}') 
-	boolPlugStat=$(grep boolPlugStat /var/www/html/openWB/ramdisk/$outputname |head -1 | awk '{print $2}') 
-	kWhCounter=$(grep kWhCounter /var/www/html/openWB/ramdisk/$outputname |head -1 | awk '{print $2}')
-	LastScannedRfidTag=$(grep LastScannedRfidTag /var/www/html/openWB/ramdisk/$outputname |head -1 | awk '{print $2}')
+	watt=$(grep "\/W" "$RAMDISKDIR/$outputname" |head -1 | awk '{print $2}') 
+	VPhase1=$(grep "VPhase1" "$RAMDISKDIR/$outputname" |head -1 | awk '{print $2}') 
+	VPhase2=$(grep "VPhase2" "$RAMDISKDIR/$outputname" |head -1 | awk '{print $2}') 
+	VPhase3=$(grep "VPhase3" "$RAMDISKDIR/$outputname" |head -1 | awk '{print $2}') 
+	APhase1=$(grep "APhase1 ""$RAMDISKDIR/$outputname" |head -1 | awk '{print $2}') 
+	APhase2=$(grep "APhase2" "$RAMDISKDIR/$outputname" |head -1 | awk '{print $2}') 
+	APhase3=$(grep "APhase3" "$RAMDISKDIR/$outputname" |head -1 | awk '{print $2}')
+	boolChargeStat=$(grep "boolChargeStat" "$RAMDISKDIR/$outputname" |head -1 | awk '{print $2}') 
+	boolPlugStat=$(grep "boolPlugStat" "$RAMDISKDIR/$outputname" |head -1 | awk '{print $2}') 
+	kWhCounter=$(grep "kWhCounter" "$RAMDISKDIR/$outputname" |head -1 | awk '{print $2}')
+	LastScannedRfidTag=$(grep "LastScannedRfidTag" "$RAMDISKDIR/$outputname" |head -1 | awk '{print $2}')
 
 	if (( chargep == "1" ));then
-		echo $VPhase1 > /var/www/html/openWB/ramdisk/llv1
-		echo $VPhase2 > /var/www/html/openWB/ramdisk/llv2
-		echo $VPhase3 > /var/www/html/openWB/ramdisk/llv3
-		echo $APhase1 > /var/www/html/openWB/ramdisk/lla1
-		echo $APhase2 > /var/www/html/openWB/ramdisk/lla2
-		echo $APhase3 > /var/www/html/openWB/ramdisk/lla3
-		echo $watt > /var/www/html/openWB/ramdisk/llaktuell
-		echo $kWhCounter > /var/www/html/openWB/ramdisk/llkwh
-		echo $boolPlugStat > /var/www/html/openWB/ramdisk/plugstat
-		echo $boolChargeStat > /var/www/html/openWB/ramdisk/chargestat
-		soc=$(</var/www/html/openWB/ramdisk/soc)
-		mosquitto_pub -h $ip -r -t openWB/set/lp/$chargepcp/%Soc -m "$soc"
+		echo "$VPhase1" > "$RAMDISKDIR/llv1"
+		echo "$VPhase2" > "$RAMDISKDIR/llv2"
+		echo "$VPhase3" > "$RAMDISKDIR/llv3"
+		echo "$APhase1" > "$RAMDISKDIR/lla1"
+		echo "$APhase2" > "$RAMDISKDIR/lla2"
+		echo "$APhase3" > "$RAMDISKDIR/lla3"
+		echo "$watt" > "$RAMDISKDIR/llaktuell"
+		echo "$kWhCounter" > "$RAMDISKDIR/llkwh"
+		echo "$boolPlugStat" > "$RAMDISKDIR/plugstat"
+		echo "$boolChargeStat" > "$RAMDISKDIR/chargestat"
+		soc=$(<"$RAMDISKDIR/soc")
+		mosquitto_pub -h "$ip" -r -t "openWB/set/lp/$chargepcp/%Soc" -m "$soc"
 	fi
 	if (( chargep == "2" ));then
-		echo $VPhase1 > /var/www/html/openWB/ramdisk/llvs11
-		echo $VPhase2 > /var/www/html/openWB/ramdisk/llvs12
-		echo $VPhase3 > /var/www/html/openWB/ramdisk/llvs13
-		echo $APhase1 > /var/www/html/openWB/ramdisk/llas11
-		echo $APhase2 > /var/www/html/openWB/ramdisk/llas12
-		echo $APhase3 > /var/www/html/openWB/ramdisk/llas13
-		echo $watt > /var/www/html/openWB/ramdisk/llaktuells1
-		echo $kWhCounter > /var/www/html/openWB/ramdisk/llkwhs1
-		echo $boolPlugStat > /var/www/html/openWB/ramdisk/plugstats1
-		echo $boolChargeStat > /var/www/html/openWB/ramdisk/chargestats1
-		soc=$(</var/www/html/openWB/ramdisk/soc1)
-		mosquitto_pub -h $ip -r -t openWB/set/lp/$chargepcp/%Soc -m "$soc"
+		echo "$VPhase1" > "$RAMDISKDIR/llvs11"
+		echo "$VPhase2" > "$RAMDISKDIR/llvs12"
+		echo "$VPhase3" > "$RAMDISKDIR/llvs13"
+		echo "$APhase1" > "$RAMDISKDIR/llas11"
+		echo "$APhase2" > "$RAMDISKDIR/llas12"
+		echo "$APhase3" > "$RAMDISKDIR/llas13"
+		echo "$watt" > "$RAMDISKDIR/llaktuells1"
+		echo "$kWhCounter" > "$RAMDISKDIR/llkwhs1"
+		echo "$boolPlugStat" > "$RAMDISKDIR/plugstats1"
+		echo "$boolChargeStat" > "$RAMDISKDIR/chargestats1"
+		soc=$(<"$RAMDISKDIR/soc1")
+		mosquitto_pub -h "$ip" -r -t "openWB/set/lp/$chargepcp/%Soc" -m "$soc"
 	fi
 	if (( chargep == "3" ));then
-		echo $VPhase1 > /var/www/html/openWB/ramdisk/llvs21
-		echo $VPhase2 > /var/www/html/openWB/ramdisk/llvs22
-		echo $VPhase3 > /var/www/html/openWB/ramdisk/llvs23
-		echo $APhase1 > /var/www/html/openWB/ramdisk/llas21
-		echo $APhase2 > /var/www/html/openWB/ramdisk/llas22
-		echo $APhase3 > /var/www/html/openWB/ramdisk/llas23
-		echo $watt > /var/www/html/openWB/ramdisk/llaktuells2
-		echo $kWhCounter > /var/www/html/openWB/ramdisk/llkwhs2
-		echo $boolPlugStat > /var/www/html/openWB/ramdisk/plugstatlp3
-		echo $boolChargeStat > /var/www/html/openWB/ramdisk/chargestatlp3
+		echo "$VPhase1" > "$RAMDISKDIR/llvs21"
+		echo "$VPhase2" > "$RAMDISKDIR/llvs22"
+		echo "$VPhase3" > "$RAMDISKDIR/llvs23"
+		echo "$APhase1" > "$RAMDISKDIR/llas21"
+		echo "$APhase2" > "$RAMDISKDIR/llas22"
+		echo "$APhase3" > "$RAMDISKDIR/llas23"
+		echo "$watt" > "$RAMDISKDIR/llaktuells2"
+		echo "$kWhCounter" > "$RAMDISKDIR/llkwhs2"
+		echo "$boolPlugStat" > "$RAMDISKDIR/plugstatlp3"
+		echo "$boolChargeStat" > "$RAMDISKDIR/chargestatlp3"
 	fi
 	if (( chargep > "3" ));then
-		echo $VPhase1 > /var/www/html/openWB/ramdisk/llv1lp$chargep
-		echo $VPhase2 > /var/www/html/openWB/ramdisk/llv2lp$chargep
-		echo $VPhase3 > /var/www/html/openWB/ramdisk/llv3lp$chargep
-		echo $APhase1 > /var/www/html/openWB/ramdisk/lla1lp$chargep
-		echo $APhase2 > /var/www/html/openWB/ramdisk/lla2lp$chargep
-		echo $APhase3 > /var/www/html/openWB/ramdisk/lla3lp$chargep
-		echo $watt > /var/www/html/openWB/ramdisk/llaktuelllp$chargep
-		echo $kWhCounter > /var/www/html/openWB/ramdisk/llkwhlp$chargep
-		echo $boolPlugStat > /var/www/html/openWB/ramdisk/plugstatlp$chargep
-		echo $boolChargeStat > /var/www/html/openWB/ramdisk/chargestatlp$chargep
+		echo "$VPhase1" > "$RAMDISKDIR/llv1lp$chargep"
+		echo "$VPhase2" > "$RAMDISKDIR/llv2lp$chargep"
+		echo "$VPhase3" > "$RAMDISKDIR/llv3lp$chargep"
+		echo "$APhase1" > "$RAMDISKDIR/lla1lp$chargep"
+		echo "$APhase2" > "$RAMDISKDIR/lla2lp$chargep"
+		echo "$APhase3" > "$RAMDISKDIR/lla3lp$chargep"
+		echo "$watt" > "$RAMDISKDIR/llaktuelllp$chargep"
+		echo "$kWhCounter" > "$RAMDISKDIR/llkwhlp$chargep"
+		echo "$boolPlugStat" > "$RAMDISKDIR/plugstatlp$chargep"
+		echo "$boolChargeStat" > "$RAMDISKDIR/chargestatlp$chargep"
 	fi
-	if ! [ -z $LastScannedRfidTag ] && [ $LastScannedRfidTag -ge "3" ]; then
-		echo $LastScannedRfidTag > /var/www/html/openWB/ramdisk/readtag
-		mosquitto_pub -h $ip -r -t openWB/set/isss/ClearRfid -m "1"
+	if [ -n "$LastScannedRfidTag" ] && [ "$LastScannedRfidTag" -ge "3" ]; then
+		echo "$LastScannedRfidTag" > "$RAMDISKDIR/readtag"
+		mosquitto_pub -h "$ip" -r -t "openWB/set/isss/ClearRfid" -m "1"
 	fi
 
-	mosquitto_pub -h $ip -r -t openWB/set/isss/parentWB -m "$myipaddress"
+	mosquitto_pub -h "$ip" -r -t "openWB/set/isss/parentWB" -m "$myipaddress"
 	if (( chargepcp == "1" )); then
-		mosquitto_pub -h $ip -r -t openWB/set/isss/parentCPlp1 -m "$chargep"
+		mosquitto_pub -h "$ip" -r -t "openWB/set/isss/parentCPlp1" -m "$chargep"
 	else
-		mosquitto_pub -h $ip -r -t openWB/set/isss/parentCPlp2 -m "$chargep"
+		mosquitto_pub -h "$ip" -r -t "openWB/set/isss/parentCPlp2" -m "$chargep"
 	fi
-	mosquitto_pub -h $ip -r -t openWB/set/isss/heartbeat -m "0"
-	openwbModulePublishState "LP" 0 "Kein Fehler" $chargep
-	echo 0 > /var/www/html/openWB/ramdisk/errcounterextopenwb
+	mosquitto_pub -h "$ip" -r -t "openWB/set/isss/heartbeat" -m "0"
+	openwbModulePublishState "LP" 0 "Kein Fehler" "$chargep"
+	echo 0 > "$RAMDISKDIR/errcounterextopenwb"
 else
-	openwbModulePublishState "LP" 1 "Keine Daten vom LP erhalten, IP Korrekt?" $chargep
+	openwbModulePublishState "LP" 1 "Keine Daten vom LP erhalten, IP Korrekt?" "$chargep"
 	openwbDebugLog "MAIN" 0 "Keine Daten von externe openWB LP $chargep empfangen"
-	errcounter=$(</var/www/html/openWB/ramdisk/errcounterextopenwb)
-	errcounter=$((errcounter+1))
-	echo $errcounter > /var/www/html/openWB/ramdisk/errcounterextopenwb
+	errcounter=$(<"$RAMDISKDIR/errcounterextopenwb")
+	errcounter=$(( errcounter + 1 ))
+	echo "$errcounter" > "$RAMDISKDIR/errcounterextopenwb"
 	if (( errcounter > 5 )); then
-		echo "Fehler bei Auslesung externe openWB LP $chargep, Netzwerk oder Konfiguration prüfen" > /var/www/html/openWB/ramdisk/lastregelungaktiv
+		echo "Fehler bei Auslesung externe openWB LP $chargep, Netzwerk und Konfiguration prüfen" > "$RAMDISKDIR/lastregelungaktiv"
 	fi
 fi

--- a/modules/extopenwblp1/main.sh
+++ b/modules/extopenwblp1/main.sh
@@ -1,2 +1,2 @@
 #!/bin/bash
-/var/www/html/openWB/modules/extopenwb/main.sh 1 $chargep1ip $chargep1cp
+/var/www/html/openWB/modules/extopenwb/main.sh 1 "$chargep1ip" "$chargep1cp"

--- a/modules/extopenwblp2/main.sh
+++ b/modules/extopenwblp2/main.sh
@@ -1,2 +1,2 @@
 #!/bin/bash
-/var/www/html/openWB/modules/extopenwb/main.sh 2 $chargep2ip $chargep2cp
+/var/www/html/openWB/modules/extopenwb/main.sh 2 "$chargep2ip" "$chargep2cp"

--- a/modules/extopenwblp3/main.sh
+++ b/modules/extopenwblp3/main.sh
@@ -1,2 +1,2 @@
 #!/bin/bash
-/var/www/html/openWB/modules/extopenwb/main.sh 3 $chargep3ip $chargep3cp
+/var/www/html/openWB/modules/extopenwb/main.sh 3 "$chargep3ip" "$chargep3cp"

--- a/modules/extopenwblp4/main.sh
+++ b/modules/extopenwblp4/main.sh
@@ -1,2 +1,2 @@
 #!/bin/bash
-/var/www/html/openWB/modules/extopenwb/main.sh 4 $chargep4ip $chargep4cp
+/var/www/html/openWB/modules/extopenwb/main.sh 4 "$chargep4ip" "$chargep4cp"

--- a/modules/extopenwblp5/main.sh
+++ b/modules/extopenwblp5/main.sh
@@ -1,2 +1,2 @@
 #!/bin/bash
-/var/www/html/openWB/modules/extopenwb/main.sh 5 $chargep5ip $chargep5cp
+/var/www/html/openWB/modules/extopenwb/main.sh 5 "$chargep5ip" "$chargep5cp"

--- a/modules/extopenwblp6/main.sh
+++ b/modules/extopenwblp6/main.sh
@@ -1,2 +1,2 @@
 #!/bin/bash
-/var/www/html/openWB/modules/extopenwb/main.sh 6 $chargep6ip $chargep6cp
+/var/www/html/openWB/modules/extopenwb/main.sh 6 "$chargep6ip" "$chargep6cp"

--- a/modules/extopenwblp7/main.sh
+++ b/modules/extopenwblp7/main.sh
@@ -1,2 +1,2 @@
 #!/bin/bash
-/var/www/html/openWB/modules/extopenwb/main.sh 7 $chargep7ip $chargep7cp
+/var/www/html/openWB/modules/extopenwb/main.sh 7 "$chargep7ip" "$chargep7cp"

--- a/modules/extopenwblp8/main.sh
+++ b/modules/extopenwblp8/main.sh
@@ -1,2 +1,2 @@
 #!/bin/bash
-/var/www/html/openWB/modules/extopenwb/main.sh 8 $chargep8ip $chargep8cp
+/var/www/html/openWB/modules/extopenwb/main.sh 8 "$chargep8ip" "$chargep8cp"

--- a/runs/isss.py
+++ b/runs/isss.py
@@ -524,7 +524,7 @@ def read_meter():
                     mclient.loop(timeout=2.0)
                     DeviceValues.update({'rfidtag': str(rfidtag)})
                 if parentWB != "0":
-                    if rfidtag == '0\n':
+                    if rfidtag.rstrip() == "0":
                         rfidtag = None  # default value for 2.0 is None, not "0"
                     remoteclient.publish("openWB/set/chargepoint/"+parentCPlp1+"/get/rfid",
                                          payload=json.dumps(rfidtag), qos=0, retain=True)
@@ -661,7 +661,7 @@ def read_meter():
                         mclient.loop(timeout=2.0)
                         DeviceValues.update({'rfidtag': str(rfidtag)})
                     if parentWB != "0":
-                        if rfidtag == '0\n':
+                        if rfidtag.rstrip() == "0":
                             rfidtag = None  # default value for 2.0 is None, not "0"
                         remoteclient.publish("openWB/set/chargepoint/"+parentCPlp2+"/get/rfid",
                                              payload=json.dumps(rfidtag), qos=0, retain=True)


### PR DESCRIPTION
- fix shellcheck warnings in extopenwb module
- fix detecting rfid null tag in `isss.py`