### PR TITLE
evu-mqtt: add missing topics

### DIFF
--- a/runs/mqttsub.py
+++ b/runs/mqttsub.py
@@ -1419,9 +1419,39 @@ def on_message(client, userdata, msg):
                     f = open('/var/www/html/openWB/ramdisk/evuv3', 'w')
                     f.write(msg.payload.decode("utf-8"))
                     f.close()
-            if (msg.topic == "openWB/set/evu/HzFrequenz"):
+            if ((msg.topic == "openWB/set/evu/HzFrequenz") or (msg.topic == "openWB/set/evu/Hz")):
                 if (float(msg.payload) >= 0 and float(msg.payload) <= 80):
                     f = open('/var/www/html/openWB/ramdisk/evuhz', 'w')
+                    f.write(msg.payload.decode("utf-8"))
+                    f.close()
+            if (msg.topic == "openWB/set/evu/WPhase1"):
+                if (float(msg.payload) >= -1000 and float(msg.payload) <= 1000):
+                    f = open('/var/www/html/openWB/ramdisk/bezugw1', 'w')
+                    f.write(msg.payload.decode("utf-8"))
+                    f.close()
+            if (msg.topic == "openWB/set/evu/WPhase2"):
+                if (float(msg.payload) >= -1000 and float(msg.payload) <= 1000):
+                    f = open('/var/www/html/openWB/ramdisk/bezugw2', 'w')
+                    f.write(msg.payload.decode("utf-8"))
+                    f.close()
+            if (msg.topic == "openWB/set/evu/WPhase3"):
+                if (float(msg.payload) >= -1000 and float(msg.payload) <= 1000):
+                    f = open('/var/www/html/openWB/ramdisk/bezugw3', 'w')
+                    f.write(msg.payload.decode("utf-8"))
+                    f.close()
+            if (msg.topic == "openWB/set/evu/PfPhase1"):
+                if (float(msg.payload) >= -1000 and float(msg.payload) <= 1000):
+                    f = open('/var/www/html/openWB/ramdisk/evupf1', 'w')
+                    f.write(msg.payload.decode("utf-8"))
+                    f.close()
+            if (msg.topic == "openWB/set/evu/PfPhase2"):
+                if (float(msg.payload) >= -1000 and float(msg.payload) <= 1000):
+                    f = open('/var/www/html/openWB/ramdisk/evupf2', 'w')
+                    f.write(msg.payload.decode("utf-8"))
+                    f.close()
+            if (msg.topic == "openWB/set/evu/PfPhase3"):
+                if (float(msg.payload) >= -1000 and float(msg.payload) <= 1000):
+                    f = open('/var/www/html/openWB/ramdisk/evupf3', 'w')
                     f.write(msg.payload.decode("utf-8"))
                     f.close()
             if (msg.topic == "openWB/set/evu/WhImported"):

--- a/runs/mqttsub.py
+++ b/runs/mqttsub.py
@@ -1419,51 +1419,31 @@ def on_message(client, userdata, msg):
                     f = open('/var/www/html/openWB/ramdisk/evuv3', 'w')
                     f.write(msg.payload.decode("utf-8"))
                     f.close()
-            if ((msg.topic == "openWB/set/evu/HzFrequenz") or (msg.topic == "openWB/set/evu/Hz")):
+            if msg.topic == "openWB/set/evu/HzFrequenz" or msg.topic == "openWB/set/evu/Hz":
                 if (float(msg.payload) >= 0 and float(msg.payload) <= 80):
                     f = open('/var/www/html/openWB/ramdisk/evuhz', 'w')
                     f.write(msg.payload.decode("utf-8"))
                     f.close()
-            if (msg.topic == "openWB/set/evu/WPhase1"):
-                if (float(msg.payload) >= -1000 and float(msg.payload) <= 1000):
-                    f = open('/var/www/html/openWB/ramdisk/bezugw1', 'w')
-                    f.write(msg.payload.decode("utf-8"))
-                    f.close()
-            if (msg.topic == "openWB/set/evu/WPhase2"):
-                if (float(msg.payload) >= -1000 and float(msg.payload) <= 1000):
-                    f = open('/var/www/html/openWB/ramdisk/bezugw2', 'w')
-                    f.write(msg.payload.decode("utf-8"))
-                    f.close()
-            if (msg.topic == "openWB/set/evu/WPhase3"):
-                if (float(msg.payload) >= -1000 and float(msg.payload) <= 1000):
-                    f = open('/var/www/html/openWB/ramdisk/bezugw3', 'w')
-                    f.write(msg.payload.decode("utf-8"))
-                    f.close()
-            if (msg.topic == "openWB/set/evu/PfPhase1"):
-                if (float(msg.payload) >= -1000 and float(msg.payload) <= 1000):
-                    f = open('/var/www/html/openWB/ramdisk/evupf1', 'w')
-                    f.write(msg.payload.decode("utf-8"))
-                    f.close()
-            if (msg.topic == "openWB/set/evu/PfPhase2"):
-                if (float(msg.payload) >= -1000 and float(msg.payload) <= 1000):
-                    f = open('/var/www/html/openWB/ramdisk/evupf2', 'w')
-                    f.write(msg.payload.decode("utf-8"))
-                    f.close()
-            if (msg.topic == "openWB/set/evu/PfPhase3"):
-                if (float(msg.payload) >= -1000 and float(msg.payload) <= 1000):
-                    f = open('/var/www/html/openWB/ramdisk/evupf3', 'w')
-                    f.write(msg.payload.decode("utf-8"))
-                    f.close()
+            wphase_match = re.match("openWB/set/evu/WPhase([123])$", msg.topic)
+            if wphase_match is not None:
+                files.evu.powers_import[int(wphase_match.group(1)) - 1].write(float(msg.payload.decode("utf-8")))
+            pfphase_match = re.match("openWB/set/evu/PfPhase([123])$", msg.topic)
+            if pfphase_match is not None:
+                files.evu.power_factors[int(pfphase_match.group(1)) - 1].write(float(msg.payload.decode("utf-8")))
             if (msg.topic == "openWB/set/evu/WhImported"):
                 if (float(msg.payload) >= 0 and float(msg.payload) <= 10000000000):
                     f = open('/var/www/html/openWB/ramdisk/bezugkwh', 'w')
                     f.write(msg.payload.decode("utf-8"))
                     f.close()
+                else:
+                    log.warning("Ignoring value %s for topic %s (out of range)", msg.payload, msg.topic)
             if (msg.topic == "openWB/set/evu/WhExported"):
                 if (float(msg.payload) >= 0 and float(msg.payload) <= 10000000000):
                     f = open('/var/www/html/openWB/ramdisk/einspeisungkwh', 'w')
                     f.write(msg.payload.decode("utf-8"))
                     f.close()
+                else:
+                    log.warning("Ignoring value %s for topic %s (out of range)", msg.payload, msg.topic)
             if (msg.topic == "openWB/set/evu/faultState"):
                 if (int(msg.payload) >= 0 and int(msg.payload) <= 2):
                     client.publish("openWB/evu/faultState", msg.payload.decode("utf-8"), qos=0, retain=True)

--- a/runs/mqttsub.py
+++ b/runs/mqttsub.py
@@ -1435,15 +1435,11 @@ def on_message(client, userdata, msg):
                     f = open('/var/www/html/openWB/ramdisk/bezugkwh', 'w')
                     f.write(msg.payload.decode("utf-8"))
                     f.close()
-                else:
-                    log.warning("Ignoring value %s for topic %s (out of range)", msg.payload, msg.topic)
             if (msg.topic == "openWB/set/evu/WhExported"):
                 if (float(msg.payload) >= 0 and float(msg.payload) <= 10000000000):
                     f = open('/var/www/html/openWB/ramdisk/einspeisungkwh', 'w')
                     f.write(msg.payload.decode("utf-8"))
                     f.close()
-                else:
-                    log.warning("Ignoring value %s for topic %s (out of range)", msg.payload, msg.topic)
             if (msg.topic == "openWB/set/evu/faultState"):
                 if (int(msg.payload) >= 0 and int(msg.payload) <= 2):
                     client.publish("openWB/evu/faultState", msg.payload.decode("utf-8"), qos=0, retain=True)

--- a/web/settings/modulconfigevu.php
+++ b/web/settings/modulconfigevu.php
@@ -195,7 +195,13 @@
 								<span class="text-info">openWB/set/evu/VPhase1</span> Spannung in Volt für Phase 1, float, Punkt als Trenner<br>
 								<span class="text-info">openWB/set/evu/VPhase2</span> Spannung in Volt für Phase 2, float, Punkt als Trenner<br>
 								<span class="text-info">openWB/set/evu/VPhase3</span> Spannung in Volt für Phase 3, float, Punkt als Trenner<br>
-								<span class="text-info">openWB/set/evu/HzFrequenz</span> Netzfrequenz in Hz, float, Punkt als Trenner
+								<span class="text-info">openWB/set/evu/HzFrequenz</span> oder <span class="text-info">openWB/set/evu/Hz</span> Netzfrequenz in Hz, float, Punkt als Trenner<br>
+								<span class="text-info">openWB/set/evu/WPhase1</span> Leistung in Watt für Phase 1, float, Punkt als Trenner, positiv Bezug, negativ Einspeisung<br>
+								<span class="text-info">openWB/set/evu/WPhase2</span> Leistung in Watt für Phase 2, float, Punkt als Trenner, positiv Bezug, negativ Einspeisung<br>
+								<span class="text-info">openWB/set/evu/WPhase3</span> Leistung in Watt für Phase 3, float, Punkt als Trenner, positiv Bezug, negativ Einspeisung<br>
+								<span class="text-info">openWB/set/evu/PfPhase1</span> Powerfaktor für Phase 1, float, Punkt als Trenner, positiv Bezug, negativ Einspeisung<br>
+								<span class="text-info">openWB/set/evu/PfPhase2</span> Powerfaktor für Phase 2, float, Punkt als Trenner, positiv Bezug, negativ Einspeisung<br>
+								<span class="text-info">openWB/set/evu/PfPhase3</span> Powerfaktor für Phase 3, float, Punkt als Trenner, positiv Bezug, negativ Einspeisung
 							</div>
 						</div>
 						<div id="wattbezuglgessv1" class="hide">


### PR DESCRIPTION
add  missing topics in evu mqtt.
openWB/set/evu/HzFrequenz oder openWB/set/evu/Hz Netzfrequenz in Hz, float, Punkt als Trenner
openWB/set/evu/WPhase1 Leistung in Watt für Phase 1, float, Punkt als Trenner, positiv Bezug, negativ Einspeisung
openWB/set/evu/WPhase2 Leistung in Watt für Phase 2, float, Punkt als Trenner, positiv Bezug, negativ Einspeisung
openWB/set/evu/WPhase3 Leistung in Watt für Phase 3, float, Punkt als Trenner, positiv Bezug, negativ Einspeisung
openWB/set/evu/PfPhase1 Powerfaktor für Phase 1, float, Punkt als Trenner, positiv Bezug, negativ Einspeisung
openWB/set/evu/PfPhase2 Powerfaktor für Phase 2, float, Punkt als Trenner, positiv Bezug, negativ Einspeisung
openWB/set/evu/PfPhase3 Powerfaktor für Phase 3, float, Punkt als Trenner, positiv Bezug, negativ Einspeisung

