### PR TITLE
fix: RAMDISKDIR is not set if OPENWBBASEDIR is set before script start

### DIFF
--- a/runs/pushButtons/pushButtonsHelper.sh
+++ b/runs/pushButtons/pushButtonsHelper.sh
@@ -1,8 +1,6 @@
 #!/bin/bash
-if [[ -z "$OPENWBBASEDIR" ]]; then
-	OPENWBBASEDIR=$(cd "$(dirname "$0")/../../" && pwd)
-	RAMDISKDIR="${OPENWBBASEDIR}/ramdisk"
-fi
+OPENWBBASEDIR=$(cd "$(dirname "$0")/../../" && pwd)
+RAMDISKDIR="${OPENWBBASEDIR}/ramdisk"
 
 declare -F openwbDebugLog &>/dev/null || {
 	. "$OPENWBBASEDIR/helperFunctions.sh"


### PR DESCRIPTION
Dem Autor geht es bei [diesem Bild](https://openwb.de/forum/download/file.php?id=14291&mode=view) in [diesem Forenpost](https://openwb.de/forum/viewtopic.php?p=73470#p73470) um etwas anderes. Mir fällt jedoch die Fehlermeldung auf, dass dort nicht ins Log geschrieben werden kann. Die Ursache ist leicht zu sehen: Es wird versucht nach `/openWB.log` zu schreiben. Die Variable `RAMDISKDIR` ist offensichtlich nicht gesetzt.

`OPENWBBASEDIR` wird in vielen Scripten bereits gesetzt und muss bei passendem Kontext nicht unbedingt neu gesetzt werden `RAMDISKDIR` wird nur in bestimmten Skripten gesetzt und ist es dann potentiell nicht.

Um es einfach zu machen entfernt dieser PR die Verzweigung. Dann passiert immer das Selbe :-).