### PR TITLE
Dac V1 bis V10 in Smarthome

### DIFF
--- a/modules/smarthome/nxdacxx/off.py
+++ b/modules/smarthome/nxdacxx/off.py
@@ -1,0 +1,38 @@
+#!/usr/bin/python3
+import sys
+import os
+import time
+named_tuple = time.localtime()   # getstruct_time
+time_string = time.strftime("%m/%d/%Y, %H:%M:%S N4DAC02 off.py", named_tuple)
+devicenumber = str(sys.argv[1])
+ipadr = str(sys.argv[2])
+uberschuss = int(sys.argv[3])
+bp = '/var/www/html/openWB/ramdisk/smarthome_device_'
+file_string = bp + str(devicenumber) + '_N4DAC02.log'
+file_stringpv = bp + str(devicenumber) + '_pv'
+file_stringcount = bp + str(devicenumber) + '_count'
+file_stringcount5 = bp + str(devicenumber) + '_count5'
+if os.path.isfile(file_string):
+    pass
+else:
+    with open(file_string, 'w') as f:
+        print('N4DAC02 start log', file=f)
+with open(file_string, 'a') as f:
+    print('%s devicenr %s ipadr %s'
+          % (time_string, devicenumber, ipadr), file=f)
+pvmodus = 0
+if os.path.isfile(file_stringpv):
+    with open(file_stringpv, 'r') as f:
+        pvmodus = int(f.read())
+#  wenn vorher pvmodus an, dann watt.py signaliseren einmalig 0
+#  ueberschuss zu schicken
+if pvmodus == 1:
+    pvmodus = 99
+with open(file_stringpv, 'w') as f:
+    f.write(str(pvmodus))
+count1 = 999
+with open(file_stringcount, 'w') as f:
+    f.write(str(count1))
+count5 = 999
+with open(file_stringcount5, 'w') as f:
+    f.write(str(count5))

--- a/modules/smarthome/nxdacxx/on.py
+++ b/modules/smarthome/nxdacxx/on.py
@@ -1,0 +1,31 @@
+#!/usr/bin/python3
+import sys
+import os
+import time
+named_tuple = time.localtime()   # getstruct_time
+time_string = time.strftime("%m/%d/%Y, %H:%M:%S N4DAC02 on.py", named_tuple)
+devicenumber = str(sys.argv[1])
+ipadr = str(sys.argv[2])
+uberschuss = int(sys.argv[3])
+bp = '/var/www/html/openWB/ramdisk/smarthome_device_'
+file_string = bp + str(devicenumber) + '_N4DAC02.log'
+file_stringpv = bp + str(devicenumber) + '_pv'
+file_stringcount = bp + str(devicenumber) + '_count'
+file_stringcount5 = bp + str(devicenumber) + '_count5'
+if os.path.isfile(file_string):
+    pass
+else:
+    with open(file_string, 'w') as f:
+        print('N4DAC02 start log', file=f)
+with open(file_string, 'a') as f:
+    print('%s devicenr %s ipadr %s' %
+          (time_string, devicenumber, ipadr), file=f)
+pvmodus = 1
+with open(file_stringpv, 'w') as f:
+    f.write(str(pvmodus))
+count1 = 999
+with open(file_stringcount, 'w') as f:
+    f.write(str(count1))
+count5 = 999
+with open(file_stringcount5, 'w') as f:
+    f.write(str(count5))

--- a/modules/smarthome/nxdacxx/watt.py
+++ b/modules/smarthome/nxdacxx/watt.py
@@ -1,0 +1,103 @@
+#!/usr/bin/python3
+import sys
+import os
+import time
+import json
+from pymodbus.client.sync import ModbusTcpClient
+named_tuple = time.localtime()   # getstruct_time
+time_string = time.strftime("%m/%d/%Y, %H:%M:%S N4DAC02 watty.py", named_tuple)
+devicenumber = str(sys.argv[1])
+ipadr = str(sys.argv[2])
+uberschuss = int(sys.argv[3])
+maxpower = int(sys.argv[4])
+forcesend = int(sys.argv[5])
+# forcesend = 0 default acthor time period applies
+# forcesend = 1 default overwritten send now
+# forcesend = 9 default overwritten no send
+bp = '/var/www/html/openWB/ramdisk/smarthome_device_'
+file_string = bp + str(devicenumber) + '_N4DAC02.log'
+file_stringpv = bp + str(devicenumber) + '_pv'
+file_stringcount = bp + str(devicenumber) + '_count'
+file_stringcount5 = bp + str(devicenumber) + '_count5'
+count5 = 999
+if os.path.isfile(file_stringcount5):
+    with open(file_stringcount5, 'r') as f:
+        count5 = int(f.read())
+if (forcesend == 0):
+    count5 = count5 + 1
+elif (forcesend == 1):
+    count5 = 999
+else:
+    count5 = 1
+if count5 > 3:
+    count5 = 0
+with open(file_stringcount5, 'w') as f:
+    f.write(str(count5))
+modbuswrite = 0
+neupower = uberschuss
+if neupower < 0:
+    neupower = 0
+if neupower > maxpower:
+    neupower = maxpower
+volt = 0
+pvmodus = 0
+if os.path.isfile(file_stringpv):
+    with open(file_stringpv, 'r') as f:
+        pvmodus = int(f.read())
+powerc = 0
+aktpower = 0
+if count5 == 0:
+    count1 = 999
+    if os.path.isfile(file_stringcount):
+        with open(file_stringcount, 'r') as f:
+            count1 = int(f.read())
+    count1 = count1+1
+    # wurde  gerade ausgeschaltet ?    (pvmodus == 99 ?)
+    # dann 0 schicken wenn kein pvmodus mehr
+    # und pv modus ausschalten
+    if pvmodus == 99:
+        modbuswrite = 1
+        pvmodus = 0
+        neupower = 0
+        with open(file_stringpv, 'w') as f:
+            f.write(str(pvmodus))
+    # sonst wenn pv modus lauft , ueberschuss schicken
+    else:
+        if pvmodus == 1:
+            modbuswrite = 1
+    # logschreiben
+    if count1 > 80:
+        count1 = 0
+    if count1 < 3:
+        if os.path.isfile(file_string):
+            pass
+        else:
+            with open(file_string, 'w') as f:
+                print('N4DAC02 start log', file=f)
+        with open(file_string, 'a') as f:
+            helpstr = '%s devicenr %s ipadr %s ueberschuss %6d '
+            helpstr += ' maxueberschuss %6d pvmodus %1d modbuswrite %1d'
+            print(helpstr % (time_string, devicenumber, ipadr, uberschuss,
+                             maxpower, pvmodus, modbuswrite), file=f)
+    # modbus write
+    if modbuswrite == 1:
+        client = ModbusTcpClient(ipadr, port=502)
+        volt = int((neupower * 1000) / maxpower)
+        rq = client.write_register(1, volt)
+        # oder
+        # rq = client.write_register(1, volt, unit = 1)
+        if count1 < 3:
+            with open(file_string, 'a') as f:
+                print('%s devicenr %s ipadr %s Volt %6d written by modbus ' %
+                      (time_string, devicenumber, ipadr, volt), file=f)
+    with open(file_stringcount, 'w') as f:
+        f.write(str(count1))
+else:
+    if pvmodus == 99:
+        pvmodus = 0
+answer = '{"power":' + str(aktpower) + ',"powerc":' + str(powerc)
+answer += ',"send":' + str(modbuswrite) + ',"sendpower":' + str(volt)
+answer += ',"on":' + str(pvmodus) + '}'
+with open('/var/www/html/openWB/ramdisk/smarthome_device_ret' +
+          str(devicenumber), 'w') as f1:
+    json.dump(answer, f1)

--- a/runs/mqttsub.py
+++ b/runs/mqttsub.py
@@ -179,7 +179,7 @@ def on_message(client, userdata, msg):
                     client.publish("openWB/config/get/SmartHome/Devices/"+str(devicenumb)+"/device_name", msg.payload.decode("utf-8"), qos=0, retain=True)
             if (( "openWB/config/set/SmartHome/Device" in msg.topic) and ("device_type" in msg.topic)):
                 devicenumb=re.sub(r'\D', '', msg.topic)
-                validDeviceTypes = ['none','shelly','tasmota','acthor','lambda','elwa','idm','vampair','stiebel','http','avm','mystrom','viessmann','mqtt','pyt'] # 'pyt' is deprecated and will be removed!
+                validDeviceTypes = ['none','shelly','tasmota','acthor','lambda','elwa','idm','vampair','stiebel','http','avm','mystrom','viessmann','mqtt','NXDACXX','pyt'] # 'pyt' is deprecated and will be removed!
                 if ( 1 <= int(devicenumb) <= numberOfSupportedDevices and len(str(msg.payload.decode("utf-8"))) > 2):
                     try:
                         # just check vor payload in list, deviceTypeIndex is not used
@@ -489,6 +489,13 @@ def on_message(client, userdata, msg):
                 else:
                     print( "invalid payload for topic '" + msg.topic + "': " + msg.payload.decode("utf-8"))
 
+            if (( "openWB/config/set/SmartHome/Device" in msg.topic) and ("device_nxdacxxueb" in msg.topic)):
+                devicenumb=re.sub(r'\D', '', msg.topic)
+                if ( 1 <= int(devicenumb) <= numberOfSupportedDevices and 0 <= int(msg.payload) <= 32000):
+                    writetoconfig(shconfigfile,'smarthomedevices','device_nxdacxxueb_'+str(devicenumb), msg.payload.decode("utf-8"))
+                    client.publish("openWB/config/get/SmartHome/Devices/"+str(devicenumb)+"/device_nxdacxxueb", msg.payload.decode("utf-8"), qos=0, retain=True)
+                else:
+                    print( "invalid payload for topic '" + msg.topic + "': " + msg.payload.decode("utf-8"))
 
             if (( "openWB/config/set/SmartHome/Device" in msg.topic) and ("device_standbyDuration" in msg.topic)):
                 devicenumb=re.sub(r'\D', '', msg.topic)

--- a/runs/smarthomemq.py
+++ b/runs/smarthomemq.py
@@ -9,6 +9,7 @@ from usmarthome.global0 import log, log_config
 from usmarthome.smartbase import Sbase
 from usmarthome.smartavm import Savm
 from usmarthome.smartacthor import Sacthor
+from usmarthome.smartnxdacxx import Snxdacxx
 from usmarthome.smartelwa import Selwa
 from usmarthome.smartidm import Sidm
 from usmarthome.smarthttp import Shttp
@@ -350,6 +351,8 @@ def update_devices():
                     mydevice = Sviessmann()
                 elif (device_type == 'acthor'):
                     mydevice = Sacthor()
+                elif (device_type == 'NXDACXX'):
+                    mydevice = Snxdacxx()
                 elif (device_type == 'elwa'):
                     mydevice = Selwa()
                 elif (device_type == 'idm'):

--- a/runs/usmarthome/smartnxdacxx.py
+++ b/runs/usmarthome/smartnxdacxx.py
@@ -1,0 +1,74 @@
+#!/usr/bin/python3
+from usmarthome.smartbase import Sbase
+from usmarthome.global0 import log
+import subprocess
+
+
+class Snxdacxx(Sbase):
+    def __init__(self):
+        # setting
+        super().__init__()
+        print('__init__ Snxdacxx executed')
+        self._smart_paramadd = {}
+        self._device_nxdacxxueb = 0
+        self.device_nummer = 0
+        self._dynregel = 1
+
+    def updatepar(self, input_param):
+        super().updatepar(input_param)
+        self._smart_paramadd = input_param.copy()
+        self.device_nummer = int(self._smart_paramadd.get('device_nummer',
+                                                          '0'))
+        for key, value in self._smart_paramadd.items():
+            try:
+                valueint = int(value)
+            except Exception:
+                valueint = 0
+            if (key == 'device_nummer'):
+                pass
+            elif (key == 'device_nxdacxxueb'):
+                self._device_nxdacxxueb = valueint
+            else:
+                log.warning("(" + str(self.device_nummer) + ") " +
+                            __class__.__name__ + " überlesen " + key +
+                            " " + value)
+
+    def getwatt(self, uberschuss, uberschussoffset):
+        self.prewatt(uberschuss, uberschussoffset)
+        forcesend = self.checkbefsend()
+        argumentList = ['python3', self._prefixpy + 'nxdacxx/watt.py',
+                        str(self.device_nummer), str(self._device_ip),
+                        str(self.devuberschuss),
+                        str(self._device_nxdacxxueb), str(forcesend)]
+        try:
+            self.proc = subprocess.Popen(argumentList)
+            self.proc.communicate()
+            self.answer = self.readret()
+            self.newwatt = int(self.answer['power'])
+            self.newwattk = int(self.answer['powerc'])
+            self.relais = int(self.answer['on'])
+            self.checksend(self.answer)
+        except Exception as e1:
+            log.warning("(" + str(self.device_nummer) +
+                        ") Leistungsmessung %s %d %s Fehlermeldung: %s "
+                        % ('n4dac02 ', self.device_nummer,
+                           str(self._device_ip), str(e1)))
+        self.postwatt()
+
+    def turndevicerelais(self, zustand, ueberschussberechnung, updatecnt):
+        self.preturn(zustand, ueberschussberechnung, updatecnt)
+        if (zustand == 1):
+            pname = "/on.py"
+        else:
+            pname = "/off.py"
+        argumentList = ['python3', self._prefixpy + 'nxdacxx' + pname,
+                        str(self.device_nummer), str(self._device_ip),
+                        str(self.devuberschuss)]
+        try:
+            self.proc = subprocess.Popen(argumentList)
+            self.proc.communicate()
+        except Exception as e1:
+            log.warning("(" + str(self.device_nummer) +
+                        ") on / off  %s %d %s Fehlermeldung: %s "
+                        % ('n4dac02 ', self.device_nummer,
+                           str(self._device_ip), str(e1)))

--- a/web/settings/smarthomeconfig.php
+++ b/web/settings/smarthomeconfig.php
@@ -85,6 +85,7 @@ $numDevices = 9;
 											<option value="lambda" data-option="lambda">Lambda</option>
 											<option value="elwa" data-option="elwa">Elwa</option>
 											<option value="idm" data-option="idm">Idm</option>
+											<option value="NXDACXX" data-option="NXDACXX">N4DAC02 V0.01 bis v10.0</option>
 											<option value="stiebel" data-option="stiebel">Stiebel</option>
 											<option value="vampair" data-option="vampair">Vampair</option>
 											<option value="http" data-option="http">Http</option>
@@ -128,6 +129,8 @@ $numDevices = 9;
 											wenn kein Zähler übergeben oder 0 übergeben wird, wird der Zähler selber gerechnet<br>
 											openWB/SmartHome/set/Devices/4/Ueberschuss = in Watt<br>
 										</span>
+										<span class="form-text small device<?php echo $devicenum; ?>-option device<?php echo $devicenum; ?>-option-NXDACXX hide">
+											N4DAC02 angesteuert über Lan. Der anliegende Überschuss wird in eine Voltzahl zwischen 0.01V und 10.0V umgewandelt. Bezug wird als 0 Volt übertragen.	</span>
 										<span class="form-text small device<?php echo $devicenum; ?>-option device<?php echo $devicenum; ?>-option-viessmann hide">
 											Vitalcal 200-s Wärmepumpe mit LON Kommunikationsmodul und Vitogate 300. Wenn die Einschaltbedingung erreicht ist wird Komfortfunktion "Einmalige Warmwasserbereitung" außerhalb des Zeitprogramms gestartet. Für die "Einmalige Warmwasserbereitung" wird der Warmwassertemperatur-Sollwert 2 genutzt. In der Wp kann eingestellt werden, ob für diese Funktion  die Elektroheizung (Heizstab) benutzt werden soll.
 										</span>
@@ -198,6 +201,7 @@ $numDevices = 9;
 									</div>
 								</div>
 							</div>
+
 							<div class="device<?php echo $devicenum; ?>-option device<?php echo $devicenum; ?>-option-idm hide">
 								<hr class="border-secondary">
 								<div class="form-row mb-1">
@@ -208,7 +212,17 @@ $numDevices = 9;
 									</div>
 								</div>
 							</div>
-							<div class="device<?php echo $devicenum; ?>-option device<?php echo $devicenum; ?>-option-shelly device<?php echo $devicenum; ?>-option-tasmota device<?php echo $devicenum; ?>-option-acthor device<?php echo $devicenum; ?>-option-lambda device<?php echo $devicenum; ?>-option-elwa device<?php echo $devicenum; ?>-option-idm device<?php echo $devicenum; ?>-option-stiebel device<?php echo $devicenum; ?>-option-avm device<?php echo $devicenum; ?>-option-mystrom device<?php echo $devicenum; ?>-option-vampair device<?php echo $devicenum;  ?>-option-viessmann device<?php echo $devicenum; ?>-option-pyt hide">
+							<div class="device<?php echo $devicenum; ?>-option device<?php echo $devicenum; ?>-option-NXDACXX hide">
+								<hr class="border-secondary">
+								<div class="form-row mb-1">
+									<label for="device_nxdacxxuebDevices<?php echo $devicenum; ?>" class="col-md-4 col-form-label">Maximaler Überschuss</label>
+									<div class="col">
+										<input id="device_nxdacxxuebDevices<?php echo $devicenum; ?>" name="device_nxdacxxueb" class="form-control naturalNumber" type="number" inputmode="decimal" required min="0" max="32000" data-default="0" value="0" data-topicprefix="openWB/config/get/SmartHome/" data-topicsubgroup="Devices/<?php echo $devicenum; ?>/">
+										<span class="form-text small">Maximaler Überschuss = v10.0. Es wird kein grösserer Wert übertragen.</span>
+									</div>
+								</div>
+							</div>
+							<div class="device<?php echo $devicenum; ?>-option device<?php echo $devicenum; ?>-option-shelly device<?php echo $devicenum; ?>-option-tasmota device<?php echo $devicenum; ?>-option-acthor device<?php echo $devicenum; ?>-option-lambda device<?php echo $devicenum; ?>-option-elwa device<?php echo $devicenum; ?>-option-idm device<?php echo $devicenum; ?>-option-stiebel device<?php echo $devicenum; ?>-option-avm device<?php echo $devicenum; ?>-option-mystrom device<?php echo $devicenum; ?>-option-vampair device<?php echo $devicenum;  ?>-option-viessmann device<?php echo $devicenum;  ?>-option-NXDACXX device<?php echo $devicenum; ?>-option-pyt hide">
 								<hr class="border-secondary">
 								<div class="form-row mb-1">
 									<label for="device_ipDevices<?php echo $devicenum; ?>" class="col-md-4 col-form-label">IP Adresse</label>
@@ -318,7 +332,7 @@ $numDevices = 9;
 									</div>
 								</div>
 							</div>
-							<div class="device<?php echo $devicenum; ?>-option device<?php echo $devicenum; ?>-option-shelly device<?php echo $devicenum; ?>-option-tasmota device<?php echo $devicenum; ?>-option-acthor device<?php echo $devicenum; ?>-option-lambda device<?php echo $devicenum; ?>-option-elwa device<?php echo $devicenum; ?>-option-idm device<?php echo $devicenum; ?>-option-stiebel device<?php echo $devicenum; ?>-option-vampair device<?php echo $devicenum; ?>-option-avm device<?php echo $devicenum; ?>-option-mystrom device<?php echo $devicenum; ?>-option-http device<?php echo $devicenum; ?>-option-mqtt device<?php echo $devicenum; ?>-option-viessmann device<?php echo $devicenum; ?>-option-pyt hide">
+							<div class="device<?php echo $devicenum; ?>-option device<?php echo $devicenum; ?>-option-shelly device<?php echo $devicenum; ?>-option-tasmota device<?php echo $devicenum; ?>-option-acthor device<?php echo $devicenum; ?>-option-lambda device<?php echo $devicenum; ?>-option-elwa device<?php echo $devicenum; ?>-option-idm device<?php echo $devicenum; ?>-option-stiebel device<?php echo $devicenum; ?>-option-vampair device<?php echo $devicenum; ?>-option-avm device<?php echo $devicenum; ?>-option-mystrom device<?php echo $devicenum; ?>-option-http device<?php echo $devicenum; ?>-option-mqtt device<?php echo $devicenum;  ?>-option-NXDACXX device<?php echo $devicenum; ?>-option-viessmann device<?php echo $devicenum; ?>-option-pyt hide">
 								<hr class="border-secondary">
 								<div class="form-group">
 									<div class="form-row mb-1">

--- a/web/settings/topicsToSubscribe_smarthomeconfig.js
+++ b/web/settings/topicsToSubscribe_smarthomeconfig.js
@@ -74,6 +74,7 @@ var topicsToSubscribe = [
 	["openWB/config/get/SmartHome/Devices/+/device_chan", 0],
 	["openWB/config/get/SmartHome/Devices/+/device_setauto", 0],
 	["openWB/config/get/SmartHome/Devices/+/device_lambdaueb", 0],
+	["openWB/config/get/SmartHome/Devices/+/device_nxdacxxueb", 0],	
 	["openWB/config/get/SmartHome/Devices/+/device_measuresmaage", 0]
 
 ];


### PR DESCRIPTION
Erste Unterstützung als Smarthomedevice.
Der Dac N4Dac02 wird mit dem Überschuss über Modbus  angesteuert, und wandelt diesen in eine Spannung zwischen 0,01 und 10,0 Volt um.