### PR TITLE
fix misplaced space character (causing failure to read external charg…

### DIFF
--- a/modules/extopenwb/main.sh
+++ b/modules/extopenwb/main.sh
@@ -15,7 +15,7 @@ if [[ $(wc -l <"$outputname") -ge 5 ]]; then
 	VPhase1=$(grep "VPhase1" "$outputname" |head -1 | awk '{print $2}') 
 	VPhase2=$(grep "VPhase2" "$outputname" |head -1 | awk '{print $2}') 
 	VPhase3=$(grep "VPhase3" "$outputname" |head -1 | awk '{print $2}') 
-	APhase1=$(grep "APhase1 ""$outputname" |head -1 | awk '{print $2}') 
+	APhase1=$(grep "APhase1" "$outputname" |head -1 | awk '{print $2}')
 	APhase2=$(grep "APhase2" "$outputname" |head -1 | awk '{print $2}') 
 	APhase3=$(grep "APhase3" "$outputname" |head -1 | awk '{print $2}')
 	boolChargeStat=$(grep "boolChargeStat" "$outputname" |head -1 | awk '{print $2}') 


### PR DESCRIPTION
Seit dem letzten Update kommt in meiner Log ständig:
```
loadvars.sh: Zeile 663: [: -ge: Einstelliger (unärer) Operator erwartet.
```
Ursächlich ist ein in 0ab5b12ef0a7862563aec42aec109001627cff17 / #2342 falsch gesetztes Leerzeichen. Wird hiermit behoben.