### PR TITLE
lgess: catch http error on failed auth

### DIFF
--- a/packages/modules/lg/device.py
+++ b/packages/modules/lg/device.py
@@ -67,11 +67,9 @@ class Device(AbstractDevice):
         if self.components:
             with MultiComponentUpdateContext(self.components):
                 session = req.get_http_session()
-                response = self._request_data(session)
-                # missing "auth" in response indicates success
-                if (response.get('auth') == "auth_key failed" or
-                        response.get('auth') == "auth timeout" or
-                        response.get('auth') == "not done"):
+                try:
+                    response = self._request_data(session)
+                except HTTPError:
                     self._update_session_key(session)
                     response = self._request_data(session)
 

--- a/packages/modules/lg/lg_test.py
+++ b/packages/modules/lg/lg_test.py
@@ -1,4 +1,5 @@
 import pytest
+from requests import HTTPError
 from unittest.mock import Mock
 
 from modules.common.component_state import BatState, CounterState, InverterState
@@ -75,7 +76,7 @@ def test_update_session_key(monkeypatch, dev: device.Device):
     monkeypatch.setattr(inverter, "get_inverter_value_store", Mock(return_value=mock_inverter_value_store))
     monkeypatch.setattr(device.Device, "_update_session_key", Mock())
     monkeypatch.setattr(device.Device, "_request_data", Mock(
-        side_effect=[sample_auth_key_invalid, sample_auth_key_valid]))
+        side_effect=[HTTPError, sample_auth_key_valid]))
     component_config = bat.component_descriptor.configuration_factory()
     component_config.id = None
     dev.add_component(component_config)


### PR DESCRIPTION
If the auth_key is not valid, the device returns http status 405. The session object checks this and throws an HTTPError and we have no chance to update the auth_key. So catch the HTTPError and try to authenticate again with password.