### PR TITLE
Incompatible variable type

### DIFF
--- a/modules/mpm3pmethll/readmpm3pm.py
+++ b/modules/mpm3pmethll/readmpm3pm.py
@@ -17,7 +17,7 @@ resp = client.read_input_registers(0x0002,4, unit=5)
 value1 = resp.registers[0] 
 value2 = resp.registers[1] 
 all = format(value1, '04x') + format(value2, '04x')
-ikwh = int(struct.unpack('>i', all.decode('hex'))[0]) 
+ikwh = float(struct.unpack('>i', all.decode('hex'))[0]) 
 ikwh = float(ikwh) /100
 f = open('/var/www/html/openWB/ramdisk/llkwhs1', 'w')
 f.write(str(ikwh))


### PR DESCRIPTION
ikwh is declared to have type `int` but is used as type `float`.