### PR TITLE
lambda wp

### DIFF
--- a/modules/smarthome/lambda/off.py
+++ b/modules/smarthome/lambda/off.py
@@ -1,0 +1,52 @@
+#!/usr/bin/python3
+import sys
+import os
+import time
+import struct
+import codecs
+
+from pymodbus.client.sync import ModbusTcpClient
+
+named_tuple = time.localtime()  # getstruct_time
+time_string = time.strftime("%m/%d/%Y, %H:%M:%S lambda off.py", named_tuple)
+devicenumber = str(sys.argv[1])
+ipadr = str(sys.argv[2])
+uberschuss = int(sys.argv[3])
+uberschussvz = str(sys.argv[4])
+if (uberschussvz == 'UN'):
+    uberschuss = uberschuss * -1
+bp = '/var/www/html/openWB/ramdisk/smarthome_device_'
+# standard
+file_string = bp + str(devicenumber) + '_lambda.log'
+file_stringpv = bp + str(devicenumber) + '_pv'
+file_stringcount = bp + str(devicenumber) + '_count'
+if os.path.isfile(file_string):
+    pass
+else:
+    with open(file_string, 'w') as f:
+        print('lambda start log', file=f)
+with open(file_string, 'a') as f:
+    print('%s devicenr %s ipadr %s ueberschuss %6d try to connect (modbus)'
+          % (time_string, devicenumber, ipadr, uberschuss), file=f)
+client = ModbusTcpClient(ipadr, port=502)
+start = 103
+resp = client.read_input_registers(start, 2)
+value1 = resp.registers[0]
+all = format(value1, '04x')
+aktpower = int(struct.unpack('>h', codecs.decode(all, 'hex'))[0])
+with open(file_string, 'a') as f:
+    print('%s devicenr %s ipadr %s Akt Leistung  %6d'
+          % (time_string, devicenumber, ipadr, aktpower), file=f)
+pvmodus = 0
+if os.path.isfile(file_stringpv):
+    with open(file_stringpv, 'r') as f:
+        pvmodus = int(f.read())
+# wenn vorher pvmodus an, dann watt.py
+# signaliseren einmalig 0 ueberschuss zu schicken
+if pvmodus == 1:
+    pvmodus = 99
+with open(file_stringpv, 'w') as f:
+    f.write(str(pvmodus))
+count1 = 999
+with open(file_stringcount, 'w') as f:
+    f.write(str(count1))

--- a/modules/smarthome/lambda/on.py
+++ b/modules/smarthome/lambda/on.py
@@ -1,0 +1,45 @@
+#!/usr/bin/python3
+import sys
+import os
+import time
+import struct
+import codecs
+
+from pymodbus.client.sync import ModbusTcpClient
+named_tuple = time.localtime()  # getstruct_time
+time_string = time.strftime("%m/%d/%Y, %H:%M:%S lambda on.py", named_tuple)
+devicenumber = str(sys.argv[1])
+ipadr = str(sys.argv[2])
+uberschuss = int(sys.argv[3])
+uberschussvz = str(sys.argv[4])
+if (uberschussvz == 'UN'):
+    uberschuss = uberschuss * -1
+bp = '/var/www/html/openWB/ramdisk/smarthome_device_'
+# standard
+# lesen
+# own log
+file_string = bp + str(devicenumber) + '_lambda.log'
+file_stringpv = bp + str(devicenumber) + '_pv'
+file_stringcount = bp + str(devicenumber) + '_count'
+if os.path.isfile(file_string):
+    pass
+else:
+    with open(file_string, 'w') as f:
+        print('lambda start log', file=f)
+with open(file_string, 'a') as f:
+    print('%s devicenr %s ipadr %s ueberschuss %6d try to connect (modbus)'
+          % (time_string, devicenumber, ipadr, uberschuss), file=f)
+client = ModbusTcpClient(ipadr, port=502)
+start = 103
+resp = client.read_input_registers(start, 2)
+value1 = resp.registers[0]
+all = format(value1, '04x')
+aktpower = int(struct.unpack('>h', codecs.decode(all, 'hex'))[0])
+with open(file_string, 'a') as f:
+    print('%s devicenr %s ipadr %s Akt Leistung  %6d ' %
+          (time_string, devicenumber, ipadr, aktpower), file=f)
+with open(file_stringpv, 'w') as f:
+    f.write(str(1))
+count1 = 999
+with open(file_stringcount, 'w') as f:
+    f.write(str(count1))

--- a/modules/smarthome/lambda/watt.py
+++ b/modules/smarthome/lambda/watt.py
@@ -1,0 +1,98 @@
+#!/usr/bin/python3
+import sys
+import os
+import time
+import json
+import struct
+import codecs
+
+from pymodbus.client.sync import ModbusTcpClient
+named_tuple = time.localtime()  # getstruct_time
+time_string = time.strftime("%m/%d/%Y, %H:%M:%S lambda watty.py", named_tuple)
+devicenumber = str(sys.argv[1])
+ipadr = str(sys.argv[2])
+uberschuss = int(sys.argv[3])
+uberschussvz = str(sys.argv[4])
+if (uberschussvz == 'UN'):
+    uberschuss = uberschuss * -1
+bp = '/var/www/html/openWB/ramdisk/smarthome_device_'
+file_string = bp + str(devicenumber) + '_lambda.log'
+file_stringpv = bp + str(devicenumber) + '_pv'
+file_stringcount = bp + str(devicenumber) + '_count'
+file_stringcount5 = bp + str(devicenumber) + '_count5'
+count5 = 999
+if os.path.isfile(file_stringcount5):
+    with open(file_stringcount5, 'r') as f:
+        count5 = int(f.read())
+count5 = count5+1
+if count5 > 6:
+    count5 = 0
+with open(file_stringcount5, 'w') as f:
+    f.write(str(count5))
+if count5 == 0:
+    # pv modus
+    pvmodus = 0
+    if os.path.isfile(file_stringpv):
+        with open(file_stringpv, 'r') as f:
+            pvmodus = int(f.read())
+    # log counter
+    count1 = 999
+    if os.path.isfile(file_stringcount):
+        with open(file_stringcount, 'r') as f:
+            count1 = int(f.read())
+    count1 = count1+1
+    if count1 > 80:
+        count1 = 0
+    with open(file_stringcount, 'w') as f:
+        f.write(str(count1))
+    # aktuelle Leistung lesen
+    client = ModbusTcpClient(ipadr, port=502)
+    start = 103
+    resp = client.read_input_registers(start, 2)
+    value1 = resp.registers[0]
+    all = format(value1, '04x')
+    aktpower = int(struct.unpack('>h', codecs.decode(all, 'hex'))[0])
+    # logik nur schicken bei pvmodus
+    modbuswrite = 0
+    if pvmodus == 1:
+        modbuswrite = 1
+    neupower = uberschuss
+    if neupower < -32767:
+        neupower = -32767
+    if neupower > 32767:
+        neupower = 32767
+    # wurde lambda gerade ausgeschaltet ?    (pvmodus == 99 ?)
+    # dann 0 schicken wenn kein pvmodus mehr
+    # und pv modus ausschalten
+    if pvmodus == 99:
+        modbuswrite = 1
+        neupower = 0
+        pvmodus = 0
+        with open(file_stringpv, 'w') as f:
+            f.write(str(pvmodus))
+    # json return power = aktuelle Leistungsaufnahme in Watt,
+    # on = 1 pvmodus, powerc = counter in kwh
+    an = '{"power":' + str(aktpower) + ',"powerc":0,"on":' + str(pvmodus) + '}'
+    with open('/var/www/html/openWB/ramdisk/smarthome_device_ret' +
+              str(devicenumber), 'w') as f1:
+        json.dump(an, f1)
+    if count1 < 3:
+        if os.path.isfile(file_string):
+            pass
+        else:
+            with open(file_string, 'w') as f:
+                print('lambda start log', file=f)
+        with open(file_string, 'a') as f:
+            print('%s Nr %s ipadr %s ueberschuss %6d Akt Leistung %6d'
+                  % (time_string, devicenumber, ipadr, uberschuss, aktpower),
+                  file=f)
+            print('%s Nr %s ipadr %s ueberschuss %6d pvmodus %1d modbusw %1d'
+                  % (time_string, devicenumber, ipadr, neupower, pvmodus,
+                     modbuswrite), file=f)
+    # modbus write
+    if modbuswrite == 1:
+        client.write_registers(102, [neupower])
+        if count1 < 3:
+            with open(file_string, 'a') as f:
+                print('%s devicenr %s ipadr %s device written by modbus ' %
+                      (time_string, devicenumber, ipadr), file=f)

--- a/runs/mqttsub.py
+++ b/runs/mqttsub.py
@@ -181,7 +181,7 @@ def on_message(client, userdata, msg):
                     client.publish("openWB/config/get/SmartHome/Devices/"+str(devicenumb)+"/device_name", msg.payload.decode("utf-8"), qos=0, retain=True)
             if (( "openWB/config/set/SmartHome/Device" in msg.topic) and ("device_type" in msg.topic)):
                 devicenumb=re.sub(r'\D', '', msg.topic)
-                validDeviceTypes = ['none','shelly','tasmota','acthor','elwa','idm','vampair','stiebel','http','avm','mystrom','viessmann','mqtt','pyt'] # 'pyt' is deprecated and will be removed!
+                validDeviceTypes = ['none','shelly','tasmota','acthor','lambda','elwa','idm','vampair','stiebel','http','avm','mystrom','viessmann','mqtt','pyt'] # 'pyt' is deprecated and will be removed!
                 if ( 1 <= int(devicenumb) <= numberOfSupportedDevices and len(str(msg.payload.decode("utf-8"))) > 2):
                     try:
                         # just check vor payload in list, deviceTypeIndex is not used
@@ -369,6 +369,18 @@ def on_message(client, userdata, msg):
                     else:
                         writetoconfig(shconfigfile,'smarthomedevices','device_acthortype_'+str(devicenumb), msg.payload.decode("utf-8"))
                         client.publish("openWB/config/get/SmartHome/Devices/"+str(devicenumb)+"/device_acthortype", msg.payload.decode("utf-8"), qos=0, retain=True)
+            if (( "openWB/config/set/SmartHome/Device" in msg.topic) and ("device_lambdaueb" in msg.topic)):
+                devicenumb=re.sub(r'\D', '', msg.topic)
+                validTypes = ['UP','UN']
+                if ( 1 <= int(devicenumb) <= numberOfSupportedDevices) :
+                    try:
+                        # just check for payload in list, TypeIndex is not used
+                        TypeIndex = validTypes.index(msg.payload.decode("utf-8"))
+                    except ValueError:
+                        pass
+                    else:
+                        writetoconfig(shconfigfile,'smarthomedevices','device_lambdaueb_'+str(devicenumb), msg.payload.decode("utf-8"))
+                        client.publish("openWB/config/get/SmartHome/Devices/"+str(devicenumb)+"/device_lambdaueb", msg.payload.decode("utf-8"), qos=0, retain=True)
             if (( "openWB/config/set/SmartHome/Device" in msg.topic) and ("device_acthorpower" in msg.topic)):
                 devicenumb=re.sub(r'\D', '', msg.topic)
                 if ( 1 <= int(devicenumb) <= numberOfSupportedDevices and 0 <= int(msg.payload) <= 18000 ):
@@ -428,6 +440,13 @@ def on_message(client, userdata, msg):
                 if ( 1 <= int(devicenumb) <= numberOfSupportedDevices and 0 <= int(msg.payload) <= 1 ):
                     writetoconfig(shconfigfile,'smarthomedevices','device_homeConsumtion_'+str(devicenumb), msg.payload.decode("utf-8"))
                     client.publish("openWB/config/get/SmartHome/Devices/"+str(devicenumb)+"/device_homeConsumtion", msg.payload.decode("utf-8"), qos=0, retain=True)
+                else:
+                    print( "invalid payload for topic '" + msg.topic + "': " + msg.payload.decode("utf-8"))
+            if (( "openWB/config/set/SmartHome/Device" in msg.topic) and ("device_setauto" in msg.topic)):
+                devicenumb=re.sub(r'\D', '', msg.topic)
+                if ( 1 <= int(devicenumb) <= numberOfSupportedDevices and 0 <= int(msg.payload) <= 1 ):
+                    writetoconfig(shconfigfile,'smarthomedevices','device_setauto_'+str(devicenumb), msg.payload.decode("utf-8"))
+                    client.publish("openWB/config/get/SmartHome/Devices/"+str(devicenumb)+"/device_setauto", msg.payload.decode("utf-8"), qos=0, retain=True)
                 else:
                     print( "invalid payload for topic '" + msg.topic + "': " + msg.payload.decode("utf-8"))
             if (( "openWB/config/set/SmartHome/Device" in msg.topic) and ("device_measurePortSdm" in msg.topic)):

--- a/runs/smarthomemq.py
+++ b/runs/smarthomemq.py
@@ -17,6 +17,7 @@ from usmarthome.smartmystrom import Smystrom
 from usmarthome.smartshelly import Sshelly
 from usmarthome.smartstiebel import Sstiebel
 from usmarthome.smartvampair import Svampair
+from usmarthome.smartlambda import Slambda
 from usmarthome.smarttasmota import Stasmota
 from usmarthome.smartviessmann import Sviessmann
 
@@ -339,6 +340,8 @@ def update_devices():
                     mydevice = Sstiebel()
                 elif (device_type == 'vampair'):
                     mydevice = Svampair()
+                elif (device_type == 'lambda'):
+                    mydevice = Slambda()
                 elif (device_type == 'tasmota'):
                     mydevice = Stasmota()
                 elif (device_type == 'avm'):
@@ -429,6 +432,11 @@ def resetmaxeinschaltdauerfunc():
                             mqtt_reset[pref + 'OnCntStandby'] = '0'
                         mydevice.c_oldstampeinschaltdauer = 0
                         mydevice.c_oldstampeinschaltdauer_f = 'N'
+                        if ((mydevice.device_setauto == 1) and
+                           (mydevice.device_manual == 1)):
+                            log.info("(" + str(i) +
+                                     ") Umschaltung auf automatisch Modus ")
+                            mqtt_reset[pref + 'mode'] = '0'
             resetmaxeinschaltdauer = 1
             # Nur einschaltgruppe in Sekunden für neuen Tag zurücksetzten
             Sbase.nureinschaltinsec = 0

--- a/runs/usmarthome/smartbase.py
+++ b/runs/usmarthome/smartbase.py
@@ -86,6 +86,7 @@ class Sbase(Sbase0):
         self._device_nonewatt = 0
         self._device_deactivateper = 0
         self._device_pbtype = 'none'
+        self._device_lambdaueb = 'UP'
         self._old_pbtype = 'none'
         self._mydevicepb = 'none'
         self._oldrelais = '2'
@@ -115,6 +116,7 @@ class Sbase(Sbase0):
         self._c_einverz = 0
         self._c_einverz_f = 'N'
         self._dynregel = 0
+        self.device_setauto = 0
         self.gruppe = 'none'
         self.btchange = 0
 
@@ -274,6 +276,8 @@ class Sbase(Sbase0):
                 self._device_maxeinschaltdauer = valueint * 60
             elif (key == 'device_homeConsumtion'):
                 self.device_homeconsumtion = valueint
+            elif (key == 'device_setauto'):
+                self.device_setauto = valueint
             elif (key == 'device_differentMeasurement'):
                 self._device_differentmeasurement = valueint
             elif (key == 'device_temperatur_configured'):
@@ -306,6 +310,8 @@ class Sbase(Sbase0):
                 self._device_nonewatt = valueint
             elif (key == 'device_type'):
                 self.device_type = value
+            elif (key == 'device_lambdaueb'):
+                self.device_lambdaueb = value
             elif (key == 'device_configured'):
                 self._device_configured = value
             elif (key == 'device_name'):

--- a/runs/usmarthome/smartlambda.py
+++ b/runs/usmarthome/smartlambda.py
@@ -1,0 +1,48 @@
+#!/usr/bin/python3
+from usmarthome.smartbase import Sbase
+from usmarthome.global0 import log
+import subprocess
+
+
+class Slambda(Sbase):
+    def __init__(self):
+        # setting
+        super().__init__()
+        print('__init__ Slambda executed')
+
+    def getwatt(self, uberschuss, uberschussoffset):
+        self.prewatt(uberschuss, uberschussoffset)
+        argumentList = ['python3', self._prefixpy + 'lambda/watt.py',
+                        str(self.device_nummer), str(self._device_ip),
+                        str(self.devuberschuss), str(self.device_lambdaueb)]
+        try:
+            self.proc = subprocess.Popen(argumentList)
+            self.proc.communicate()
+            self.answer = self.readret()
+            self.newwatt = int(self.answer['power'])
+            self.newwattk = int(self.answer['powerc'])
+            self.relais = int(self.answer['on'])
+        except Exception as e1:
+            log.warning("(" + str(self.device_nummer) +
+                        ") Leistungsmessung %s %d %s Fehlermeldung: %s "
+                        % ('lambda', self.device_nummer,
+                           str(self._device_ip), str(e1)))
+        self.postwatt()
+
+    def turndevicerelais(self, zustand, ueberschussberechnung, updatecnt):
+        self.preturn(zustand, ueberschussberechnung, updatecnt)
+        if (zustand == 1):
+            pname = "/on.py"
+        else:
+            pname = "/off.py"
+        argumentList = ['python3', self._prefixpy + 'lambda' + pname,
+                        str(self.device_nummer), str(self._device_ip),
+                        str(self.devuberschuss), str(self.device_lambdaueb)]
+        try:
+            self.proc = subprocess.Popen(argumentList)
+            self.proc.communicate()
+        except Exception as e1:
+            log.warning("(" + str(self.device_nummer) +
+                        ") on / off  %s %d %s Fehlermeldung: %s "
+                        % ('lambda', self.device_nummer,
+                           str(self._device_ip), str(e1)))

--- a/web/settings/smarthomeconfig.php
+++ b/web/settings/smarthomeconfig.php
@@ -82,6 +82,7 @@ $numDevices = 9;
 											<option value="shelly" data-option="shelly">Shelly oder Shelly plus</option>
 											<option value="tasmota" data-option="tasmota">Tasmota</option>
 											<option value="acthor" data-option="acthor">Acthor</option>
+											<option value="lambda" data-option="lambda">Lambda</option>
 											<option value="elwa" data-option="elwa">Elwa</option>
 											<option value="idm" data-option="idm">Idm</option>
 											<option value="stiebel" data-option="stiebel">Stiebel</option>
@@ -102,6 +103,15 @@ $numDevices = 9;
 											Wenn die Einschaltbedingung erreicht ist wird alle 30 Sekunden der gerechnete Überschuss übertragen (in 1000 Watt Schritten)
 											Wenn die Ausschaltbedingung erreicht ist wird einmalig 0 als Überschuss übertragen.
 											Die Ausschaltschwelle/ Ausschaltverzögerung in OpenWB ist sinnvoll zu wählen (z.B. 500 / 3) um die Regelung von Acthor nicht zu stören.
+										</span>
+										<span class="form-text small device<?php echo $devicenum; ?>-option device<?php echo $devicenum; ?>-option-lambda hide">
+											Wp der Firma lambda<br>
+											Im Web Frontend der WP muss unter "Steuerungs-Einstellungen" der Parameter "Ansteuerungs-Typ = Modbus TCP" und "Zeitablauf Ansteuerung = ??? Sek" gesetzt werden.
+											Wenn die Einschaltbedingung erreicht ist wird alle 30 Sekunden der gerechnete Überschuss übertragen
+											Wenn die Ausschaltbedingung erreicht ist wird einmalig 0 als Überschuss übertragen.<br>
+											Als Parameter muss in Lambda für die Modbusadresse 102 als übertragener Wert<br>
+											 "Actual excess power INT16, min = - 32768W, max = - 32768W" parametrisiet sein.<br>
+											Die Ausschaltschwelle/ Ausschaltverzögerung in OpenWB ist sinnvoll zu wählen (z.B. 500 / 3) um die Regelung von Lambda nicht zu stören.
 										</span>
 										<span class="form-text small device<?php echo $devicenum; ?>-option device<?php echo $devicenum; ?>-option-mqtt hide">
 											Generisches MQTT modul<br>
@@ -198,7 +208,7 @@ $numDevices = 9;
 									</div>
 								</div>
 							</div>
-							<div class="device<?php echo $devicenum; ?>-option device<?php echo $devicenum; ?>-option-shelly device<?php echo $devicenum; ?>-option-tasmota device<?php echo $devicenum; ?>-option-acthor device<?php echo $devicenum; ?>-option-elwa device<?php echo $devicenum; ?>-option-idm device<?php echo $devicenum; ?>-option-stiebel device<?php echo $devicenum; ?>-option-avm device<?php echo $devicenum; ?>-option-mystrom device<?php echo $devicenum; ?>-option-vampair device<?php echo $devicenum;  ?>-option-viessmann device<?php echo $devicenum; ?>-option-pyt hide">
+							<div class="device<?php echo $devicenum; ?>-option device<?php echo $devicenum; ?>-option-shelly device<?php echo $devicenum; ?>-option-tasmota device<?php echo $devicenum; ?>-option-acthor device<?php echo $devicenum; ?>-option-lambda device<?php echo $devicenum; ?>-option-elwa device<?php echo $devicenum; ?>-option-idm device<?php echo $devicenum; ?>-option-stiebel device<?php echo $devicenum; ?>-option-avm device<?php echo $devicenum; ?>-option-mystrom device<?php echo $devicenum; ?>-option-vampair device<?php echo $devicenum;  ?>-option-viessmann device<?php echo $devicenum; ?>-option-pyt hide">
 								<hr class="border-secondary">
 								<div class="form-row mb-1">
 									<label for="device_ipDevices<?php echo $devicenum; ?>" class="col-md-4 col-form-label">IP Adresse</label>
@@ -291,7 +301,24 @@ $numDevices = 9;
 									</div>
 								</div>
 							</div>
-							<div class="device<?php echo $devicenum; ?>-option device<?php echo $devicenum; ?>-option-shelly device<?php echo $devicenum; ?>-option-tasmota device<?php echo $devicenum; ?>-option-acthor device<?php echo $devicenum; ?>-option-elwa device<?php echo $devicenum; ?>-option-idm device<?php echo $devicenum; ?>-option-stiebel device<?php echo $devicenum; ?>-option-vampair device<?php echo $devicenum; ?>-option-avm device<?php echo $devicenum; ?>-option-mystrom device<?php echo $devicenum; ?>-option-http device<?php echo $devicenum; ?>-option-mqtt device<?php echo $devicenum; ?>-option-viessmann device<?php echo $devicenum; ?>-option-pyt hide">
+							<div class="device<?php echo $devicenum; ?>-option device<?php echo $devicenum; ?>-option-lambda hide">
+								<hr class="border-secondary">
+								<div class="form-group">
+									<div class="form-row mb-1">
+										<label for="device_lambdauebDevices<?php echo $devicenum; ?>" class="col-md-4 col-form-label">Überschuss...</label>
+										<div class="col">
+											<select class="form-control" name="device_lambdaueb" id="device_lambdauebDevices<?php echo $devicenum; ?>" data-default="" data-topicprefix="openWB/config/get/SmartHome/" data-topicsubgroup="Devices/<?php echo $devicenum; ?>/">
+												<option value="UP" data-option="UP">Überschuss als positive Zahl übertragen</option>
+												<option value="UN" data-option="UN">Überschuss als negative Zahl übertragen</option>
+											</select>
+											<span class="form-text small">
+												Bezieht sich nur auf die Modbusadresse 102, wie ist Überschuss zu übertragen. Muss in der WP genau gleich eingestellt sein.
+											</span>
+										</div>
+									</div>
+								</div>
+							</div>
+							<div class="device<?php echo $devicenum; ?>-option device<?php echo $devicenum; ?>-option-shelly device<?php echo $devicenum; ?>-option-tasmota device<?php echo $devicenum; ?>-option-acthor device<?php echo $devicenum; ?>-option-lambda device<?php echo $devicenum; ?>-option-elwa device<?php echo $devicenum; ?>-option-idm device<?php echo $devicenum; ?>-option-stiebel device<?php echo $devicenum; ?>-option-vampair device<?php echo $devicenum; ?>-option-avm device<?php echo $devicenum; ?>-option-mystrom device<?php echo $devicenum; ?>-option-http device<?php echo $devicenum; ?>-option-mqtt device<?php echo $devicenum; ?>-option-viessmann device<?php echo $devicenum; ?>-option-pyt hide">
 								<hr class="border-secondary">
 								<div class="form-group">
 									<div class="form-row mb-1">
@@ -385,17 +412,17 @@ $numDevices = 9;
 												<span class="form-text small">Uhrzeit im 24 Stunden-Format, z.B. "14:45". Der Wert "00:00" schaltet die Funktion ab. Das Gerät wird ab dieser Uhrzeit eingeschaltet, unabhängig vom Überschuss unter Berücksichtigung der maximalen Einschaltdauer.</span>
 											</div>
 										</div>
-										
+
 										<div class="form-row mb-1">
 											<label for="device_offTimeDevices<?php echo $devicenum; ?>" class="col-md-4 col-form-label">Immer aus nach</label>
 											<div class="col">
 												<input id="device_offTimeDevices<?php echo $devicenum; ?>" name="device_offTime" class="form-control" type="text" pattern="^([01]{0,1}\d|2[0-3]):[0-5]\d" maxlength="5" required data-default="00:00" value="00:00" data-topicprefix="openWB/config/get/SmartHome/" data-topicsubgroup="Devices/<?php echo $devicenum; ?>/">
 												<span class="form-text small">Uhrzeit im 24 Stunden-Format, z.B. "14:45". Der Wert "00:00" schaltet die Funktion ab. Das Gerät wird ab dieser Uhrzeit ausgeschaltet, und für den laufenden Tag nicht mehr eingeschaltet.</span>
 											</div>
-										</div>										
-										
-										
-										
+										</div>
+
+
+
 									</div>
 									<div class="device<?php echo $devicenum; ?>-option device<?php echo $devicenum; ?>-option-shelly device<?php echo $devicenum; ?>-option-tasmota device<?php echo $devicenum; ?>-option-http device<?php echo $devicenum; ?>-option-avm device<?php echo $devicenum; ?>-option-mystrom hide">
 										<hr class="border-secondary">
@@ -470,6 +497,24 @@ $numDevices = 9;
 												wird bei Ausschaltschwelle anpassen: Die Ausschaltverzögerung auf 0 gesetzt und die Ausschaltschwelle (sofern eine Bezugsschwelle definiert ist) auf 0 gesetzt. Dadurch werden diese Geräte als erstes abgeschaltet, wenn das Auto lädt und der Überschuss nicht ausreicht.
 												<br>
 												wird bei ausschalten/nicht einschalten: Das Gerät abgeschaltet.		Dann steht die aktuelle Leistungsaufnahme sofort für die Autoladung zur Verfügung.
+												</span>
+											</div>
+										</div>
+									</div>
+									<hr class="border-secondary">
+									<div class="form-group">
+										<div class="form-row mb-1">
+											<label class="col-md-4 col-form-label">Um 23:59...</label>
+											<div class="col">
+												<div class="btn-group btn-group-toggle btn-block" id="device_setautoDevices<?php echo $devicenum; ?>" name="device_setauto" data-toggle="buttons" data-default="0" value="0" data-topicprefix="openWB/config/get/SmartHome/" data-topicsubgroup="Devices/<?php echo $devicenum; ?>/">
+													<label class="btn btn-outline-info">
+														<input type="radio" name="device_setautoDevices<?php echo $devicenum; ?>" id="device_setauto<?php echo $devicenum; ?>0" data-option="0" value="0" checked="checked">nichts tun
+													</label>
+													<label class="btn btn-outline-info">
+														<input type="radio" name="device_setautoDevices<?php echo $devicenum; ?>" id="device_setauto<?php echo $devicenum; ?>1" data-option="1" value="1">in den automatischen Modus stellen
+													</label>
+												</div>
+												<span class="form-text small">Diese Option bewirkt, dass ein Gerät um 23:59 immer in den automaischen Modus geschaltet wird.
 												</span>
 											</div>
 										</div>

--- a/web/settings/topicsToSubscribe_smarthomeconfig.js
+++ b/web/settings/topicsToSubscribe_smarthomeconfig.js
@@ -71,6 +71,8 @@ var topicsToSubscribe = [
 	["openWB/config/get/SmartHome/Devices/+/device_pbip", 0],
 	["openWB/config/get/SmartHome/Devices/+/device_measchan", 0],
 	["openWB/config/get/SmartHome/Devices/+/device_chan", 0],
+	["openWB/config/get/SmartHome/Devices/+/device_setauto", 0],
+	["openWB/config/get/SmartHome/Devices/+/device_lambdaueb", 0],
 	["openWB/config/get/SmartHome/Devices/+/device_measuresmaage", 0]
 
 ];


### PR DESCRIPTION
Erstmalig wird die Lambda WP unterstützt. Die Aktuelle Leistung wird aus Modbusadresse 103 gelesen, der Überschuss wird laufend (zirka alle 30 Sekunden) in die Modbusadresse 102 geschrieben. Als Parameter kann gewählt werden, ob der Überschuss als positive Zahl (UP) oder als negative Zahl (UN) übertragen wird. Zusätzlich gibt es einen generelle Parameter für jedes Gerät, womit das Gerät um 23:59 auf den automatik Modus geschaltet wird, sofern es im manual Modus ist.