### PR TITLE
Zielladen: Wirkungsgrad der Ladeelektronik beachten

### DIFF
--- a/loadconfig.sh
+++ b/loadconfig.sh
@@ -1,3 +1,5 @@
+OPENWBBASEDIR=$(cd $(dirname "${BASH_SOURCE[0]}") && pwd)
+
 while read -r x; do
 	value="${x#*=}"
 	if [[ "${value:0:1}" == "'" ]] ; then
@@ -7,4 +9,4 @@ while read -r x; do
 	else
 		export "$x"
 	fi
-done < /var/www/html/openWB/openwb.conf
+done < "$OPENWBBASEDIR/openwb.conf"

--- a/web/settings/settings.php
+++ b/web/settings/settings.php
@@ -702,6 +702,21 @@
 										<span class="form-text small">Ampere mit denen geladen werden soll um den Ziel SoC zu erreichen.</span>
 									</div>
 								</div>
+
+								<div class="form-row mb-1">
+									<label for="wirkungsgradlp1" class="col-md-4 col-form-label">Wirkungsgrad Ladeelektronik</label>
+									<div class="col">
+										<input class="form-control" type="number" min="1" step="1" max="100" name="wirkungsgradlp1" id="wirkungsgradlp1" value="<?php echo $wirkungsgradlp1old ?>">
+										<span class="form-text small">
+											Wert in Prozent, der den gemittelten Wirkungsgrad der Ladeelektronik angibt.<br>
+											Durch Verluste in der Ladeelektronik (z. B. Umwandlung Wechselspannung in Gleichspannung) gelangt nicht die komplette Energie, welche durch den Zähler in der Wallbox gemesen wird, im Akku des Fahrzeugs.
+											Der anzugebende Wert liegt bei gängigen Fahrzeugen im Bereich 90-95%. Eine Ausnahme stellt der Zoe dar, dessen Chameleonlader je nach Modellversion und freigegebener Leistung der Wallbox teilweise nur auf ca. 50% kommt.<br>
+											Liegen die Angaben der Wallbox und des Fahrzeugs nach der Ladung mehrere Prozent auseinander, dann kann mit dieser Einstellung eine Feinabstimmung erfolgen:<br>
+											SoC an der Wallbox zu hoch: Wirkungsgrad um ein paar Prozent reduzieren<br>
+											SoC an der Wallbox zu gering: Wirkungsgrad um ein paar Prozent erhöhen
+										</span>
+									</div>
+								</div>
 							</div>
 						</div>
 					</div>

--- a/web/settings/settings.php
+++ b/web/settings/settings.php
@@ -262,7 +262,7 @@
 														}
 														addressStr = addressStr + ', ' + this.address.postalCode + ' ' + this.address.city;
 														$('#tibberHomesDropdown').append('<option value="' + homeID + '">' + addressStr + '</option>');
-    												});
+													});
 													$('#tibberhomeIdModal').find('.modal-header').removeClass('bg-danger');
 													$('#tibberhomeIdModal').find('.modal-header').addClass('bg-success');
 													$('#tibberhomeIdModalOkBtn').show();
@@ -287,7 +287,7 @@
 													$('#tibberModalSelectHomeIdDiv').hide();
 													$('#tibberhomeid').val('');
 													$('#tibberhomeIdModal').modal("show");
-								  				})
+												})
 										});
 
 										$('#verifyTibberBtn').click(function(){
@@ -344,10 +344,10 @@
 												<div id="tibberModalSelectHomeIdDiv" class="row justify-content-center hide">
 													<div class="col">
 														<div class="form-group">
-														<label for="tibberHomesDropdown">Bitte wählen Sie eine Adresse:</label>
-														<select class="form-control selectpicker" id="tibberHomesDropdown">
-														</select>
-													  </div>
+															<label for="tibberHomesDropdown">Bitte wählen Sie eine Adresse:</label>
+															<select class="form-control selectpicker" id="tibberHomesDropdown">
+															</select>
+														</div>
 													</div>
 												</div>
 

--- a/zielladen.sh
+++ b/zielladen.sh
@@ -12,12 +12,13 @@ ziellademodus(){
 	epochdateziel=$(date -d "$zielladenuhrzeitlp1" +"%s")
 	zeitdiff=$(( epochdateziel - epochdateaktuell ))
 	minzeitdiff=$(( zeitdiff / 60 ))
+	wirkungsgrad=${wirkungsgradlp1:-100}
 
 	# zu ladende Menge ermitteln
 	soc=$(<"$RAMDISKDIR/soc")
 	zuladendersoc=$(( zielladensoclp1 - soc ))
 	akkuglp1wh=$(( akkuglp1 * 1000 ))
-	zuladendewh=$(( akkuglp1wh * zuladendersoc / 100))
+	zuladendewh=$(( akkuglp1wh * zuladendersoc / wirkungsgrad ))
 
 	#ladeleistung ermitteln
 	lademaxwh=$(( zielladenmaxalp1 * zielladenphasenlp1 * 230 ))

--- a/zielladen.sh
+++ b/zielladen.sh
@@ -1,18 +1,20 @@
 #!/bin/bash
+OPENWBBASEDIR=$(cd $(dirname "${BASH_SOURCE[0]}") && pwd)
+RAMDISKDIR="${OPENWBBASEDIR}/ramdisk"
 
 ziellademodus(){
 
 	#verbleibende Zeit berechnen
 	dateaktuell=$(date '+%Y-%m-%d %H:%M')
 	epochdateaktuell=$(date -d "$dateaktuell" +"%s")
-	zielladenkorrektura=$(</var/www/html/openWB/ramdisk/zielladenkorrektura)
-	ladestatus=$(</var/www/html/openWB/ramdisk/ladestatus)
+	zielladenkorrektura=$(<"$RAMDISKDIR/zielladenkorrektura")
+	ladestatus=$(<"$RAMDISKDIR/ladestatus")
 	epochdateziel=$(date -d "$zielladenuhrzeitlp1" +"%s")
 	zeitdiff=$(( epochdateziel - epochdateaktuell ))
 	minzeitdiff=$(( zeitdiff / 60 ))
 
 	# zu ladende Menge ermitteln
-	soc=$(</var/www/html/openWB/ramdisk/soc)
+	soc=$(<"$RAMDISKDIR/soc")
 	zuladendersoc=$(( zielladensoclp1 - soc ))
 	akkuglp1wh=$(( akkuglp1 * 1000 ))
 	zuladendewh=$(( akkuglp1wh * zuladendersoc / 100))
@@ -31,32 +33,32 @@ ziellademodus(){
 	diffwh=$(( zuladendewh - moeglichewh ))
 
 	#vars
-	ladungdurchziel=$(<ramdisk/ladungdurchziel)
+	ladungdurchziel=$(<"$RAMDISKDIR/ladungdurchziel")
 	if (( zuladendewh <= 0 )); then
 		if (( ladestatus == 1 )); then
-			echo 0 > ramdisk/ladungdurchziel
-			echo 0 > ramdisk/zielladenkorrektura
-			sed -e "s/zielladenaktivlp1=.*/zielladenaktivlp1=0/" openwb.conf > ramdisk/openwb.conf	&& mv ramdisk/openwb.conf openwb.conf && chmod 777 openwb.conf
-			runs/set-current.sh 0 m
+			echo 0 > "$RAMDISKDIR/ladungdurchziel"
+			echo 0 > "$RAMDISKDIR/zielladenkorrektura"
+			sed -i 's/^\(zielladenaktivlp1=\).*/\10/' "$OPENWBBASEDIR/openwb.conf"
+			"$OPENWBBASEDIR/runs/set-current.sh" 0 m
 		fi
 	else
 		if (( zuladendewh > moeglichewh )); then
 			if (( ladestatus == 0 )); then
-				runs/set-current.sh "$zielladenalp1" m
+				"$OPENWBBASEDIR/runs/set-current.sh" "$zielladenalp1" m
 				openwbDebugLog "MAIN" 1 "setzte Soctimer hoch zum Abfragen des aktuellen SoC"
-				echo 20000 > /var/www/html/openWB/ramdisk/soctimer
-				echo 1 > ramdisk/ladungdurchziel
+				echo 20000 > "$RAMDISKDIR/soctimer"
+				echo 1 > "$RAMDISKDIR/ladungdurchziel"
 				exit 0
 			else
 				if (( diffwh > 1000 )); then
-					if test $(find /var/www/html/openWB/ramdisk/zielladenkorrektura -mmin +10); then
+					if test $(find "$RAMDISKDIR/zielladenkorrektura" -mmin +10); then
 						zielladenkorrektura=$(( zielladenkorrektura + 1 ))
-						echo $zielladenkorrektura > ramdisk/zielladenkorrektura
+						echo $zielladenkorrektura > "$RAMDISKDIR/zielladenkorrektura"
 						zielneu=$(( zielladenalp1 + zielladenkorrektura ))
 						if (( zielneu > zielladenmaxalp1)); then
 							zielneu=$zielladenmaxalp1
 						fi
-						runs/set-current.sh "$zielneu" m
+						"$OPENWBBASEDIR/runs/set-current.sh" "$zielneu" m
 						exit 0
 					fi
 				fi
@@ -64,14 +66,14 @@ ziellademodus(){
 		else
 			if (( ladestatus == 1 )); then
 				if (( diffwh < -1000 )); then
-					if test $(find /var/www/html/openWB/ramdisk/zielladenkorrektura -mmin +10); then
+					if test $(find "$RAMDISKDIR/zielladenkorrektura" -mmin +10); then
 						zielladenkorrektura=$(( zielladenkorrektura - 1 ))
-						echo $zielladenkorrektura > ramdisk/zielladenkorrektura
+						echo $zielladenkorrektura > "$RAMDISKDIR/zielladenkorrektura"
 						zielneu=$(( zielladenalp1 + zielladenkorrektura ))
 						if (( zielneu < minimalstromstaerke )); then
 							zielneu=$minimalstromstaerke
 						fi
-						runs/set-current.sh "$zielneu" m
+						"$OPENWBBASEDIR/runs/set-current.sh" "$zielneu" m
 						exit 0
 					fi
 				fi


### PR DESCRIPTION
Ich finde das mit dem Zielladen recht praktisch, beobachte aber, dass das Verhalten nicht optimal ist. Das Laden beginnt zu spät und irgendwann bemerkt es der Algorithmus und muss die Stromstärke hochkorrigieren. Je nach Einstellung der maximalen Ladeleistung ist es dann zu spät und der gewünschte Ladezustand kann nicht mehr erreicht werden.

Meiner Analyse nach liegt das Problem bei mir an zwei Dingen:
1. Der Algorithmus rechnet immer mit einer Effizienz der Ladeelektronik von 100%. Das wird kaum ein Fahrzeug schaffen und entsprechend beginnt die Ladung immer zu spät.
2. Besonders wenn man nur kleine Mengen mit eher hohem Ladestrom lädt, reagiert der Algorithmus zu träge.

Dieser PR beschäftigt sich mit Punkt 1. Es wird ein Feld unter Zielladen ergänzt, welches sonst nur im Manuell+Berechnung-Modul zu sehen ist und die hier hinterlegte Effizienz wird verwendet um auszurechnen wie viel tatsächlich durch die Wallbox gehen muss um den gewünschten Ladezustand zu erreichen.

Das ganze habe ich auf meiner Wallbox bereits installiert und letzte Nacht getestet. Mit Angabe von einer Ladeeffizienz von 90% ludt mein Ioniq bei Vorgabe von 19A ohne dass nachgeregelt wurde nahzu perfekt auf den eingestellten gewünschten Ladezustand.

Da ich sowieso dran war habe ich noch die `zielladen.sh` und die `loadconfig.sh` auf Pfade relativ zum Script umgestellt. Das war zum lokalen testen einfacher und weil es eh bei neueren Skripten der Standard ist kommt es mit dem PR gleich mit.