### PR TITLE
use QoS=2 when clearing set-topics

### DIFF
--- a/runs/mqttsub.py
+++ b/runs/mqttsub.py
@@ -1682,8 +1682,8 @@ def on_message(client, userdata, msg):
                     f.close()
 
             # clear all set topics if not already done
-            if ( not(setTopicCleared) ):
-                client.publish(msg.topic, "", qos=0, retain=True)
+            if not setTopicCleared:
+                client.publish(msg.topic, "", qos=2, retain=True)
 
         finally:
             lock.release()


### PR DESCRIPTION
Siehe auch im Forum diverse Beiträge im Berechnung+Manuell Support-Thread, insbesondere [meine "Diskussion" mit zut ab hier](https://openwb.de/forum/viewtopic.php?p=70970#p70970) bis Seite 16 und dort insbesondere die gefundene Ursache ab [hier](https://openwb.de/forum/viewtopic.php?p=71969#p71969) (auf Seite 15).

Die Web-UI sendet Befehle an die openWB mit QoS=2:
https://github.com/snaptec/openWB/blob/216379d27c3020ef26ef235bcbfd4133c1837d26/web/live.js#L904

Das ist auch sinnvoll, denn der Befehl soll auch jeden Fall ausgeführt werden, also qos>=1 und er soll nicht mehrmals ausgeführt werden, also QoS=2.

Die OpenWB cleared das Topic aber mit QoS=0:
https://github.com/snaptec/openWB/blob/81845c9a640dddf7df77d70771de112d25df58fb/runs/mqttsub.py#L1673

Dadurch ist [die Reihenfolge in der die Nachrichten kommen nicht garantiert](https://stackoverflow.com/a/30959058). Wie in dem entsprechenden Thread im Forum zu sehen ist, ist das Problem nicht nur theoretisch, sondern zumindest in Verbindung mit der openWB-Cloud real: Manchmal kommt die "clear"-Nachricht in der Cloud vor dem "set" an. Damit verliert das "clear" seine Wirkung und wenn die Verbindung zwischen openWB und Cloud unterbrochen und erneut aufgebaut wird, ist noch eine alte Nachricht mit "retain" in der Cloud und führt dazu, dass ungewollte Befehle ausgeführt werden.

Dieser PR behebt das Problem, indem auch das "clear" mit QoS=2 gesendet wird.