### PR TITLE
add support for Siemens SENTRON (7KM PAC2200) measuring devices

### DIFF
--- a/modules/bezug_siemens_sentron/main.sh
+++ b/modules/bezug_siemens_sentron/main.sh
@@ -1,0 +1,20 @@
+#!/bin/bash
+OPENWBBASEDIR=$(cd "$(dirname "$0")/../../" && pwd)
+RAMDISKDIR="${OPENWBBASEDIR}/ramdisk"
+#DMOD="EVU"
+DMOD="MAIN"
+
+if [ ${DMOD} == "MAIN" ]; then
+	MYLOGFILE="${RAMDISKDIR}/openWB.log"
+else
+	MYLOGFILE="${RAMDISKDIR}/evu.log"
+fi
+
+openwbDebugLog ${DMOD} 2 "Siemens SENTRON IP: ${bezug1_ip}"
+
+bash "$OPENWBBASEDIR/packages/legacy_run.sh" "modules.siemens_sentron.device" "counter" "${bezug1_ip}" >>"$MYLOGFILE" 2>&1
+ret=$?
+
+openwbDebugLog ${DMOD} 2 "RET: ${ret}"
+
+cat "${RAMDISKDIR}/wattbezug"

--- a/packages/modules/siemens_sentron/config.py
+++ b/packages/modules/siemens_sentron/config.py
@@ -1,0 +1,34 @@
+from typing import Optional
+
+from modules.common.component_setup import ComponentSetup
+
+
+class SiemensSentronConfiguration:
+    def __init__(self, ip_address: Optional[str] = None):
+        self.ip_address = ip_address
+
+
+class SiemensSentron:
+    def __init__(self,
+                 name: str = "Siemens Sentron",
+                 type: str = "siemens_sentron",
+                 id: int = 0,
+                 configuration: SiemensSentronConfiguration = None) -> None:
+        self.name = name
+        self.type = type
+        self.id = id
+        self.configuration = configuration or SiemensSentronConfiguration()
+
+
+class SiemensSentronCounterConfiguration:
+    def __init__(self):
+        pass
+
+
+class SiemensSentronCounterSetup(ComponentSetup[SiemensSentronCounterConfiguration]):
+    def __init__(self,
+                 name: str = "Siemens Sentron Zähler",
+                 type: str = "counter",
+                 id: int = 0,
+                 configuration: SiemensSentronCounterConfiguration = None) -> None:
+        super().__init__(name, type, id, configuration or SiemensSentronCounterConfiguration())

--- a/packages/modules/siemens_sentron/counter.py
+++ b/packages/modules/siemens_sentron/counter.py
@@ -1,0 +1,49 @@
+#!/usr/bin/env python3
+from typing import Dict, Union
+
+from dataclass_utils import dataclass_from_dict
+from modules.common import modbus
+from modules.common.component_state import CounterState
+from modules.common.component_type import ComponentDescriptor
+from modules.common.fault_state import ComponentInfo
+from modules.common.modbus import ModbusDataType
+from modules.common.store import get_counter_value_store
+from modules.siemens_sentron.config import SiemensSentronCounterSetup
+
+
+class SiemensSentronCounter:
+    def __init__(self,
+                 device_id: int,
+                 component_config: Union[Dict, SiemensSentronCounterSetup],
+                 tcp_client: modbus.ModbusTcpClient_) -> None:
+        self.__device_id = device_id
+        self.component_config = dataclass_from_dict(SiemensSentronCounterSetup, component_config)
+        self.__tcp_client = tcp_client
+        self.__store = get_counter_value_store(self.component_config.id)
+        self.component_info = ComponentInfo.from_component_config(self.component_config)
+
+    def update(self):
+        with self.__tcp_client:
+            imported = self.__tcp_client.read_holding_registers(801, ModbusDataType.FLOAT_64, unit=1)
+            exported = self.__tcp_client.read_holding_registers(809, ModbusDataType.FLOAT_64, unit=1)
+            power = self.__tcp_client.read_holding_registers(65, ModbusDataType.FLOAT_32, unit=1)
+            powers = self.__tcp_client.read_holding_registers(25, [ModbusDataType.FLOAT_32] * 3, unit=1)
+            frequency = self.__tcp_client.read_holding_registers(55, ModbusDataType.FLOAT_32, unit=1)
+            currents = self.__tcp_client.read_holding_registers(13, [ModbusDataType.FLOAT_32] * 3, unit=1)
+            voltages = self.__tcp_client.read_holding_registers(1, [ModbusDataType.FLOAT_32] * 3, unit=1)
+            power_factors = self.__tcp_client.read_holding_registers(37, [ModbusDataType.FLOAT_32] * 3, unit=1)
+
+        counter_state = CounterState(
+            imported=imported,
+            exported=exported,
+            power=power,
+            powers=powers,
+            currents=currents,
+            voltages=voltages,
+            frequency=frequency,
+            power_factors=power_factors
+        )
+        self.__store.set(counter_state)
+
+
+component_descriptor = ComponentDescriptor(configuration_factory=SiemensSentronCounterSetup)

--- a/packages/modules/siemens_sentron/device.py
+++ b/packages/modules/siemens_sentron/device.py
@@ -1,0 +1,86 @@
+#!/usr/bin/env python3
+import logging
+from typing import Dict, List, Union, Optional
+
+from dataclass_utils import dataclass_from_dict
+from helpermodules.cli import run_using_positional_cli_args
+from modules.common import modbus
+from modules.common.abstract_device import AbstractDevice, DeviceDescriptor
+from modules.common.component_context import SingleComponentUpdateContext
+from modules.siemens_sentron import counter
+from modules.siemens_sentron.config import SiemensSentron, SiemensSentronCounterSetup
+
+log = logging.getLogger(__name__)
+
+
+class Device(AbstractDevice):
+    COMPONENT_TYPE_TO_CLASS = {
+        "counter": counter.SiemensSentronCounter,
+    }
+
+    def __init__(self, device_config: Union[Dict, SiemensSentron]) -> None:
+        self.components = {}  # type: Dict[str, counter.SiemensSentronCounter]
+        try:
+            self.device_config = dataclass_from_dict(SiemensSentron, device_config)
+            ip_address = self.device_config.configuration.ip_address
+            self.client = modbus.ModbusTcpClient_(ip_address, 502)
+        except Exception:
+            log.exception("Fehler im Modul "+self.device_config.name)
+
+    def add_component(self, component_config: Union[Dict, SiemensSentronCounterSetup]) -> None:
+        if isinstance(component_config, Dict):
+            component_type = component_config["type"]
+        else:
+            component_type = component_config.type
+        component_config = dataclass_from_dict(COMPONENT_TYPE_TO_MODULE[
+            component_type].component_descriptor.configuration_factory, component_config)
+        if component_type in self.COMPONENT_TYPE_TO_CLASS:
+            self.components["component"+str(component_config.id)] = self.COMPONENT_TYPE_TO_CLASS[component_type](
+                self.device_config.id, component_config, self.client)
+        else:
+            raise Exception(
+                "illegal component type " + component_type + ". Allowed values: " +
+                ','.join(self.COMPONENT_TYPE_TO_CLASS.keys())
+            )
+
+    def update(self) -> None:
+        log.debug("Start device reading " + str(self.components))
+        if self.components:
+            for component in self.components:
+                # Auch wenn bei einer Komponente ein Fehler auftritt, sollen alle anderen noch ausgelesen werden.
+                with SingleComponentUpdateContext(self.components[component].component_info):
+                    self.components[component].update()
+        else:
+            log.warning(
+                self.device_config.name +
+                ": Es konnten keine Werte gelesen werden, da noch keine Komponenten konfiguriert wurden."
+            )
+
+
+COMPONENT_TYPE_TO_MODULE = {
+    "counter": counter,
+}
+
+
+def read_legacy(component_type: str, ip_address: str, num: Optional[int] = None) -> None:
+    device_config = SiemensSentron()
+    device_config.configuration.ip_address = ip_address
+    dev = Device(device_config)
+    if component_type in COMPONENT_TYPE_TO_MODULE:
+        component_config = COMPONENT_TYPE_TO_MODULE[component_type].component_descriptor.configuration_factory()
+    else:
+        raise Exception(
+            "illegal component type " + component_type + ". Allowed values: " +
+            ','.join(COMPONENT_TYPE_TO_MODULE.keys())
+        )
+    component_config.id = num
+    dev.add_component(component_config)
+
+    dev.update()
+
+
+def main(argv: List[str]):
+    run_using_positional_cli_args(read_legacy, argv)
+
+
+device_descriptor = DeviceDescriptor(configuration_factory=SiemensSentron)

--- a/web/settings/modulconfigevu.php
+++ b/web/settings/modulconfigevu.php
@@ -88,6 +88,7 @@
 										<option <?php if($wattbezugmodulold == "bezug_rct") echo "selected" ?> value="bezug_rct">RCT</option>
 										<option <?php if($wattbezugmodulold == "bezug_rct2") echo "selected" ?> value="bezug_rct2">RCT V.2</option>
 										<option <?php if($wattbezugmodulold == "bezug_siemens") echo "selected" ?> value="bezug_siemens">Siemens Speicher</option>
+										<option <?php if($wattbezugmodulold == "bezug_siemens_sentron") echo "selected" ?> value="bezug_siemens_sentron">Siemens SENTRON</option>
 										<option <?php if($wattbezugmodulold == "bezug_smashm") echo "selected" ?> value="bezug_smashm">SMA HomeManager</option>
 										<option <?php if($wattbezugmodulold == "bezug_sbs25") echo "selected" ?> value="bezug_sbs25">SMA Sunny Boy Storage </option>
 										<option <?php if($wattbezugmodulold == "bezug_smartfox") echo "selected" ?> value="bezug_smartfox">Smartfox</option>
@@ -216,6 +217,11 @@
 						<div id="wattbezugsiemens" class="hide">
 							<div class="card-text alert alert-info">
 								IP Adresse des Siemens Speichers eingeben. Im Siemens Speicher muss die Schnittstelle openWB gewählt werden.
+							</div>
+						</div>
+						<div id="wattbezugsiemenssentron" class="hide">
+							<div class="card-text alert alert-info">
+								Derzeit werden nur Messgeräte vom Typ "7KM PAC2200" mit Ethernet-Schnittstelle unterstützt.
 							</div>
 						</div>
 						<div id="wattbezugrct" class="hide">
@@ -993,6 +999,7 @@
 								hideSection('#wattbezugvarta');
 								hideSection('#wattbezugfems');
 								hideSection('#wattbezugsiemens');
+								hideSection('#wattbezugsiemenssentron');
 								hideSection('#wattbezugpowerdog');
 								hideSection('#wattbezugpowerfox');
 								hideSection('#wattbezugrct');
@@ -1032,6 +1039,10 @@
 								if($('#wattbezugmodul').val() == 'bezug_siemens') {
 									showSection('#wattbezugsiemens');
 									showSection('#wattbezugip');
+								}
+								if($('#wattbezugmodul').val() == 'bezug_siemens_sentron') {
+									showSection('#wattbezugip');
+									showSection('#wattbezugsiemenssentron');
 								}
 								if($('#wattbezugmodul').val() == 'bezug_janitza') {
 									showSection('#wattbezugjanitza');


### PR DESCRIPTION
Currently, Siemens SENTRON (7KM PAC2200) energy meters can be used in the EVU module of openWB by choosing the generic JSON module and parsing the power/import/export values from the energy meter's webpage data URLs. However, this is limited to measuring only the basic EVU values and also has the unnecessary performance overhead of HTTP and JSON parsing.

This commit introduces a custom implementation for these energy meters. It reads all EVU values openWB can process directly from the energy meter via Modbus/TCP. Users only have to enter the meter's IP address.

This implementation has been tested in my home installation. All values correspond to the ones displayed in the meter's webpage and no performance issues for running the control loop could be detected.