### PR TITLE
convert HTTP module to configurable device in order to reduce code duplication

### DIFF
--- a/packages/modules/http/config.py
+++ b/packages/modules/http/config.py
@@ -1,11 +1,14 @@
+from helpermodules.auto_str import auto_str
 from modules.common.component_setup import ComponentSetup
 
 
+@auto_str
 class HTTPConfiguration:
     def __init__(self, url=None):
         self.url = url
 
 
+@auto_str
 class HTTP:
     def __init__(self,
                  name: str = "HTTP",
@@ -18,6 +21,7 @@ class HTTP:
         self.configuration = configuration or HTTPConfiguration()
 
 
+@auto_str
 class HttpBatConfiguration:
     def __init__(self, power_path=None, soc_path=None, imported_path=None, exported_path=None):
         self.power_path = power_path
@@ -26,6 +30,7 @@ class HttpBatConfiguration:
         self.exported_path = exported_path
 
 
+@auto_str
 class HttpBatSetup(ComponentSetup[HttpBatConfiguration]):
     def __init__(self,
                  name: str = "HTTP Speicher",
@@ -35,6 +40,7 @@ class HttpBatSetup(ComponentSetup[HttpBatConfiguration]):
         super().__init__(name, type, id, configuration or HttpBatConfiguration())
 
 
+@auto_str
 class HttpCounterConfiguration:
     def __init__(self,
                  current_l1_path=None,
@@ -51,6 +57,7 @@ class HttpCounterConfiguration:
         self.power_path = power_path
 
 
+@auto_str
 class HttpCounterSetup(ComponentSetup[HttpCounterConfiguration]):
     def __init__(self,
                  name: str = "HTTP Zähler",
@@ -60,12 +67,14 @@ class HttpCounterSetup(ComponentSetup[HttpCounterConfiguration]):
         super().__init__(name, type, id, configuration or HttpCounterConfiguration())
 
 
+@auto_str
 class HttpInverterConfiguration:
     def __init__(self, power_path=None, exported_path=None):
         self.power_path = power_path
         self.exported_path = exported_path
 
 
+@auto_str
 class HttpInverterSetup(ComponentSetup[HttpInverterConfiguration]):
     def __init__(self,
                  name: str = "HTTP Wechselrichter",


### PR DESCRIPTION
ssia. Dient auch als weitere Demo wie `ConfigurableDevice` eingesetzt werden kann.

Nebenbei haben die ganzen HTTP-Config-Klassen `@auto_str` spendiert bekommen, damit die Logausgabe auch lesbar ist.

Das ganze ist noch ungetestet!