### PR TITLE
update.sh: Auf die Regelschleife warten statt auf gut Glück zu schlafen

### DIFF
--- a/runs/update.sh
+++ b/runs/update.sh
@@ -57,7 +57,9 @@ for i in $(seq 4 8); do
 	fi
 done
 
-sleep 15
+# Wait for regulation loop(s) and cron jobs to end, but with timeout in case a script hangs
+pgrep -f "$OPENWBBASEDIR/(regel\\.sh|runs/cron5min\\.sh|runs/cronnightly\\.sh)$" | \
+	timeout 15 xargs -n1 -I'{}' tail -f --pid="{}" /dev/null
 
 # backup some files before fetching new release
 # module soc_eq


### PR DESCRIPTION
In der `update.sh` gibt es ein `sleep 15`. Warum? Es ist ein Faktor der Updates langsamer macht. Gerade wenn man Änderungen "eben schnell" testen will ist das nervig, dass das Update so lange dauert.

Das ganze kam aus commit 90fd667d0c6a588380e7e80a535e3160e4d928a4, in dem die commit-message "schalte lademodus auf stop bei update start" steht. Damals wurde ein Befehl eingeführt, der den Lademodus auf stop stellt und dann 15 Sekunden wartet. Ich nehme schwer an um darauf zu warten, dass der neue Lademodus aktiv wird. Das hat sich wohl durch das `updateinprogress`-Flag erledigt. Der Lademodus wird zwar noch auf "stop" gestellt, die Regelschleife macht damit aber ohnehin nichts mehr, denn sie bricht wegen dem `updateinprogress`-Flag sofort ab.

Es erscheint mir aber trotzdem schlau ein Update nicht in eine laufende Regelschleife reinzuwerfen. Wenn dem laufenden Programm der Quelltext ausgetauscht wird und potentiell auch Dateien überschrieben werden mit denen die Regelschleife arbeitet oder deren Berechtigungen geändert werden könnte das Fehler nach sich ziehen.

Dieser PR ändert das Verhalten so, dass nur gewartet wird, wenn die Regelschleife gerade läuft und dann auch nur so lange bis die Regelschleife endet. Maximal jedoch weiterhin 15 Sekunden, damit eine hängende Regelschleife nicht den ganzen Prozess lahmlegt. Man könnte überlegen ob 15 Sekunden ausreichen, da manche Leute (zum Beispiel die Geschichte mit den Huawei-WR) sehr langsame Regelschleifen haben und die 15 Sekunden dann vielleicht nicht ausreichen. Andererseits haben die 15 Sekunden bis jetzt scheinbar ihren Dienst getan...