### PR TITLE
fix: from_dict does not work on classes that extend classes with generic

### DIFF
--- a/packages/dataclass_utils/_dataclass_from_dict.py
+++ b/packages/dataclass_utils/_dataclass_from_dict.py
@@ -16,7 +16,7 @@ def dataclass_from_dict(cls: Type[T], args: Union[dict, T]) -> T:
     """
     if isinstance(args, cls):
         return args
-    arg_spec = inspect.getfullargspec(cls)
+    arg_spec = inspect.getfullargspec(cls.__init__)
     return cls(*[_get_argument_value(arg_spec, index, args) for index in range(1, len(arg_spec.args))])
 
 

--- a/packages/dataclass_utils/_dataclass_from_dict_test.py
+++ b/packages/dataclass_utils/_dataclass_from_dict_test.py
@@ -1,4 +1,4 @@
-from typing import Type, TypeVar
+from typing import Type, TypeVar, Generic
 
 import pytest
 
@@ -13,10 +13,20 @@ class SimpleSample:
         self.b = b
 
 
-class NestedSample():
+class NestedSample:
     def __init__(self, normal: str, nested: SimpleSample):
         self.normal = normal
         self.nested = nested
+
+
+class Base(Generic[T]):
+    def __init__(self, a: T):
+        self.a = a
+
+
+class Extends(Base[str]):
+    def __init__(self, a: str):
+        super().__init__(a)
 
 
 def test_from_dict_simple():
@@ -56,6 +66,14 @@ def test_from_dict_returns_args_if_type_correct():
 
     # evaluation
     assert actual is sample
+
+
+def test_from_dict_extends_generic():
+    # execution
+    actual = dataclass_from_dict(Extends, {"a": "aValue"})
+
+    # evaluation
+    assert actual.a == "aValue"
 
 
 @pytest.mark.parametrize(["type", "invalid_parameter"], [


### PR DESCRIPTION
Auf der Suche nach der Ursache des [hier beschriebenen Problems mit dem HTTP Modul](https://openwb.de/forum/viewtopic.php?p=71902#p71902) ist mir aufgefallen, dass die Funktion `dataclass_from_dict` offenbar nicht damit klar kommt, wenn eine Klasse von einer anderen Klasse ableitet, die ein Generic hat. Daher wird in dem Beispiel die Klasse `HttpCounterSetup` nicht korrekt erzeugt und nix geht.

Ich konnte das Problem mit einem einfachen Test nachbilden und auch fixen. Im Bezug auf HTTP ist das mit #2289 reingekommen, welcher bereits am 14.07., also vor über 2 Monaten gemergt wurde. Ich bin etwas irritiert davon, dass das erst jetzt auffällt. Hat es wirklich niemand gemerkt oder übersehe ich da noch etwas??