### PR TITLE
fix: simcount saved counter state is in Ws not Wh.

### DIFF
--- a/packages/modules/common/simcount/_simcount.py
+++ b/packages/modules/common/simcount/_simcount.py
@@ -44,6 +44,6 @@ def sim_count(power_present: float, topic: str = "", data: SimCounterState = Non
             previous_state.imported + imported,
             previous_state.exported + exported
         )
-        log.debug("imported: %g kWh, exported: %g kWh, new state: %s", imported, exported, current_state)
+        log.debug("imported: %g Wh, exported: %g Wh, new state: %s", imported, exported, current_state)
         store.save(prefix, topic, current_state)
         return current_state

--- a/packages/modules/common/simcount/_simcounter_state.py
+++ b/packages/modules/common/simcount/_simcounter_state.py
@@ -8,8 +8,13 @@ class SimCounterState:
     def __init__(self, timestamp: float, power: float, imported: float, exported: float):
         self.timestamp = timestamp
         self.power = power
+        """In Watt"""
+
         self.imported = imported
+        """In Watt-hours"""
+
         self.exported = exported
+        """In Watt-hours"""
 
     def __iter__(self) -> Iterator[float]:
         yield self.imported


### PR DESCRIPTION
fixup for #2417 

Nach [Rückmeldungen im Forum](https://openwb.de/forum/viewtopic.php?f=9&t=5944) gibt es Anzeichen dafür, dass SimCount nicht mehr richtig rechnet. Ich habe mir die Logs und Screenshots von [Jens hier](https://openwb.de/forum/viewtopic.php?p=72637#p72637) gepostet wurden angesehen und bin kritisch über den Code gegangen.

Ich glaube einen Fehler gefunden zu haben. Wenn ich es richtig sehe speichert SimCount die Zählerzwischenstände nicht in Wattstunden (so wie alle anderen Zählerstände), sondern verwendet Wattsekunden. Das muss dann natürlich schief gehen.

Außerdem ist mir in der Logausgabe ein Fehler aufgefallen wo einmal kWh statt Wh steht.

Ich selber habe auf meiner openWB kein SimCount im Einsatz, daher ist auch diese Änderung nicht live getestet. Bitte gut kritisch reviewen ob ich das Problem korrekt erfasst und gelöst habe.

Ich bin wahrscheinlich nicht der letzte der darauf reinfällt, dass hier unterschiedliche Einheiten am Werk sind. Alle Zähler werden sonst in Wh abgespeichert, aber die Zwischenstände von SimCount in Ws. Warum? Meine Vermutung: In Bash ist das Arbeiten mit floats umständlich und dann hat wahrscheinlich jemand gedacht, dass er lieber Ganzzahlen nimmt. Damit wäre die Genauigkeit von SimCount bei Verwendung von Wh aber zu gering und daher hat man dann Ws genommen. Da Bash-Skripte ohnehin in diesem Kontext "legacy" sind und aussterben ist das kein Thema mehr. Ich denke es wäre hilfreich in Zukunft IMMER und einheitlich Wh für Energie zu verwenden. So sind auch meine Änderungen hier am Code. Der Code rechnet mit Wh nur beim Laden wird durch 3600 geteilt und beim Speichern mit 3600 multipliziert. Für den Broker (openWB 2.0) habe ich das nicht implementiert. Das wäre hier nach wie vor ein braking-change was für die frühe alpha vielleicht auch OK ist. Ggf. sollte dann aber ein Migrationsskript dazu oder zumindest eine Notiz für die frühen Alpha-Tester. Ich halte es zumindest für sinnvoll auch dort jetzt auf Wh zu gehen um künftige Verwirrung zu vermeiden.