### PR TITLE
fix isss for duo

### DIFF
--- a/runs/services.sh
+++ b/runs/services.sh
@@ -70,6 +70,7 @@ start() {
 			openwbDebugLog "MAIN" 1 "isss handler already running"
 		else
 			openwbDebugLog "MAIN" 0 "isss handler not running! restarting process"
+			echo "$lastmanagement" > "$OPENWBBASEDIR/ramdisk/issslp2act"
 			nohup python3 "$OPENWBBASEDIR/runs/isss.py" >>"$OPENWBBASEDIR/ramdisk/isss.log" 2>&1 &
 		fi
 	else


### PR DESCRIPTION
`echo "$lastmanagement" > "$OPENWBBASEDIR/ramdisk/issslp2act"`
Aus dieser ramdisk-Datei holt der isss-Daemon die Information, ob eine Duo vorliegt.

`sudo pkill -f '^python.*/isss.py'`
Hier müsste noch unterschieden werden, ob ein Neustart oder Cron5Min vorliegt. Ohne diese Zeile wird nach einem Update der isss-Daemon nicht neu gestartet, sondern nur nach einem Reboot. Kannst Du dir das bitte nochmal anschauen @yankee42 ?