### PR TITLE
refactor simcount for better readability

### DIFF
--- a/modules/bezug_e3dc/e3dc.py
+++ b/modules/bezug_e3dc/e3dc.py
@@ -1,13 +1,14 @@
 #!/usr/bin/python
-from pymodbus.constants import Endian
 import logging
 from typing import List
+
+from pymodbus.constants import Endian
 
 from helpermodules.cli import run_using_positional_cli_args
 from modules.common.component_state import CounterState
 from modules.common.modbus import ModbusTcpClient_, ModbusDataType
+from modules.common.simcount import sim_count
 from modules.common.store import get_counter_value_store
-from modules.common.simcount import SimCountFactory
 
 log = logging.getLogger("E3DC EVU")
 
@@ -29,7 +30,7 @@ def update(ipaddress: str):
             if powers[0] == 1:
                 log.debug("Evu Leistungsmessung gefunden")
                 break
-    counter_import, counter_export = SimCountFactory().get_sim_counter()().sim_count(power_all, prefix="bezug")
+    counter_import, counter_export = sim_count(power_all, prefix="bezug")
     get_counter_value_store(1).set(CounterState(
         imported=counter_import,
         exported=counter_export,

--- a/modules/speicher_e3dc/e3dc.py
+++ b/modules/speicher_e3dc/e3dc.py
@@ -9,8 +9,8 @@ from modules.common.component_context import SingleComponentUpdateContext
 from modules.common.component_state import InverterState, BatState
 from modules.common.fault_state import ComponentInfo
 from modules.common.modbus import ModbusTcpClient_, ModbusDataType
+from modules.common.simcount import sim_count
 from modules.common.store import get_inverter_value_store, get_bat_value_store
-from modules.common.simcount import SimCountFactory
 from modules.common.store.ramdisk import files
 
 log = logging.getLogger("E3DC Battery")
@@ -43,7 +43,7 @@ def update_e3dc_battery(addresses: Iterable[str], read_external: int, pv_other: 
     soc = soc / count
     log.debug("Battery soc %d battery_power %d pv %d pv_external %d count ip %d",
               soc, battery_power, pv, pv_external, count)
-    counter_import, counter_export = SimCountFactory().get_sim_counter()().sim_count(battery_power, prefix="speicher")
+    counter_import, counter_export = sim_count(battery_power, prefix="speicher")
     get_bat_value_store(1).set(BatState(power=battery_power, soc=soc, imported=counter_import, exported=counter_export))
     # pv_other sagt aus, ob WR definiert ist, und dessen PV Leistung auch gilt
     # wenn 0 gilt nur PV und pv_external aus e3dc
@@ -59,7 +59,7 @@ def update_e3dc_battery(addresses: Iterable[str], read_external: int, pv_other: 
             except:
                 pass
         log.debug("wr update pv_other %s pv_total %d", pv_other, pv_total)
-        _, counter_pv = SimCountFactory().get_sim_counter()().sim_count(pv_total, prefix="pv")
+        _, counter_pv = sim_count(pv_total, prefix="pv")
         get_inverter_value_store(1).set(InverterState(exported=counter_pv, power=pv_total))
 
 

--- a/packages/modules/common/simcount/__init__.py
+++ b/packages/modules/common/simcount/__init__.py
@@ -1,2 +1,3 @@
-from modules.common.simcount._simcount import SimCountFactory
+from modules.common.simcount._simcount import sim_count
 from modules.common.simcount._simcounter import SimCounter
+from modules.common.simcount._simcounter_state import SimCounterState

--- a/packages/modules/common/simcount/_simcount.py
+++ b/packages/modules/common/simcount/_simcount.py
@@ -2,324 +2,48 @@
 Berechnet die importierte und exportierte Leistung, wenn der Zähler / PV-Modul / Speicher diese nicht liefert.
 """
 import logging
-import os
 import time
-import typing
 
-import paho.mqtt.client as mqtt
-
-from helpermodules import compatibility
-from helpermodules import pub
-from helpermodules.cli import run_using_positional_cli_args
-from modules.common.fault_state import FaultState
+from modules.common.fault_state import exceptions_to_fault_state
 from modules.common.simcount._calculate import calculate_import_export
+from modules.common.simcount._simcounter_state import SimCounterState
+from modules.common.simcount._simcounter_store import get_sim_counter_store
 
 log = logging.getLogger(__name__)
 
 
-def process_error(e):
-    raise FaultState.error(__name__+" "+str(type(e))+" "+str(e)) from e
+@exceptions_to_fault_state(__name__)
+def sim_count(power_present: float, topic: str = "", data: SimCounterState = None, prefix: str = "") -> SimCounterState:
+    """ emulate import export
 
+    Parameters
+    ----------
+    power_present: aktuelle Leistung
+    topic: Topic, für den Broker
+    data: bisheriger state
+    prefix: prefix für die ramdisk-Datei
 
-class SimCountFactory:
-    def get_sim_counter(self):
-        try:
-            ramdisk = compatibility.is_ramdisk_in_use()
-            return SimCountLegacy if ramdisk else SimCount
-        except Exception as e:
-            process_error(e)
+    Return
+    ------
+    neuer state
+    """
+    store = get_sim_counter_store()
+    timestamp_present = time.time()
+    previous_state = store.load(prefix, topic) if data is None else data
 
-
-def get_topic(prefix: str) -> str:
-    """ ermittelt das zum Präfix gehörende Topic."""
-    try:
-        if prefix == "bezug":
-            topic = "evu"
-        elif prefix == "pv" or prefix == "pv2":
-            topic = prefix
-        elif prefix == "speicher":
-            topic = "housebattery"
-        else:
-            raise FaultState.error("Fehler im Modul simcount: Unbekannter Präfix")
-        return topic
-    except Exception as e:
-        process_error(e)
-
-
-def read_ramdisk_file(name: str):
-    try:
-        with open('/var/www/html/openWB/ramdisk/' + name, 'r') as f:
-            return f.read()
-    except Exception as e:
-        process_error(e)
-
-
-def write_ramdisk_file(name: str, value):
-    try:
-        with open('/var/www/html/openWB/ramdisk/' + name, 'w') as f:
-            f.write(str(value))
-    except Exception as e:
-        process_error(e)
-
-
-class SimCountLegacy:
-    def sim_count(
-        self, power_present: float, topic: str = "", data: dict = {}, prefix: str = ""
-    ) -> typing.Tuple[float, float]:
-        """ emulate import export
-
-        Parameters
-        ----------
-        power_present: aktuelle Leistung
-        topic: Topic, ungenutzt
-        data:  ungenutzt
-        prefix: prefix für die ramdisk-Datei
-        Return
-        ------
-        imported: importierte Energie
-        exported: exportierte Energie
-        """
-        try:
-            timestamp_present = time.time()
-            power_previous, counter_export_present, counter_export_previous = 0, 0, 0
-            counter_import_present, counter_import_previous = 0, 0
-            timestamp_previous = 0.0
-            start_new = True
-            if os.path.isfile('/var/www/html/openWB/ramdisk/'+prefix+'sec0'):
-                timestamp_previous = float(read_ramdisk_file(prefix+'sec0'))
-                power_previous = int(float(read_ramdisk_file(prefix+'wh0')))
-                try:
-                    counter_import_present = int(float(read_ramdisk_file(prefix+'watt0pos')))
-                except Exception:
-                    counter_import_present = int(Restore().restore_value("watt0pos", prefix))
-                counter_import_previous = counter_import_present
-                try:
-                    counter_export_present = int(float(read_ramdisk_file(prefix+'watt0neg')))
-                except Exception:
-                    counter_export_present = int(Restore().restore_value("watt0neg", prefix))
-                if counter_export_present < 0:
-                    # runs/simcount.py speichert das Zwischenergebnis des Exports negativ ab.
-                    counter_export_present = counter_export_present * -1
-                counter_export_previous = counter_export_present
-                log.debug("simcount Zwischenergebnisse letzte Berechnung: Import: " +
-                          str(counter_import_previous) + " Export: " + str(counter_export_previous) +
-                          " Leistung: " + str(power_previous))
-                start_new = False
-            write_ramdisk_file(prefix+'sec0', "%22.6f" % timestamp_present)
-            write_ramdisk_file(prefix+'wh0', int(power_present))
-
-            if start_new:
-                log.debug("Neue Simulation starten.")
-                if prefix == "bezug":
-                    imported = get_existing_imports_exports('bezugkwh')
-                    exported = get_existing_imports_exports('einspeisungkwh')
-                elif prefix == "pv2":
-                    imported = 0
-                    exported = get_existing_imports_exports('pv2kwh')
-                elif prefix == "pv":
-                    imported = 0
-                    exported = get_existing_imports_exports('pvkwh')
-                else:
-                    imported = get_existing_imports_exports('speicherikwh')
-                    exported = get_existing_imports_exports('speicherekwh')
-                return imported, exported
-            else:
-                # timestamp_previous = timestamp_previous + 1  # do not increment time if calculating areas!
-                seconds_since_previous = timestamp_present - timestamp_previous
-                imp_exp = calculate_import_export(
-                    seconds_since_previous, power_previous, power_present)
-                counter_export_present = counter_export_present + imp_exp[1]
-                counter_import_present = counter_import_present + imp_exp[0]
-                log.debug(
-                    "simcount aufsummierte Energie: Bezug[Ws]: " + str(counter_import_present) + ", Einspeisung[Ws]: " +
-                    str(counter_export_present)
-                )
-                energy_positive_kWh = counter_import_present / 3600
-                energy_negative_kWh = counter_export_present / 3600
-                log.info(
-                    "simcount Ergebnis: Bezug[Wh]: " + str(energy_positive_kWh) +
-                    ", Einspeisung[Wh]: " + str(energy_negative_kWh)
-                )
-
-                topic = get_topic(prefix)
-                log.debug(
-                    "simcount Zwischenergebnisse aktuelle Berechnung: Import: " + str(counter_import_present) +
-                    " Export: " + str(counter_export_present) + " Leistung: " + str(power_present)
-                )
-                write_ramdisk_file(prefix+'watt0pos', counter_import_present)
-                if counter_import_present != counter_import_previous:
-                    pub.pub_single("openWB/"+topic+"/WHImported_temp", counter_import_present, no_json=True)
-                write_ramdisk_file(prefix+'watt0neg', counter_export_present)
-                if counter_export_present != counter_export_previous:
-                    pub.pub_single("openWB/"+topic+"/WHExport_temp",
-                                   counter_export_present, no_json=True)
-                return energy_positive_kWh, energy_negative_kWh
-        except Exception as e:
-            process_error(e)
-
-
-def get_existing_imports_exports(file: str) -> float:
-    if os.path.isfile('/var/www/html/openWB/ramdisk/'+file):
-        value = float(read_ramdisk_file(file))
-        log.info("Es wurde ein vorhandener Zählerstand in "+file+" gefunden: "+str(value)+"Wh")
+    if previous_state is None:
+        log.debug("No previous state found. Starting new simulation.")
+        return store.initialize(prefix, topic, power_present, timestamp_present)
     else:
-        value = 0
-    return value
-
-
-class Restore():
-    def restore_value(self, value: str, prefix: str) -> float:
-        result = 0
-        self.temp = ""
-        try:
-            self.value = value
-            self.prefix = prefix
-            client = mqtt.Client("openWB-simcount_restore-" + str(self.__get_serial()))
-
-            client.on_connect = self.__on_connect
-            client.on_message = self.__on_message
-
-            client.connect("localhost", 1883)
-            client.loop_start()
-            time.sleep(0.5)
-            client.loop_stop()
-            try:
-                result = float(self.temp)
-                if value == "watt0pos":
-                    log.info(
-                        "loadvars read openWB/"+get_topic(self.prefix)+"/WHImported_temp from mosquito "+str(self.temp))
-                else:
-                    log.info(
-                        "loadvars read openWB/"+get_topic(self.prefix)+"/WHExport_temp from mosquito "+str(self.temp))
-            except ValueError:
-                log.info("Keine Werte auf dem Broker gefunden.")
-                if prefix == "bezug":
-                    file = "bezugkwh" if value == "watt0pos" else "einspeisungkwh"
-                elif prefix == "pv2":
-                    file = "pv2kwh"
-                elif prefix == "pv":
-                    file = "pvkwh"
-                else:
-                    file = "speicherikwh" if value == "watt0pos" else "speicherekwh"
-                if os.path.isfile('/var/www/html/openWB/ramdisk/'+file):
-                    result = get_existing_imports_exports(file) * 3600
-                    self.temp = str(result)
-            write_ramdisk_file(prefix+value, self.temp)
-        except Exception:
-            log.exception("Fehler in der Restore-Klasse")
-        finally:
-            return result
-
-    def __on_connect(self, client, user_data, flags, rc):
-        """ connect to broker and subscribe to set topics
-        """
-        try:
-            topic = get_topic(self.prefix)
-            if self.value == "watt0pos":
-                client.subscribe("openWB/"+topic+"/WHImported_temp", 2)
-            else:
-                client.subscribe("openWB/"+topic+"/WHExport_temp", 2)
-        except Exception:
-            log.exception("Fehler in der Restore-Klasse")
-
-    def __on_message(self, client, user_data, msg):
-        """ wartet auf eingehende Topics.
-        """
-        self.temp = msg.payload
-
-    def __get_serial(self):
-        """ Extract serial from cpuinfo file
-        """
-        try:
-            with open('/proc/cpuinfo', 'r') as f:
-                for line in f:
-                    if line[0:6] == 'Serial':
-                        return line[10:26]
-                return "0000000000000000"
-        except Exception:
-            log.exception("Fehler in der Restore-Klasse")
-
-
-class SimCount:
-    def sim_count(
-        self, power_present: float, topic: str = "", data: dict = {}, prefix: str = ""
-    ) -> typing.Tuple[float, float]:
-        """ emulate import export
-
-        Parameters
-        ----------
-        power_present: aktuelle Leistung
-        topic: str Topic, in welches veröffentlicht werden soll
-        data: Komponenten-Daten
-        Return
-        ------
-        imported: importierte Energie
-        exported: exportierte Energie
-        """
-        try:
-            timestamp_present = time.time()
-            power_previous, counter_export_present, counter_import_present = 0, 0, 0
-            timestamp_previous = 0.0
-            start_new = True
-            if "timestamp_present" in data:
-                timestamp_previous = float(data["timestamp_present"])
-                power_previous = int(data["power_present"])
-                if "present_imported" in data:
-                    counter_import_present = int(data["present_imported"])
-                else:
-                    counter_import_present = 0
-                if "present_exported" in data:
-                    counter_export_present = int(data["present_exported"])
-                else:
-                    counter_export_present = 0
-                log.debug(
-                    "Fortsetzen der Simulation: Importzähler: " + str(counter_import_present)+"Ws, Export-Zähler: " +
-                    str(counter_export_present) + "Ws"
-                )
-                start_new = False
-            pub.Pub().pub(topic+"simulation/timestamp_present", "%22.6f" % timestamp_present)
-            pub.Pub().pub(topic+"simulation/power_present", power_present)
-
-            if start_new:
-                log.debug("Neue Simulation")
-                pub.Pub().pub(topic+"simulation/present_imported", 0)
-                pub.Pub().pub(topic+"simulation/present_exported", 0)
-                return 0, 0
-            else:
-                # timestamp_previous = timestamp_previous + 1  # do not increment time if calculating areas!
-                seconds_since_previous = timestamp_present - timestamp_previous
-                imp_exp = calculate_import_export(
-                    seconds_since_previous, power_previous, power_present)
-                counter_export_present = counter_export_present + imp_exp[1]
-                counter_import_present = counter_import_present + imp_exp[0]
-                log.debug(
-                    "simcount aufsummierte Energie: Bezug[Ws]: " + str(counter_import_present) +
-                    ", Einspeisung[Ws]: " +
-                    str(counter_export_present)
-                )
-                energy_positive_kWh = counter_import_present / 3600
-                energy_negative_kWh = counter_export_present / 3600
-                log.info(
-                    "simcount Ergebnis: Bezug[Wh]: " + str(energy_positive_kWh) +
-                    ", Einspeisung[Wh]: " + str(energy_negative_kWh)
-                )
-                log.debug(
-                    "simcount Zwischenergebnisse aktuelle Berechnung: Import: " + str(counter_import_present) +
-                    " Export: " + str(counter_export_present) + " Power: " + str(power_present)
-                )
-                pub.Pub().pub(topic+"simulation/present_imported", counter_import_present)
-                pub.Pub().pub(topic+"simulation/present_exported", counter_export_present)
-                return energy_positive_kWh, energy_negative_kWh
-        except Exception as e:
-            process_error(e)
-
-
-def run_cli(power_present: int, prefix: str):
-    SimCountLegacy().sim_count(power_present=power_present, prefix=prefix)
-
-
-if __name__ == "__main__":
-    try:
-        run_using_positional_cli_args(run_cli)
-    except Exception as e:
-        process_error(e)
+        log.debug("Previous state: %s", previous_state)
+        hours_since_previous = (timestamp_present - previous_state.timestamp) / 3600
+        imported, exported = calculate_import_export(hours_since_previous, previous_state.power, power_present)
+        current_state = SimCounterState(
+            timestamp_present,
+            power_present,
+            previous_state.imported + imported,
+            previous_state.exported + exported
+        )
+        log.debug("imported: %g kWh, exported: %g kWh, new state: %s", imported, exported, current_state)
+        store.save(prefix, topic, current_state)
+        return current_state

--- a/packages/modules/common/simcount/_simcounter.py
+++ b/packages/modules/common/simcount/_simcounter.py
@@ -1,13 +1,15 @@
-from typing import Tuple, Any
+from typing import Tuple, Optional
 
-from modules.common.simcount import SimCountFactory
+from modules.common.simcount._simcount import sim_count
+from modules.common.simcount._simcounter_state import SimCounterState
 
 
 class SimCounter:
     def __init__(self, device_id: int, component_id: int, prefix: str):
         self.topic = "openWB/set/system/device/{}/component/{}/".format(device_id, component_id)
         self.prefix = "pv2" if prefix == "pv" and component_id != 1 else prefix
-        self.data = {}  # type: dict[str, Any]
+        self.data = None  # type: Optional[SimCounterState]
 
     def sim_count(self, power: float) -> Tuple[float, float]:
-        return SimCountFactory().get_sim_counter()().sim_count(power, self.topic, self.data, self.prefix)
+        self.data = sim_count(power, self.topic, self.data, self.prefix)
+        return self.data.imported, self.data.exported

--- a/packages/modules/common/simcount/_simcounter_state.py
+++ b/packages/modules/common/simcount/_simcounter_state.py
@@ -1,0 +1,16 @@
+from typing import Iterator
+
+from helpermodules.auto_str import auto_str
+
+
+@auto_str
+class SimCounterState:
+    def __init__(self, timestamp: float, power: float, imported: float, exported: float):
+        self.timestamp = timestamp
+        self.power = power
+        self.imported = imported
+        self.exported = exported
+
+    def __iter__(self) -> Iterator[float]:
+        yield self.imported
+        yield self.exported

--- a/packages/modules/common/simcount/_simcounter_store.py
+++ b/packages/modules/common/simcount/_simcounter_store.py
@@ -1,0 +1,176 @@
+import logging
+from abc import abstractmethod
+from queue import Queue, Empty
+from typing import Optional
+
+from paho.mqtt.client import Client as MqttClient, MQTTMessage
+
+from helpermodules import pub, compatibility
+from modules.common.fault_state import FaultState
+from modules.common.simcount._simcounter_state import SimCounterState
+from modules.common.store import ramdisk_write, ramdisk_read_float
+
+log = logging.getLogger(__name__)
+
+
+def get_topic(prefix: str) -> str:
+    """ ermittelt das zum Präfix gehörende Topic."""
+    if prefix == "bezug":
+        topic = "evu"
+    elif prefix == "pv" or prefix == "pv2":
+        topic = prefix
+    elif prefix == "speicher":
+        topic = "housebattery"
+    else:
+        raise FaultState.error("Fehler im Modul simcount: Unbekannter Präfix: " + prefix)
+    return topic
+
+
+def get_existing_imports_exports(file: str) -> float:
+    try:
+        result = ramdisk_read_float(file)
+        log.info("Found counter reading <%g Wh> in file <%s>", result, file)
+        return result
+    except FileNotFoundError:
+        return 0
+
+
+def get_serial():
+    try:
+        with open('/proc/cpuinfo', 'r') as f:
+            for line in f:
+                if line[0:6] == 'Serial':
+                    return line[10:26]
+    except Exception:
+        log.exception("Could not read serial from cpuinfo")
+
+    return "0000000000000000"
+
+
+def read_mqtt_topic(topic: str) -> Optional[str]:
+    """Reads and returns the first message received for the specified topic.
+
+    Returns None if no value is received before timeout"""
+
+    def on_message(_client, _userdata, message: MQTTMessage):
+        queue.put(message.payload.decode("utf-8"))
+
+    def on_connect(*_args):
+        client.subscribe(topic)
+
+    queue = Queue(1)  # type: Queue[str]
+    client = MqttClient("openWB-simcounter-" + get_serial())
+    try:
+        client.on_connect = on_connect
+        client.on_message = on_message
+        client.connect("localhost", 1883)
+        client.loop_start()
+        return queue.get(block=True, timeout=.5)
+    except Empty:
+        return None
+    finally:
+        client.disconnect()
+
+
+def restore_value(name: str, prefix: str) -> float:
+    topic = "openWB/" + get_topic(prefix) + ("/WHImported_temp" if name == "watt0pos" else "/WHExport_temp")
+    mqtt_value = read_mqtt_topic(topic)
+    log.info("read from broker: %s=%s", topic, mqtt_value)
+    if mqtt_value is None:
+        result = None
+    else:
+        try:
+            result = float(mqtt_value)
+        except ValueError:
+            log.warning("Value <%s> from topic <%s> is not a valid number", mqtt_value, topic)
+            result = None
+
+    if result is None:
+        if prefix == "bezug":
+            file = "bezugkwh" if name == "watt0pos" else "einspeisungkwh"
+        elif prefix == "pv2":
+            file = "pv2kwh"
+        elif prefix == "pv":
+            file = "pvkwh"
+        else:
+            file = "speicherikwh" if name == "watt0pos" else "speicherekwh"
+        result = get_existing_imports_exports(file) * 3600
+
+    ramdisk_write(prefix + name, result)
+    return result
+
+
+class SimCounterStore:
+    @abstractmethod
+    def load(self, prefix: str, topic: str) -> Optional[SimCounterState]:
+        pass
+
+    @abstractmethod
+    def save(self, prefix: str, topic: str, state: SimCounterState):
+        pass
+
+    @abstractmethod
+    def initialize(self, prefix: str, topic: str, power: float, timestamp: float) -> SimCounterState:
+        pass
+
+
+class SimCounterStoreRamdisk(SimCounterStore):
+    def initialize(self, prefix: str, topic: str, power: float, timestamp: float) -> SimCounterState:
+        if prefix == "bezug":
+            imported = get_existing_imports_exports("bezugkwh")
+            exported = get_existing_imports_exports("einspeisungkwh")
+        elif prefix == "pv" or prefix == "pv2":
+            imported = 0
+            exported = get_existing_imports_exports(prefix + "kwh")
+        else:
+            imported = get_existing_imports_exports("speicherikwh")
+            exported = get_existing_imports_exports("speicherekwh")
+        result = SimCounterState(timestamp, power, imported, exported)
+        self.save(prefix, topic, result)
+        return result
+
+    def load(self, prefix: str, topic: str) -> Optional[SimCounterState]:
+        try:
+            timestamp = ramdisk_read_float(prefix + "sec0")
+        except FileNotFoundError:
+            return None
+
+        def read_or_restore(name: str) -> int:
+            try:
+                return int(ramdisk_read_float(prefix + name))
+            except Exception:
+                return int(restore_value(name, prefix))
+
+        return SimCounterState(
+            timestamp=timestamp,
+            power=ramdisk_read_float(prefix + "wh0"),
+            imported=read_or_restore("watt0pos"),
+            # abs() weil runs/simcount.py speichert das Zwischenergebnis des Exports negativ ab:
+            exported=abs(read_or_restore("watt0neg")),
+        )
+
+    def save(self, prefix: str, topic: str, state: SimCounterState):
+        ramdisk_write(prefix + "sec0", state.timestamp)
+        ramdisk_write(prefix + "wh0", state.power)
+        ramdisk_write(prefix + "watt0pos", state.imported)
+        ramdisk_write(prefix + "watt0neg", state.exported)
+        topic = get_topic(prefix)
+        pub.pub_single("openWB/" + topic + "/WHImported_temp", state.imported, no_json=True)
+        pub.pub_single("openWB/" + topic + "/WHExport_temp", state.exported, no_json=True)
+
+
+class SimCounterStoreBroker(SimCounterStore):
+    def initialize(self, prefix: str, topic: str, power: float, timestamp: float) -> SimCounterState:
+        state = SimCounterState(timestamp, power, imported=0, exported=0)
+        self.save(prefix, topic, state)
+        return state
+
+    def load(self, prefix: str, topic: str) -> Optional[SimCounterState]:
+        return None
+
+    def save(self, prefix: str, topic: str, state: SimCounterState):
+        pub.Pub().pub(topic + "simulation", vars(state))
+
+
+def get_sim_counter_store() -> SimCounterStore:
+    return SimCounterStoreRamdisk() if compatibility.is_ramdisk_in_use() else SimCounterStoreBroker()

--- a/packages/modules/conftest.py
+++ b/packages/modules/conftest.py
@@ -22,13 +22,8 @@ module.BinaryPayloadDecoder = Mock()
 sys.modules['pymodbus.payload'] = module
 
 
-class MockSimCount:
-    def __init__(self):
-        self.sim_count = Mock(return_value=(100, 200))
-
-
 @pytest.fixture(autouse=True)
-def mock_simcount(monkeypatch) -> MockSimCount:
-    mock = MockSimCount()
-    monkeypatch.setattr(simcount.SimCountFactory, 'get_sim_counter', Mock(return_value=lambda: mock))
+def mock_simcount(monkeypatch) -> Mock:
+    mock = Mock(return_value=(100, 200))
+    monkeypatch.setattr(simcount.SimCounter, 'sim_count', mock)
     return mock

--- a/packages/modules/fronius/bat_test.py
+++ b/packages/modules/fronius/bat_test.py
@@ -28,7 +28,7 @@ def test_update(monkeypatch, requests_mock: requests_mock.Mocker, mock_ramdisk, 
 
     mock = Mock(return_value=None)
     monkeypatch.setattr(LoggingValueStore, "set", mock)
-    mock_simcount.sim_count.return_value = 0, 0
+    mock_simcount.return_value = 0, 0
     requests_mock.get(
         "http://" + SAMPLE_IP + "/solar_api/v1/GetPowerFlowRealtimeData.fcgi",
         json=json)

--- a/packages/modules/fronius/counter_s0_test.py
+++ b/packages/modules/fronius/counter_s0_test.py
@@ -28,7 +28,7 @@ def test_update(monkeypatch, requests_mock: requests_mock.Mocker, mock_ramdisk, 
 
     mock = Mock(return_value=None)
     monkeypatch.setattr(LoggingValueStore, "set", mock)
-    mock_simcount.sim_count.return_value = 0, 0
+    mock_simcount.return_value = 0, 0
     requests_mock.get(
         "http://" + SAMPLE_IP + "/solar_api/v1/GetPowerFlowRealtimeData.fcgi",
         json=json)

--- a/packages/modules/fronius/counter_sm_test.py
+++ b/packages/modules/fronius/counter_sm_test.py
@@ -29,7 +29,7 @@ def test_update_grid(monkeypatch, requests_mock: requests_mock.Mocker, mock_ramd
 
     mock = Mock(return_value=None)
     monkeypatch.setattr(LoggingValueStore, "set", mock)
-    mock_simcount.sim_count.return_value = 0, 0
+    mock_simcount.return_value = 0, 0
     requests_mock.get(
         "http://" + SAMPLE_IP + "/solar_api/v1/GetMeterRealtimeData.cgi",
         json=json_grid)
@@ -59,7 +59,7 @@ def test_update_grid_var2(monkeypatch, requests_mock: requests_mock.Mocker, mock
 
     mock = Mock(return_value=None)
     monkeypatch.setattr(LoggingValueStore, "set", mock)
-    mock_simcount.sim_count.return_value = 0, 0
+    mock_simcount.return_value = 0, 0
     requests_mock.get(
         "http://" + SAMPLE_IP + "/solar_api/v1/GetMeterRealtimeData.cgi",
         json=json_grid_var2)
@@ -88,7 +88,7 @@ def test_update_external_var2(monkeypatch, requests_mock: requests_mock.Mocker, 
 
     mock = Mock(return_value=None)
     monkeypatch.setattr(LoggingValueStore, "set", mock)
-    mock_simcount.sim_count.return_value = 0, 0
+    mock_simcount.return_value = 0, 0
     requests_mock.get(
         "http://" + SAMPLE_IP + "/solar_api/v1/GetMeterRealtimeData.cgi",
         json=json_ext_var2)
@@ -117,7 +117,7 @@ def test_update_load(monkeypatch, requests_mock: requests_mock.Mocker, mock_ramd
 
     mock = Mock(return_value=None)
     monkeypatch.setattr(LoggingValueStore, "set", mock)
-    mock_simcount.sim_count.return_value = 0, 0
+    mock_simcount.return_value = 0, 0
     requests_mock.get(
         "http://" + SAMPLE_IP + "/solar_api/v1/GetMeterRealtimeData.cgi",
         json=json_load_meter)

--- a/packages/modules/fronius/inverter_test.py
+++ b/packages/modules/fronius/inverter_test.py
@@ -23,7 +23,7 @@ def test_update(monkeypatch, requests_mock: requests_mock.Mocker, mock_ramdisk, 
 
     mock = Mock(return_value=None)
     monkeypatch.setattr(LoggingValueStore, "set", mock)
-    mock_simcount.sim_count.return_value = 0, 0
+    mock_simcount.return_value = 0, 0
     requests_mock.get(
         "http://" + SAMPLE_IP + "/solar_api/v1/GetPowerFlowRealtimeData.fcgi",
         json=json_wr1)

--- a/packages/modules/kostal_piko/device.py
+++ b/packages/modules/kostal_piko/device.py
@@ -8,15 +8,15 @@ from modules.byd.config import BYD, BYDBatSetup, BYDConfiguration
 from modules.byd.device import Device as BYDDevice
 from modules.common.abstract_device import AbstractDevice, DeviceDescriptor
 from modules.common.component_context import SingleComponentUpdateContext
-from modules.common.store import get_counter_value_store
-from modules.common import simcount
 from modules.common.component_state import CounterState
+from modules.common.simcount import sim_count
+from modules.common.store import get_counter_value_store
+from modules.kostal_piko import counter
+from modules.kostal_piko import inverter
 from modules.kostal_piko.config import (KostalPiko,
                                         KostalPikoConfiguration,
                                         KostalPikoCounterSetup, KostalPikoInverterConfiguration,
                                         KostalPikoInverterSetup)
-from modules.kostal_piko import counter
-from modules.kostal_piko import inverter
 
 log = logging.getLogger(__name__)
 
@@ -110,8 +110,7 @@ def read_legacy(component_type: str,
             inverter_power, _ = dev.components["component"+str(1)].get_values()
 
             power = home_consumption + inverter_power
-            imported, exported = simcount.SimCountFactory().get_sim_counter(
-            )().sim_count(power, topic="topic_str", data={}, prefix="bezug")
+            imported, exported = sim_count(power, prefix="bezug")
             counter_state = CounterState(
                 imported=imported,
                 exported=exported,


### PR DESCRIPTION
Der nächste Schritt nach #2349:

Ich habe mir das SimCount-Modul genauer angesehen und mir ist aufgefallen, dass die Klassen `SimCountLegacy` und `SimCount` viel gemeinsame Code haben. Mein Hauptziel war es das ganze so zu überarbeiten, dass der Code de-dupliziert wird. Dazu habe ich:
- Eine Funktion `sim_count` erzeugt, die beide Klassen abdeckt.
- Der Teil der nicht gemeinsam ist, ist der Teil, der sich damit beschäftigt Daten aus Ramdisk und/oder Broker zu laden. Den Teil habe ich in die Klassen `SimCounterStoreRamdisk` und `SimCounterStoreBroker` extrahiert.

Der alter Parameter `data` der Funktion `sim_count` war vom Typ `dict`. Das fand ich ungünstig, da nicht direkt ersichtlich ist, mit welchen Eigenschaften man in diesem Objekt rechnen kann. Ich habe daher eine Klasse `SimCounterState` extrahiert und stattdessen verwendet.

Was mich im Rahmen des Parameters `data` noch irrtiert, ist dass die Daten nie aus dem Broker wieder geladen werden. Bei einem Neustart der openWB würde die Simulation damit immer wieder von vorn beginnen. Da das vorher schon so war, habe ich das auch so gelassen. Ich vermute jedoch, dass das keine Absicht ist und da ein follow-up zu kommen sollte...

Die Klasse `Restore` fand ich unnötig komplex. Es hat eine ganze Weile gebraucht bis ich die verstanden habe. Das hat auch damit zu tun, dass sie zwei Dinge tut: Sie redet mit dem MQTT-broker und führt Werte zusammen. Ich habe das ganze getrennt in eine Funktion `read_mqtt_topic` die mit dem Broker redet und eine Funktion `restore_value`, die Werte zusammenführt. In dem Zusammenhang frage ich mich: Steht hinter der Funktion `get_serial` ein tieferer Sinn?

Bei meiner Installation habe ich kein SimCount im Einsatz. Das ganze ist daher im wesentlich in der "echten Welt" ungetestet. Freiwillige gesucht ;-).