### PR TITLE
fix sma smart energy power

### DIFF
--- a/packages/modules/sma_sunny_boy/sma_sunny_boy_test.py
+++ b/packages/modules/sma_sunny_boy/sma_sunny_boy_test.py
@@ -37,7 +37,7 @@ def test_sma_modbus_hybrid(monkeypatch, params: Params):
     # setup
     mock_inverter_value_store = Mock()
     monkeypatch.setattr(device, "get_inverter_value_store", Mock(return_value=mock_inverter_value_store))
-    monkeypatch.setattr(SmaSunnyBoyInverter, "read", Mock(return_value=SAMPLE_INVERTER_STATE))
+    monkeypatch.setattr(SmaSunnyBoyInverter, "read", Mock(return_value=(SAMPLE_INVERTER_STATE, True)))
     monkeypatch.setattr(SunnyBoyBat, "read", Mock(return_value=SAMPLE_BAT_STATE))
 
     # execution


### PR DESCRIPTION
Nur wenn der WR DC-seitig Leistung liefert, darf die WR-Leistung um die Speicher-Leistung reduziert werden. Andernfalls beträgt die WR-Leistung 0W.
Getestet mit einem Sunny Boy Smart Energy.