### PR TITLE
Module soc_aiways: Remove "content-length" from POST request headers

### DIFF
--- a/modules/soc_aiways/aiways_get_soc.py
+++ b/modules/soc_aiways/aiways_get_soc.py
@@ -65,7 +65,6 @@ if __name__ == "__main__":
         "apptimezone": apptimezone,
         "apptimezoneid": apptimezoneid,
         "content-type": "application/json; charset=utf-8",
-        "content-length": "65",
         "accept-encoding": "gzip",
         "user-agent": "okhttp/4.3.1"
     }
@@ -101,7 +100,6 @@ if __name__ == "__main__":
         "apptimezone": apptimezone,
         "apptimezoneid": apptimezoneid,
         "content-type": "application/json; charset=utf-8",
-        "content-length": "54",
         "accept-encoding": "gzip",
         "user-agent": "okhttp/4.3.1"
     }


### PR DESCRIPTION
The Python module "requests" adds "content-length" headers automatically. There is no need to add them manually to the headers, as the module currently does. In fact, even if you add them manually, they are actually overwritten by mod requests. (And that is good because the static length would otherwise be wrong in most cases and would ruin the transmission.)