### PR TITLE
fix permissions for backup dir, fix wrong positive error message from pkill

### DIFF
--- a/runs/atreboot.sh
+++ b/runs/atreboot.sh
@@ -20,8 +20,11 @@ at_reboot() {
 	sleep 5
 	mkdir -p "$OPENWBBASEDIR/web/backup"
 	touch "$OPENWBBASEDIR/web/backup/.donotdelete"
-	sudo chown -R www-data:www-data "$OPENWBBASEDIR/web/backup"
-	sudo chown -R www-data:www-data "$OPENWBBASEDIR/web/tools/upload"
+	# web/backup and web/tools/upload are used to (temporarily) store backup files for download and for restoring.
+	# files are created from PHP as user www-data, thus www-data needs write permissions.
+	sudo chown -R pi:www-data "$OPENWBBASEDIR/"{web/backup,web/tools/upload}
+	sudo chmod -R g+w "$OPENWBBASEDIR/"{web/backup,web/tools/upload}
+
 	sudo chmod 777 "$OPENWBBASEDIR/openwb.conf"
 	sudo chmod 777 "$OPENWBBASEDIR/smarthome.ini"
 	sudo chmod 777 "$OPENWBBASEDIR/ramdisk"

--- a/runs/update.sh
+++ b/runs/update.sh
@@ -16,7 +16,7 @@ chmod 777 /var/www/html/openWB/ramdisk/mqttlastregelungaktiv
 # The update might replace a number of files which might currently be in use by the continuously running legacy-run
 # server. If we replace the source files while the process is running, funny things might happen.
 # Thus we shut-down the legacy run server before performing the update.
-pkill -f "$OPENWBBASEDIR/packages/legacy_run_server.py"
+pkill -u pi -f "$OPENWBBASEDIR/packages/legacy_run_server.py"
 
 if [[ "$releasetrain" == "stable" ]]; then
 	train=stable17
@@ -72,9 +72,7 @@ git reset --hard origin/$train
 # set permissions
 cd /var/www/html/
 sudo chown -R pi:pi openWB 
-sudo chown -R www-data:www-data /var/www/html/openWB/web/backup
-sudo chown -R www-data:www-data /var/www/html/openWB/web/tools/upload
-sudo cp /tmp/openwb.conf /var/www/html/openWB/openwb.conf
+cp /tmp/openwb.conf /var/www/html/openWB/openwb.conf
 
 # restore saved files after fetching new release
 # module soc_eq


### PR DESCRIPTION
In #2328 schrieb @DetMoerk:
> Seit der Anpassung treten Fehler beim Update auf. Die Version wird nicht mehr aktualisiert und teilweise können Verzeichnisse nicht gelöscht werden.
Werden der pkill und die beiden Git Zeilen per sudo aufgerufen, funktioniert es wieder. Fehler sind in der /var/log/apache/error.log zu finden!

Ich bin dem nachgegangen. Im Log fand ich:
```
pkill: killing pid 7405 failed: Die Operation ist nicht erlaubt
error: unable to unlink old 'web/backup/.donotdelete': Keine Berechtigung
error: unable to unlink old 'web/tools/upload/restore.log': Keine Berechtigung
error: unable to unlink old 'web/tools/upload/uploaddir': Keine Berechtigung
Checke Dateien aus: 100% (1277/1277), Fertig.
fatal: Konnte Index-Datei nicht zu Commit 'origin/master' setzen.
[Tue Aug 09 08:18:49.604407 2022] [mpm_prefork:notice] [pid 14536] AH00171: Graceful restart requested, doing restart
AH00558: apache2: Could not reliably determine the server's fully qualified domain name, using 127.0.1.1. Set the 'ServerName' directive globally to suppress this message
[Tue Aug 09 08:18:49.806853 2022] [mpm_prefork:notice] [pid 14536] AH00163: Apache/2.4.25 (Raspbian) configured -- resuming normal operations
[Tue Aug 09 08:18:49.806924 2022] [core:notice] [pid 14536] AH00094: Command line: '/usr/sbin/apache2'
error: unable to unlink old 'web/backup/.donotdelete': Keine Berechtigung
```
## killing failed

Die Meldung "pkill: killing pid 7405 failed: Die Operation ist nicht erlaubt" kommt von https://github.com/snaptec/openWB/blob/a59decd5005502635d853a95de54f20e6ae2ebc9/runs/update.sh#L19

Ursache ist, dass neben dem Server noch das Script läuft, welches den Prozess kontrolliert und Daten loggt:
```
$ ps aux | grep legacy_run_server.py
root      2005  0.0  0.3   7308  3516 ?        S    09:48   0:00 sudo -u pi python3 /var/www/html/openWB/packages/legacy_run_server.py
pi        2015  2.4  3.0  42612 28808 ?        S    09:48   0:06 python3 /var/www/html/openWB/packages/legacy_run_server.py
```
(In dem Beispiel der Prozess mit der pid 2005). Dieser Prozess kann nicht abgeschossen werden, da er als `root` läuft. Muss er auch nicht, denn wenn der Prozess, der als `pi` läuft (hier mit PID=2015) endet, dann endet der andere Prozess automatisch mit. Der Fehler ist damit "falsch positiv". Ich habe den Aufruf daher geändert zu:
```bash
pkill -u pi -f "$OPENWBBASEDIR/packages/legacy_run_server.py"
```
Durch das `-u pi` wird nurnoch der "normale" Prozess versucht zu killen, der andere Prozess endet automatisch mit und es gibt keinen "falschen Fehler" im Log mehr.

## error: unable to unlink

Git kann dies nicht ausführen, weil die betroffenen Dateien www-data gehören, wegen folgender Zeilen:
https://github.com/snaptec/openWB/blob/4836d995dd0a4af8d20e52300560614761190d30/runs/atreboot.sh#L23-L24

Vor meiner Änderung das `sudo` von Git wegzunehmen konnte sich Git da drüber hinwegsetzen. Sinnvoll erscheint es mir trotzdem nicht das `sudo` wieder einzubauen. Dadurch würden wieder jede Menge Dateien als `root` entstehen, die wieder zu `pi` geändert werden müssen. Generell ist es nichts sinnvoll, wenn git als root läuft. Die Motivation, dass die entsprechenden Verzeichnisse nicht `pi` gehören ist wohl, dass in diesen Verzeichnissen PHP als user `www-data` schreiben können soll.

Meine Lösung: Die Verzeichnisse bleiben bei dem user `pi`, bekommen aber als Gruppe `www-data` und die Gruppe bekommt Schreibrechte in dem Ordner.

Außerdem habe ich die Zeilen
```bash
sudo chown -R www-data:www-data /var/www/html/openWB/web/backup
sudo chown -R www-data:www-data /var/www/html/openWB/web/tools/upload
```
Entfernt. Die sind nicht nur unnötig, denn die kommen in der `atreboot.sh` nochmal in anderer Form, sondern sie sind auch hinderlich, denn das `touch "$OPENWBBASEDIR/web/backup/.donotdelete"` in atreboot.sh schlägt dann fehl, weil es keine Schreibberechtigung hat. Nachteil an dem Fix: Er funktioniert erst bei dem übernächstem Update, weil die `update.sh` bei ersten Update wahrscheinlich schon komplett im RAM ist und weiter unverändert ausgeführt wird.

## Sonstiges
In der Zeile
```bash
sudo cp /tmp/openwb.conf /var/www/html/openWB/openwb.conf
```
Habe ich das `sudo` entfernt. Sonst gehört die Datei schon wieder root. Das sollte sie eigentlich nicht...

## Version aktualisieren

> Die Version wird nicht mehr aktualisiert[..]

Entweder ich verstehe das Problem nicht oder es ist zumindest bei mir nicht da.