### PR TITLE
Acthor besseres Loging

### DIFF
--- a/modules/smarthome/acthor/watt.py
+++ b/modules/smarthome/acthor/watt.py
@@ -3,40 +3,50 @@ import sys
 import os
 import time
 import json
-import getopt
-import socket
 import struct
 import codecs
 from pymodbus.client.sync import ModbusTcpClient
-named_tuple = time.localtime() # getstruct_time
+named_tuple = time.localtime()   # getstruct_time
 time_string = time.strftime("%m/%d/%Y, %H:%M:%S acthor watty.py", named_tuple)
-devicenumber=str(sys.argv[1])
-ipadr=str(sys.argv[2])
-uberschuss=int(sys.argv[3])
-atype=str(sys.argv[4])
-instpower=int(sys.argv[5])
-file_string= '/var/www/html/openWB/ramdisk/smarthome_device_' + str(devicenumber) + '_acthor.log'
-file_stringpv= '/var/www/html/openWB/ramdisk/smarthome_device_' + str(devicenumber) + '_pv'
-file_stringcount= '/var/www/html/openWB/ramdisk/smarthome_device_' + str(devicenumber) + '_count'
-file_stringcount5= '/var/www/html/openWB/ramdisk/smarthome_device_' + str(devicenumber) + '_count5'
+devicenumber = str(sys.argv[1])
+ipadr = str(sys.argv[2])
+uberschuss = int(sys.argv[3])
+atype = str(sys.argv[4])
+instpower = int(sys.argv[5])
+forcesend = int(sys.argv[6])
+# forcesend = 0 default acthor time period applies
+# forcesend = 1 default overwritten send now
+# forcesend = 9 default overwritten no send
+fp = '/var/www/html/openWB/ramdisk/smarthome_device_'
+file_string = fp + str(devicenumber) + '_acthor.log'
+file_stringpv = fp + str(devicenumber) + '_pv'
+file_stringcount = fp + str(devicenumber) + '_count'
+file_stringcount5 = fp + str(devicenumber) + '_count5'
 count5 = 999
 if os.path.isfile(file_stringcount5):
-   f = open( file_stringcount5, 'r')
-   count5 =int(f.read())
-   f.close()
-count5=count5+1
+    f = open(file_stringcount5, 'r')
+    count5 = int(f.read())
+    f.close()
+if (forcesend == 0):
+    count5 = count5 + 1
+elif (forcesend == 1):
+    count5 = 999
+else:
+    count5 = 1
 if count5 > 3:
-   count5=0
-f = open( file_stringcount5 , 'w')
+    count5 = 0
+f = open(file_stringcount5, 'w')
 f.write(str(count5))
 f.close()
-faktor=1.0
+faktor = 1.0
+modbuswrite = 0
+neupower = 0
 if instpower == 0:
     instpower = 1000
-cap = 9000   
+cap = 9000
 if atype == "9s18":
-    faktor = 18000/instpower  
-    cap = 18000   
+    faktor = 18000/instpower
+    cap = 18000
 elif atype == "9s":
     faktor = 9000/instpower
 elif atype == "M3":
@@ -45,9 +55,9 @@ else:
     faktor = 3000/instpower
 pvmodus = 0
 if os.path.isfile(file_stringpv):
-   f = open( file_stringpv , 'r')
-   pvmodus =int(f.read())
-   f.close()
+    f = open(file_stringpv, 'r')
+    pvmodus = int(f.read())
+    f.close()
 powerc = 0
 # aktuelle Leistung lesen
 client = ModbusTcpClient(ipadr, port=502)
@@ -55,87 +65,85 @@ client = ModbusTcpClient(ipadr, port=502)
 #
 start = 1000
 resp=client.read_holding_registers(start,10,unit=1)
+# start = 3524
+# resp = client.read_input_registers(start, 10, unit=1)
 value1 = resp.registers[0]
 all = format(value1, '04x')
-aktpower= int(struct.unpack('>h',codecs.decode(all, 'hex'))[0])
-if count5==0:
-   count1 = 999
-   if os.path.isfile(file_stringcount):
-      f = open( file_stringcount , 'r')
-      count1 =int(f.read())
-      f.close()
-   count1=count1+1
-   value1 = resp.registers[3]
-   all = format(value1, '04x')
-   status= int(struct.unpack('>h',codecs.decode(all, 'hex') )[0])
-   # logik
-   modbuswrite = 0
-   if uberschuss < 0:
-      neupowertarget = int((uberschuss + aktpower) * faktor)
-   else:
-      neupowertarget = int((uberschuss + aktpower) * faktor)
-   if neupowertarget < 0:
-      neupowertarget = 0
-   if neupowertarget > int(cap * faktor):
-      neupowertarget = int(cap * faktor)
-   # status nach handbuch Thor
-   #0.. Aus
-   #1-8 Geraetestart
-   #9 Betrieb
-   #>=200 Fehlerzustand Leistungsteil
-   neupower = neupowertarget
-   # wurde Thor gerade ausgeschaltet ?    (pvmodus == 99 ?)
-   # dann 0 schicken wenn kein pvmodus mehr
-   # und pv modus ausschalten
-   if pvmodus == 99:
-      modbuswrite = 1
-      neupower = 0
-      f = open( file_stringpv , 'w')
-      pvmodus = 0
-      f.write(str(pvmodus))
-      f.close()
+aktpower = int(struct.unpack('>h', codecs.decode(all, 'hex'))[0])
+if count5 == 0:
+    count1 = 999
+    if os.path.isfile(file_stringcount):
+        f = open(file_stringcount, 'r')
+        count1 = int(f.read())
+        f.close()
+    count1 = count1+1
+    value1 = resp.registers[3]
+    all = format(value1, '04x')
+    status = int(struct.unpack('>h', codecs.decode(all, 'hex'))[0])
+    # logik
+    if uberschuss < 0:
+        neupowertarget = int((uberschuss + aktpower) * faktor)
+    else:
+        neupowertarget = int((uberschuss + aktpower) * faktor)
+    if neupowertarget < 0:
+        neupowertarget = 0
+    if neupowertarget > int(cap * faktor):
+        neupowertarget = int(cap * faktor)
+    # status nach handbuch Thor
+    # 0.. Aus
+    # 1-8 Geraetestart
+    # 9 Betrieb
+    # >=200 Fehlerzustand Leistungsteil
+    neupower = neupowertarget
+    # wurde Thor gerade ausgeschaltet ?    (pvmodus == 99 ?)
+    # dann 0 schicken wenn kein pvmodus mehr
+    # und pv modus ausschalten
+    if pvmodus == 99:
+        modbuswrite = 1
+        neupower = 0
+        f = open(file_stringpv, 'w')
+        pvmodus = 0
+        f.write(str(pvmodus))
+        f.close()
     # sonst wenn pv modus lauft , ueberschuss schicken
-   else:
-      if pvmodus == 1:
-         modbuswrite = 1
-   #Sonst nichts schicken
-   # test only faken aktpower
-   #if pvmodus == 1:
-   #   aktpower = neupower
-   #else:
-   #   aktpower = 0
-   # test only
-   #json return power = aktuelle Leistungsaufnahme in Watt, on = 1 pvmodus, powerc = counter in kwh
-   #answer = '{"power":225,"on":0} '
-   answer = '{"power":' + str(aktpower) + ',"powerc":' + str(powerc) + ',"on":' + str(pvmodus) + '} '
-   f1 = open('/var/www/html/openWB/ramdisk/smarthome_device_ret' + str(devicenumber), 'w')
-   json.dump(answer,f1)
-   f1.close()
-   # logschreiben
-   if count1 > 80:
-      count1=0
-   if count1 < 3:
-      if os.path.isfile(file_string):
-         f = open( file_string , 'a')
-      else:
-         f = open( file_string , 'w')
-      print ('%s devicenr %s ipadr %s ueberschuss %6d Akt Leistung  %6d Status %2d type %s inst. Leistung %6d Skalierung %.2f' % (time_string,devicenumber,ipadr,uberschuss,aktpower,status,atype,instpower,faktor),file=f)
-      print ('%s devicenr %s ipadr %s Neu Leistung %6d pvmodus %1d modbuswrite %1d  ' % (time_string,devicenumber,ipadr,neupower,pvmodus,modbuswrite),file=f)
-      f.close()
-   # modbus write
-   if modbuswrite == 1:
-      rq = client.write_register(1000, neupower, unit=1)
-      if count1 < 3:
-         f = open( file_string , 'a')
-         print ('%s devicenr %s ipadr %s device written by modbus ' % (time_string,devicenumber,ipadr),file=f)
-         f.close()
-   f = open( file_stringcount , 'w')
-   f.write(str(count1))
-   f.close()
+    else:
+        if pvmodus == 1:
+            modbuswrite = 1
+    # logschreiben
+    if count1 > 80:
+        count1 = 0
+    if count1 < 3:
+        if os.path.isfile(file_string):
+            f = open(file_string, 'a')
+        else:
+            f = open(file_string, 'w')
+        helpstr = '%s devicenr %s ipadr %s ueberschuss %6d Akt Leistung'
+        helpstr += ' %6d Status %2d type %s inst. Leistung %6d Skalierung %.2f'
+        print(helpstr % (time_string, devicenumber, ipadr, uberschuss,
+                         aktpower, status, atype, instpower, faktor), file=f)
+        helpstr = '%s devicenr %s ipadr %s Neu Leistung %6d '
+        helpstr += 'pvmodus %1d modbuswrite %1d'
+        print(helpstr % (time_string, devicenumber, ipadr, neupower,
+                         pvmodus, modbuswrite), file=f)
+        f.close()
+    # modbus write
+    if modbuswrite == 1:
+        rq = client.write_register(1000, neupower, unit=1)
+        if count1 < 3:
+            f = open(file_string, 'a')
+            print('%s devicenr %s ipadr %s device written by modbus ' %
+                  (time_string, devicenumber, ipadr), file=f)
+            f.close()
+    f = open(file_stringcount, 'w')
+    f.write(str(count1))
+    f.close()
 else:
-   if pvmodus == 99:
-      pvmodus = 0
-   answer = '{"power":' + str(aktpower) + ',"powerc":' + str(powerc) + ',"on":' + str(pvmodus) + '} '
-   f1 = open('/var/www/html/openWB/ramdisk/smarthome_device_ret' + str(devicenumber), 'w')
-   json.dump(answer,f1)
-   f1.close()
+    if pvmodus == 99:
+        pvmodus = 0
+answer = '{"power":' + str(aktpower) + ',"powerc":' + str(powerc)
+answer += ',"send":' + str(modbuswrite) + ',"sendpower":' + str(neupower)
+answer += ',"on":' + str(pvmodus) + '}'
+f1 = open('/var/www/html/openWB/ramdisk/smarthome_device_ret' +
+          str(devicenumber), 'w')
+json.dump(answer, f1)
+f1.close()

--- a/runs/mqttsub.py
+++ b/runs/mqttsub.py
@@ -239,6 +239,11 @@ def on_message(client, userdata, msg):
                 if ( 1 <= int(devicenumb) <= numberOfSupportedDevices and 0 <= int(msg.payload) <= 100000):
                     writetoconfig(shconfigfile,'smarthomedevices','device_einschaltverzoegerung_'+str(devicenumb), msg.payload.decode("utf-8"))
                     client.publish("openWB/config/get/SmartHome/Devices/"+str(devicenumb)+"/device_einschaltverzoegerung", msg.payload.decode("utf-8"), qos=0, retain=True)
+            if (( "openWB/config/set/SmartHome/Device" in msg.topic) and ("device_updatesec" in msg.topic)):
+                devicenumb=re.sub(r'\D', '', msg.topic)
+                if ( 1 <= int(devicenumb) <= numberOfSupportedDevices and 0 <= int(msg.payload) <= 180):
+                    writetoconfig(shconfigfile,'smarthomedevices','device_updatesec_'+str(devicenumb), msg.payload.decode("utf-8"))
+                    client.publish("openWB/config/get/SmartHome/Devices/"+str(devicenumb)+"/device_updatesec", msg.payload.decode("utf-8"), qos=0, retain=True)
             if (( "openWB/config/set/SmartHome/Device" in msg.topic) and ("device_measureid" in msg.topic)):
                 devicenumb=re.sub(r'\D', '', msg.topic)
                 if ( 1 <= int(devicenumb) <= numberOfSupportedDevices and 1 <= int(msg.payload) <= 255):

--- a/runs/usmarthome/smartacthor.py
+++ b/runs/usmarthome/smartacthor.py
@@ -13,6 +13,7 @@ class Sacthor(Sbase):
         self._device_acthortype = 'none'
         self._device_acthorpower = 'none'
         self.device_nummer = 0
+        self._dynregel = 1
 
     def updatepar(self, input_param):
         super().updatepar(input_param)
@@ -33,10 +34,11 @@ class Sacthor(Sbase):
 
     def getwatt(self, uberschuss, uberschussoffset):
         self.prewatt(uberschuss, uberschussoffset)
+        forcesend = self.checkbefsend()
         argumentList = ['python3', self._prefixpy + 'acthor/watt.py',
                         str(self.device_nummer), str(self._device_ip),
                         str(self.devuberschuss), self._device_acthortype,
-                        self._device_acthorpower]
+                        self._device_acthorpower, str(forcesend)]
         try:
             self.proc = subprocess.Popen(argumentList)
             self.proc.communicate()
@@ -44,6 +46,7 @@ class Sacthor(Sbase):
             self.newwatt = int(self.answer['power'])
             self.newwattk = int(self.answer['powerc'])
             self.relais = int(self.answer['on'])
+            self.checksend(self.answer)
         except Exception as e1:
             log.warning("(" + str(self.device_nummer) +
                         ") Leistungsmessung %s %d %s Fehlermeldung: %s "

--- a/runs/usmarthome/smartbase.py
+++ b/runs/usmarthome/smartbase.py
@@ -92,6 +92,7 @@ class Sbase(Sbase0):
         self._oldrelais = '2'
         self._oldwatt = 0
         self._device_chan = 0
+        self._device_updatesec = 0
         # mqtt per
         self._whimported_tmp = 0
         self.runningtime = 0
@@ -115,6 +116,8 @@ class Sbase(Sbase0):
         self._c_ausverz_f = 'N'
         self._c_einverz = 0
         self._c_einverz_f = 'N'
+        self._c_updatetime = 0
+        self._seclastup = 0
         self._dynregel = 0
         self.device_setauto = 0
         self.gruppe = 'none'
@@ -339,7 +342,9 @@ class Sbase(Sbase0):
             elif (key == 'device_onuntilTime'):
                 self._device_onuntiltime = value
             elif (key == 'mode'):
-                self.device_manual = valueint
+                self.device_manual = valueint        
+            elif (key == 'device_updatesec'):   
+                self._device_updatesec = valueint             
             elif (key == 'device_chan'):
                 self._device_chan = valueint
             elif (key == 'device_manual_control'):

--- a/runs/usmarthome/smartbase.py
+++ b/runs/usmarthome/smartbase.py
@@ -342,9 +342,9 @@ class Sbase(Sbase0):
             elif (key == 'device_onuntilTime'):
                 self._device_onuntiltime = value
             elif (key == 'mode'):
-                self.device_manual = valueint        
-            elif (key == 'device_updatesec'):   
-                self._device_updatesec = valueint             
+                self.device_manual = valueint
+            elif (key == 'device_updatesec'):
+                self._device_updatesec = valueint
             elif (key == 'device_chan'):
                 self._device_chan = valueint
             elif (key == 'device_manual_control'):
@@ -533,10 +533,13 @@ class Sbase(Sbase0):
            (self.device_manual == 1)):
             return
         file_charge = '/var/www/html/openWB/ramdisk/llkombiniert'
-        testcharge = 0
-        if os.path.isfile(file_charge):
-            with open(file_charge, 'r') as f:
-                testcharge = int(f.read())
+        testcharge = 0.0
+        try:
+            if os.path.isfile(file_charge):
+                with open(file_charge, 'r') as f:
+                    testcharge = float(f.read())
+        except Exception:
+            pass
         if testcharge <= 1000:
             chargestatus = 0
         else:

--- a/runs/usmarthome/smartbase0.py
+++ b/runs/usmarthome/smartbase0.py
@@ -2,6 +2,7 @@ import json
 import time
 from usmarthome.global0 import log
 
+
 class Sbase0:
     _basePath = '/var/www/html/openWB'
     _prefixpy = _basePath+'/modules/smarthome/'
@@ -14,12 +15,12 @@ class Sbase0:
                   str(self.device_nummer), 'r') as f1:
             answer = json.loads(json.load(f1))
         return answer
-    
+
     def checkbefsend(self):
-        newtime = int(time.time())   
+        newtime = int(time.time())
         if (self._c_updatetime == 0):
             self._c_updatetime = newtime - 180
-        self._seclastup = newtime - int(self._c_updatetime)       
+        self._seclastup = newtime - int(self._c_updatetime)
         # forcesend = 0 default acthor time period applies
         # forcesend = 1 default overwritten send now
         # forcesend = 9 default overwritten no send
@@ -30,13 +31,19 @@ class Sbase0:
                 forcesend = 1
             else:
                 forcesend = 9
-        return forcesend       
-        
+        return forcesend
+
     def checksend(self, answer):
-        send = int(answer['send'])
-        sendpower = int(answer['sendpower'])
-        if (send == 1):
-            self._c_updatetime = int(time.time())
-            log.info("(" + str(self.device_nummer) +
-                     ") Gerät wurde upgedatet, neue Vorgabe %s Periode %s"
-                     % (str(sendpower), str(self._seclastup)))
+        try:
+            send = int(answer['send'])
+            sendpower = int(answer['sendpower'])
+            if (send == 1):
+                self._c_updatetime = int(time.time())
+                log.info("(" + str(self.device_nummer) +
+                         ") Gerät wurde upgedatet, " +
+                         "neue Vorgabe %s Periode %s"
+                         % (str(sendpower), str(self._seclastup)))
+        except Exception as e1:
+            log.warning("(" + str(self.device_nummer) +
+                        ") checksend Fehlermeldung: %s "
+                        % (str(e1)))

--- a/runs/usmarthome/smartbase0.py
+++ b/runs/usmarthome/smartbase0.py
@@ -1,5 +1,6 @@
 import json
-
+import time
+from usmarthome.global0 import log
 
 class Sbase0:
     _basePath = '/var/www/html/openWB'
@@ -13,3 +14,29 @@ class Sbase0:
                   str(self.device_nummer), 'r') as f1:
             answer = json.loads(json.load(f1))
         return answer
+    
+    def checkbefsend(self):
+        newtime = int(time.time())   
+        if (self._c_updatetime == 0):
+            self._c_updatetime = newtime - 180
+        self._seclastup = newtime - int(self._c_updatetime)       
+        # forcesend = 0 default acthor time period applies
+        # forcesend = 1 default overwritten send now
+        # forcesend = 9 default overwritten no send
+        if (self._device_updatesec == 0):
+            forcesend = 0
+        else:
+            if (self._seclastup > self._device_updatesec):
+                forcesend = 1
+            else:
+                forcesend = 9
+        return forcesend       
+        
+    def checksend(self, answer):
+        send = int(answer['send'])
+        sendpower = int(answer['sendpower'])
+        if (send == 1):
+            self._c_updatetime = int(time.time())
+            log.info("(" + str(self.device_nummer) +
+                     ") Gerät wurde upgedatet, neue Vorgabe %s Periode %s"
+                     % (str(sendpower), str(self._seclastup)))

--- a/web/settings/smarthomeconfig.php
+++ b/web/settings/smarthomeconfig.php
@@ -573,6 +573,13 @@ $numDevices = 9;
 											</div>
 										</div>
 										<div class="form-row mb-1">
+											<label for="device_updatesecDevices<?php echo $devicenum; ?>" class="col-md-4 col-form-label">Updategerät</label>
+											<div class="col">
+												<input id="device_updatesecDevices<?php echo $devicenum; ?>" name="device_updatesec" class="form-control naturalNumber" type="number" inputmode="decimal" required min="0" max="180" data-default="0" value="0" data-topicprefix="openWB/config/get/SmartHome/" data-topicsubgroup="Devices/<?php echo $devicenum; ?>/">
+												<span class="form-text small">Parameter in Sekunden (von 0 bis 180), in was für einen Abstand openWB das Gerät updatet. 0 Sekunden bedeutet Defaultverhalten. Das Defaultverhalten ist pro Typ definiert und eher konservativ (langsam).</span>
+											</div>
+										</div>
+										<div class="form-row mb-1">
 											<label for="device_ausschaltschwelleDevices<?php echo $devicenum; ?>" class="col-md-4 col-form-label">Ausschaltschwelle</label>
 											<div class="col">
 												<div class="form-row vaRow">

--- a/web/settings/topicsToSubscribe_smarthomeconfig.js
+++ b/web/settings/topicsToSubscribe_smarthomeconfig.js
@@ -27,6 +27,7 @@ var topicsToSubscribe = [
 	["openWB/config/get/SmartHome/Devices/+/device_einschaltschwelle", 0],
 	["openWB/config/get/SmartHome/Devices/+/device_ausschaltschwelle", 0],
 	["openWB/config/get/SmartHome/Devices/+/device_einschaltverzoegerung", 0],
+	["openWB/config/get/SmartHome/Devices/+/device_updatesec", 0],
 	["openWB/config/get/SmartHome/Devices/+/device_maxeinschaltdauer", 0],
 	["openWB/config/get/SmartHome/Devices/+/device_mineinschaltdauer", 0],
 	["openWB/config/get/SmartHome/Devices/+/device_deactivateWhileEvCharging", 0],


### PR DESCRIPTION
Um den Supportaufwand zu reduzieren, wird neu im smarthomelog bei den Geräten die mit Überschuss aus openWB versorgt werden eine zusätzliche Meldung geschrieben wenn ein Modbuswrite statgefunden hat. 
2022-09-15 17:46:38,186 INFO (2) Actest rel: 1 oncnt/onstandby/time: 14/0/23893 Status/Üeb: 10/1 akt: 40 Z: 0 2022-09-15 17:46:38,183 INFO (2) Gerät wurde upgedatet, neue Vorgabe 530 Periode 32

Die Periode ist die Zeit zwischen zwei Updates. Die Vorgabe ist der Betrag der übertragen wurde. Diese ist je nach Gerätetyp mal der Überschuss , oder die Sollleistungsaufnahme. Zusätzlich kann als Parameter neu pro Gerät eine Anzahl Sekunden eingegeben werden, nachdem eon Gerät upgedatet wird (Feld Periode). Wird in den Einstellungen 0 Sekunden erfasst, kommt die Defaultregelung von Openwb zum Einsatz, die eher eine konservativen Updateperiode (= langsam) fährt. Diese Funktionalitöt wird mit Acthor getestet und nachher auf alle anderen Geräte mit Überschusssteuerung ausgeweitet-