### PR TITLE
use Go-e API V2 instead of API V1 (in case of HWv3 which supports it)

### DIFF
--- a/goecheck.sh
+++ b/goecheck.sh
@@ -2,29 +2,54 @@
 goecheck(){
 	#######################################
 	#goe mobility check
+	digit='^[0-9]$'
+	
 	if [[ $evsecon == "goe" ]]; then
 		output=$(curl --connect-timeout 1 -s http://$goeiplp1/status)
 		if [[ $? == "0" ]] ; then
-			state=$(echo $output | jq -r '.alw')
-			if grep -q 1 "/var/www/html/openWB/ramdisk/ladestatus"; then
-				lp1enabled=$(</var/www/html/openWB/ramdisk/lp1enabled)
-				if ((state == "0")) && (( lp1enabled == "1" )) ; then
-					curl --silent --connect-timeout $goetimeoutlp1 -s http://$goeiplp1/mqtt?payload=alw=1 > /dev/null
+			#check whether goe has 1to3phase switch capability => new HWV3 and new API V2
+			fsp=$(echo $output | jq -r '.fsp')
+			if [[ ! $fsp =~ $digit ]] ; then
+				state=$(echo $output | jq -r '.alw')
+				if grep -q 1 "/var/www/html/openWB/ramdisk/ladestatus"; then
+					lp1enabled=$(</var/www/html/openWB/ramdisk/lp1enabled)
+					if ((state == "0"))  && (( lp1enabled == "1" )) ; then
+						curl --silent --connect-timeout $goetimeoutlp1 -s http://$goeiplp1/mqtt?payload=alw=1 > /dev/null
+					fi
 				fi
-			fi
-			if grep -q 0 "/var/www/html/openWB/ramdisk/ladestatus"; then
-				if ((state == "1")) ; then
-					curl --silent --connect-timeout $goetimeoutlp1 -s http://$goeiplp1/mqtt?payload=alw=0 > /dev/null
+				if grep -q 0 "/var/www/html/openWB/ramdisk/ladestatus"; then
+					if ((state == "1")) ; then
+						curl --silent --connect-timeout $goetimeoutlp1 -s http://$goeiplp1/mqtt?payload=alw=0 > /dev/null
+					fi
 				fi
-			fi
-			fwv=$(echo $output | jq -r '.fwv' | grep -Po "[1-9]\d{1,2}")
-			oldcurrent=$(echo $output | jq -r '.amp')
-			current=$(</var/www/html/openWB/ramdisk/llsoll)
-			if (( oldcurrent != $current )) && (( $current != 0 )); then
-				if (($fwv >= 40)) ; then
-					curl --silent --connect-timeout $goetimeoutlp1 -s http://$goeiplp1/mqtt?payload=amx=$current > /dev/null
-				else
-					curl --silent --connect-timeout $goetimeoutlp1 -s http://$goeiplp1/mqtt?payload=amp=$current > /dev/null
+				fwv=$(echo $output | jq -r '.fwv' | grep -Po "[1-9]\d{1,2}")
+				oldcurrent=$(echo $output | jq -r '.amp')
+				current=$(</var/www/html/openWB/ramdisk/llsoll)
+				if (( oldcurrent != $current )) && (( $current != 0 )) ; then
+					if (($fwv >= 40)) ; then
+						curl --silent --connect-timeout $goetimeoutlp1 -s http://$goeiplp1/mqtt?payload=amx=$current > /dev/null
+					else
+						curl --silent --connect-timeout $goetimeoutlp1 -s http://$goeiplp1/mqtt?payload=amp=$current > /dev/null
+					fi
+				fi
+			else
+				output=$(curl --connect-timeout 1 -s http://$goeiplp1/api/status)
+				state=$(echo $output | jq -r '.frc')
+				if grep -q 1 "/var/www/html/openWB/ramdisk/ladestatus"; then
+					lp1enabled=$(</var/www/html/openWB/ramdisk/lp1enabled)
+					if ((state == "1"))  && (( lp1enabled == "1" )) ; then
+						curl --silent --connect-timeout $goetimeoutlp1 -s http://$goeiplp1/api/set?frc=0 > /dev/null
+					fi
+				fi
+				if grep -q 0 "/var/www/html/openWB/ramdisk/ladestatus"; then
+					if (( state == "0" )) || (( state == "2" )) ; then
+						curl --silent --connect-timeout $goetimeoutlp1 -s http://$goeiplp1/api/set?frc=1 > /dev/null
+					fi
+				fi
+				oldcurrent=$(echo $output | jq -r '.amp')
+				current=$(</var/www/html/openWB/ramdisk/llsoll)
+				if (( oldcurrent != $current )) && (( $current != 0 )) ; then
+					curl --silent --connect-timeout $goetimeoutlp1 -s http://$goeiplp1/api/set?amp=$current > /dev/null
 				fi
 			fi
 		fi
@@ -33,38 +58,64 @@ goecheck(){
 		if [[ $evsecons1 == "goe" ]]; then
 			output=$(curl --connect-timeout 1 -s http://$goeiplp2/status)
 			if [[ $? == "0" ]] ; then
-				state=$(echo $output | jq -r '.alw')
-				if grep -q 1 "/var/www/html/openWB/ramdisk/ladestatuss1"; then
-					lp2enabled=$(</var/www/html/openWB/ramdisk/lp2enabled)
-					if ((state == "0"))  && (( lp2enabled == "1" )) ; then
-						curl --silent --connect-timeout $goetimeoutlp2 -s http://$goeiplp2/mqtt?payload=alw=1 > /dev/null
+				#check whether goe has 1to3phase switch capability => new HWV3 and new API V2
+				fsp=$(echo $output | jq -r '.fsp')
+				if [[ ! $fsp =~ $digit ]] ; then
+					state=$(echo $output | jq -r '.alw')
+					if grep -q 1 "/var/www/html/openWB/ramdisk/ladestatuss1"; then
+						lp2enabled=$(</var/www/html/openWB/ramdisk/lp2enabled)
+						if ((state == "0"))  && (( lp2enabled == "1" )) ; then
+							curl --silent --connect-timeout $goetimeoutlp2 -s http://$goeiplp2/mqtt?payload=alw=1 > /dev/null
+						fi
 					fi
-				fi
-				if grep -q 0 "/var/www/html/openWB/ramdisk/ladestatuss1"; then
-					if ((state == "1")) ; then
-						curl --silent --connect-timeout $goetimeoutlp2 -s http://$goeiplp2/mqtt?payload=alw=0 > /dev/null
+					if grep -q 0 "/var/www/html/openWB/ramdisk/ladestatuss1"; then
+						if ((state == "1")) ; then
+							curl --silent --connect-timeout $goetimeoutlp2 -s http://$goeiplp2/mqtt?payload=alw=0 > /dev/null
+						fi
 					fi
-				fi
-				fwv=$(echo $output | jq -r '.fwv' | grep -Po "[1-9]\d{1,2}")
-				oldcurrent=$(echo $output | jq -r '.amp')
-				current=$(</var/www/html/openWB/ramdisk/llsolls1)
-				if (( oldcurrent != $current )) && (( $current != 0 )); then
-					if (($fwv >= 40)) ; then
-						curl --silent --connect-timeout $goetimeoutlp2 -s http://$goeiplp2/mqtt?payload=amx=$current > /dev/null
-					else
-						curl --silent --connect-timeout $goetimeoutlp2 -s http://$goeiplp2/mqtt?payload=amp=$current > /dev/null
+					fwv=$(echo $output | jq -r '.fwv' | grep -Po "[1-9]\d{1,2}")
+					oldcurrent=$(echo $output | jq -r '.amp')
+					current=$(</var/www/html/openWB/ramdisk/llsolls1)
+					if (( oldcurrent != $current )) && (( $current != 0 )) ; then
+						if (($fwv >= 40)) ; then
+							curl --silent --connect-timeout $goetimeoutlp2 -s http://$goeiplp2/mqtt?payload=amx=$current > /dev/null
+						else
+							curl --silent --connect-timeout $goetimeoutlp2 -s http://$goeiplp2/mqtt?payload=amp=$current > /dev/null
+						fi
+					fi
+				else
+					output=$(curl --connect-timeout 1 -s http://$goeiplp2/api/status)
+					state=$(echo $output | jq -r '.frc')
+					if grep -q 1 "/var/www/html/openWB/ramdisk/ladestatuss1"; then
+						lp2enabled=$(</var/www/html/openWB/ramdisk/lp2enabled)
+						if ((state == "1"))  && (( lp2enabled == "1" )) ; then
+							curl --silent --connect-timeout $goetimeoutlp2 -s http://$goeiplp2/api/set?frc=0 > /dev/null
+						fi
+					fi
+					if grep -q 0 "/var/www/html/openWB/ramdisk/ladestatuss1"; then
+						if (( state == "0" )) || (( state == "2" )) ; then
+							curl --silent --connect-timeout $goetimeoutlp2 -s http://$goeiplp2/api/set?frc=1 > /dev/null
+						fi
+					fi
+					oldcurrent=$(echo $output | jq -r '.amp')
+					current=$(</var/www/html/openWB/ramdisk/llsolls1)
+					if (( oldcurrent != $current )) && (( $current != 0 )) ; then
+						curl --silent --connect-timeout $goetimeoutlp2 -s http://$goeiplp2/api/set?amp=$current > /dev/null
 					fi
 				fi
 			fi
 		fi
 		if [[ $lastmanagements2 == "1" ]]; then
 			if [[ $evsecons2 == "goe" ]]; then
-				output=$(curl --connect-timeout 1 -s http://$goeiplp3/status)
-				if [[ $? == "0" ]] ; then
+			output=$(curl --connect-timeout 1 -s http://$goeiplp3/status)
+			if [[ $? == "0" ]] ; then
+				#check whether goe has 1to3phase switch capability => new HWV3 and new API V2
+				fsp=$(echo $output | jq -r '.fsp')
+				if [[ ! $fsp =~ $digit ]] ; then
 					state=$(echo $output | jq -r '.alw')
 					if grep -q 1 "/var/www/html/openWB/ramdisk/ladestatuss2"; then
 						lp3enabled=$(</var/www/html/openWB/ramdisk/lp3enabled)
-						if ((state == "0"))  && (( lp3enabled == "1" ))  ; then
+						if ((state == "0"))  && (( lp3enabled == "1" )) ; then
 							curl --silent --connect-timeout $goetimeoutlp3 -s http://$goeiplp3/mqtt?payload=alw=1 > /dev/null
 						fi
 					fi
@@ -76,14 +127,34 @@ goecheck(){
 					fwv=$(echo $output | jq -r '.fwv' | grep -Po "[1-9]\d{1,2}")
 					oldcurrent=$(echo $output | jq -r '.amp')
 					current=$(</var/www/html/openWB/ramdisk/llsolls2)
-					if (( oldcurrent != $current )) ; then
+					if (( oldcurrent != $current && $current != 0 )) ; then
 						if (($fwv >= 40)) ; then
 							curl --silent --connect-timeout $goetimeoutlp3 -s http://$goeiplp3/mqtt?payload=amx=$current > /dev/null
 						else
 							curl --silent --connect-timeout $goetimeoutlp3 -s http://$goeiplp3/mqtt?payload=amp=$current > /dev/null
 						fi
 					fi
+				else
+					output=$(curl --connect-timeout 1 -s http://$goeiplp3/api/status)
+					state=$(echo $output | jq -r '.frc')
+					if grep -q 1 "/var/www/html/openWB/ramdisk/ladestatuss2"; then
+						lp3enabled=$(</var/www/html/openWB/ramdisk/lp3enabled)
+						if (( state == "1" ))  && (( lp3enabled == "1" )) ; then
+							curl --silent --connect-timeout $goetimeoutlp3 -s http://$goeiplp3/api/set?frc=0 > /dev/null
+						fi
+					fi
+					if grep -q 0 "/var/www/html/openWB/ramdisk/ladestatuss2"; then
+						if (( state == "0" )) || (( state == "2" )) ; then
+							curl --silent --connect-timeout $goetimeoutlp3 -s http://$goeiplp3/api/set?frc=1 > /dev/null
+						fi
+					fi
+					oldcurrent=$(echo $output | jq -r '.amp')
+					current=$(</var/www/html/openWB/ramdisk/llsolls2)
+					if (( oldcurrent != $current && $current != 0 )) ; then
+						curl --silent --connect-timeout $goetimeoutlp3 -s http://$goeiplp3/api/set?amp=$current > /dev/null
+					fi
 				fi
+			fi
 			fi
 		fi
 	fi

--- a/modules/goelp1/main.sh
+++ b/modules/goelp1/main.sh
@@ -4,62 +4,131 @@ rekwh='^[-+]?[0-9]+\.?[0-9]*$'
 
 output=$(curl --connect-timeout $goetimeoutlp1 -s http://$goeiplp1/status)
 if [[ $? == "0" ]] ; then
-	watt=$(echo $output | jq -r '.nrg[11]')
-	watt=$(echo "scale=0;$watt * 10 /1" |bc)
-	if [[ $watt =~ $re ]] ; then
-		echo $watt > /var/www/html/openWB/ramdisk/llaktuell
-	fi
-	lla1=$(echo $output | jq -r '.nrg[4]')
-	lla1=$(echo "scale=0;$lla1 / 10" |bc)
-	if [[ $lla1 =~ $re ]] ; then
-		echo $lla1 > /var/www/html/openWB/ramdisk/lla1
-	fi
-	lla2=$(echo $output | jq -r '.nrg[5]')
-	lla2=$(echo "scale=0;$lla2 / 10" |bc)
-	if [[ $lla2 =~ $re ]] ; then
-		echo $lla2 > /var/www/html/openWB/ramdisk/lla2
-	fi
-	lla3=$(echo $output | jq -r '.nrg[6]')
-	lla3=$(echo "scale=0;$lla3 / 10" |bc)
-	if [[ $lla3 =~ $re ]] ; then
-		echo $lla3 > /var/www/html/openWB/ramdisk/lla3
-	fi
-	llv1=$(echo $output | jq -r '.nrg[0]')
-	if [[ $llv1 =~ $re ]] ; then
-		echo $llv1 > /var/www/html/openWB/ramdisk/llv1
-	fi
-	llv2=$(echo $output | jq -r '.nrg[1]')
-	if [[ $llv2 =~ $re ]] ; then
-		echo $llv2 > /var/www/html/openWB/ramdisk/llv2
-	fi
-	llv3=$(echo $output | jq -r '.nrg[2]')
-	if [[ $llv3 =~ $re ]] ; then
-		echo $llv3 > /var/www/html/openWB/ramdisk/llv3
-	fi
-	llkwh=$(echo $output | jq -r '.eto')
-	llkwh=$(echo "scale=3;$llkwh / 10" |bc)
-	if [[ $llkwh =~ $rekwh ]] ; then
-		echo $llkwh > /var/www/html/openWB/ramdisk/llkwh
-	fi
-	rfid=$(echo $output | jq -r '.uby')
-	oldrfid=$(</var/www/html/openWB/ramdisk/tmpgoelp1rfid)
-	if [[ $rfid != $oldrfid ]] ; then
-		echo $rfid > /var/www/html/openWB/ramdisk/readtag
-		echo $rfid > /var/www/html/openWB/ramdisk/tmpgoelp1rfid
-	fi
-	#car status 1 Ladestation bereit, kein Auto
-	#car status 2 Auto lädt
-	#car status 3 Warte auf Fahrzeug
-	#car status 4 Ladung beendet, Fahrzeug verbunden
-	car=$(echo $output | jq -r '.car')
-	if [[ $car == "1" ]] ; then
-		echo 0 > /var/www/html/openWB/ramdisk/plugstat
-	else
-		echo 1 > /var/www/html/openWB/ramdisk/plugstat
-	fi
-	if [[ $car == "2" ]] ; then
-		echo 1 > /var/www/html/openWB/ramdisk/chargestat
-	else
-		echo 0 > /var/www/html/openWB/ramdisk/chargestat
-	fi
+    #check whether goe has 1to3phase switch capability => new HWV3 and new API V2
+    fsp=$(echo $output | jq -r '.fsp')
+    if [[ ! $fsp =~ $re ]] ; then       
+        watt=$(echo $output | jq -r '.nrg[11]')
+        watt=$(echo "scale=0;$watt * 10 /1" |bc)
+        if [[ $watt =~ $re ]] ; then
+            echo $watt > /var/www/html/openWB/ramdisk/llaktuell
+        fi
+        lla1=$(echo $output | jq -r '.nrg[4]')
+        lla1=$(echo "scale=0;$lla1 / 10" |bc)
+        if [[ $lla1 =~ $re ]] ; then
+            echo $lla1 > /var/www/html/openWB/ramdisk/lla1
+        fi
+        lla2=$(echo $output | jq -r '.nrg[5]')
+        lla2=$(echo "scale=0;$lla2 / 10" |bc)
+        if [[ $lla2 =~ $re ]] ; then
+            echo $lla2 > /var/www/html/openWB/ramdisk/lla2
+        fi
+        lla3=$(echo $output | jq -r '.nrg[6]')
+        lla3=$(echo "scale=0;$lla3 / 10" |bc)
+        if [[ $lla3 =~ $re ]] ; then
+            echo $lla3 > /var/www/html/openWB/ramdisk/lla3
+        fi
+        llv1=$(echo $output | jq -r '.nrg[0]')
+        if [[ $llv1 =~ $re ]] ; then
+            echo $llv1 > /var/www/html/openWB/ramdisk/llv1
+        fi
+        llv2=$(echo $output | jq -r '.nrg[1]')
+        if [[ $llv2 =~ $re ]] ; then
+            echo $llv2 > /var/www/html/openWB/ramdisk/llv2
+        fi
+        llv3=$(echo $output | jq -r '.nrg[2]')
+        if [[ $llv3 =~ $re ]] ; then
+            echo $llv3 > /var/www/html/openWB/ramdisk/llv3
+        fi
+        llkwh=$(echo $output | jq -r '.eto')
+        llkwh=$(echo "scale=3;$llkwh / 10" |bc)
+        if [[ $llkwh =~ $rekwh ]] ; then
+            echo $llkwh > /var/www/html/openWB/ramdisk/llkwh
+        fi
+        rfid=$(echo $output | jq -r '.uby')
+        oldrfid=$(</var/www/html/openWB/ramdisk/tmpgoelp1rfid)
+        if [[ $rfid != $oldrfid ]] ; then
+            echo $rfid > /var/www/html/openWB/ramdisk/readtag
+            echo $rfid > /var/www/html/openWB/ramdisk/tmpgoelp1rfid
+        fi
+        #car status 1 Ladestation bereit, kein Auto
+        #car status 2 Auto lädt
+        #car status 3 Warte auf Fahrzeug
+        #car status 4 Ladung beendet, Fahrzeug verbunden
+        car=$(echo $output | jq -r '.car')
+        if [[ $car == "1" ]] ; then
+            echo 0 > /var/www/html/openWB/ramdisk/plugstat
+        else
+            echo 1 > /var/www/html/openWB/ramdisk/plugstat
+        fi
+        if [[ $car == "2" ]] ; then
+            echo 1 > /var/www/html/openWB/ramdisk/chargestat
+        else
+            echo 0 > /var/www/html/openWB/ramdisk/chargestat
+        fi
+    else 
+        output=$(curl --connect-timeout $goetimeoutlp1 -s http://$goeiplp1/api/status)
+        if [[ $? == "0" ]] ; then
+            watt=$(echo $output | jq -r '.nrg[11]')
+            watt=$(echo "scale=0;$watt /1" |bc)
+            if [[ $watt =~ $re ]] ; then
+                echo $watt > /var/www/html/openWB/ramdisk/llaktuell
+            fi
+            lla1=$(echo $output | jq -r '.nrg[4]')
+            lla1=$(echo "scale=0;$lla1" |bc)
+            if [[ $lla1 =~ $rekwh ]] ; then
+                echo $lla1 > /var/www/html/openWB/ramdisk/lla1
+            fi
+            lla2=$(echo $output | jq -r '.nrg[5]')
+            lla2=$(echo "scale=0;$lla2" |bc)
+            if [[ $lla2 =~ $rekwh ]] ; then
+                echo $lla2 > /var/www/html/openWB/ramdisk/lla2
+            fi
+            lla3=$(echo $output | jq -r '.nrg[6]')
+            lla3=$(echo "scale=0;$lla3" |bc)
+            if [[ $lla3 =~ $rekwh ]] ; then
+                echo $lla3 > /var/www/html/openWB/ramdisk/lla3
+            fi
+            llv1=$(echo $output | jq -r '.nrg[0]')
+            if [[ $llv1 =~ $re ]] ; then
+                echo $llv1 > /var/www/html/openWB/ramdisk/llv1
+            fi
+            llv2=$(echo $output | jq -r '.nrg[1]')
+            if [[ $llv2 =~ $re ]] ; then
+                echo $llv2 > /var/www/html/openWB/ramdisk/llv2
+            fi
+            llv3=$(echo $output | jq -r '.nrg[2]')
+            if [[ $llv3 =~ $re ]] ; then
+                echo $llv3 > /var/www/html/openWB/ramdisk/llv3
+            fi
+            llkwh=$(echo $output | jq -r '.eto')
+            llkwh=$(echo "scale=3;$llkwh / 1000" |bc)
+            if [[ $llkwh =~ $rekwh ]] ; then
+                echo $llkwh > /var/www/html/openWB/ramdisk/llkwh
+            fi
+            rfid=$(echo $output | jq -r '.trx')
+            if [[ $rfid == "null" ]] ; then
+                rfid="0"
+            fi
+            oldrfid=$(</var/www/html/openWB/ramdisk/tmpgoelprfid)
+            if [[ $rfid != $oldrfid ]] ; then
+                echo $rfid > /var/www/html/openWB/ramdisk/readtag
+                echo $rfid > /var/www/html/openWB/ramdisk/tmpgoelprfid
+            fi
+            #car status 1 Ladestation bereit, kein Auto
+            #car status 2 Auto lädt
+            #car status 3 Warte auf Fahrzeug
+            #car status 4 Ladung beendet, Fahrzeug verbunden
+            car=$(echo $output | jq -r '.car')
+            if [[ $car == "2" ]] || [[ $car == "3" ]] || [[ $car == "4" ]] ; then
+                echo 1 > /var/www/html/openWB/ramdisk/plugstat
+            else
+                echo 0 > /var/www/html/openWB/ramdisk/plugstat
+            fi
+            if [[ $car == "2" ]] ; then
+                echo 1 > /var/www/html/openWB/ramdisk/chargestat
+            else
+                echo 0 > /var/www/html/openWB/ramdisk/chargestat
+            fi
+        fi
+    fi
 fi

--- a/modules/goelp2/main.sh
+++ b/modules/goelp2/main.sh
@@ -4,62 +4,131 @@ rekwh='^[-+]?[0-9]+\.?[0-9]*$'
 
 output=$(curl --connect-timeout $goetimeoutlp2 -s http://$goeiplp2/status)
 if [[ $? == "0" ]] ; then
-	watt=$(echo $output | jq -r '.nrg[11]')
-	watt=$(echo "scale=0;$watt * 10 /1" |bc)
-	if [[ $watt =~ $re ]] ; then
-		echo $watt > /var/www/html/openWB/ramdisk/llaktuells1
-	fi
-	lla1=$(echo $output | jq -r '.nrg[4]')
-	lla1=$(echo "scale=0;$lla1 / 10" |bc)
-	if [[ $lla1 =~ $re ]] ; then
-		echo $lla1 > /var/www/html/openWB/ramdisk/llas11
-	fi
-	lla2=$(echo $output | jq -r '.nrg[5]')
-	lla2=$(echo "scale=0;$lla2 / 10" |bc)
-	if [[ $lla2 =~ $re ]] ; then
-		echo $lla2 > /var/www/html/openWB/ramdisk/llas12
-	fi
-	lla3=$(echo $output | jq -r '.nrg[6]')
-	lla3=$(echo "scale=0;$lla3 / 10" |bc)
-	if [[ $lla3 =~ $re ]] ; then
-		echo $lla3 > /var/www/html/openWB/ramdisk/llas13
-	fi
-	llv1=$(echo $output | jq -r '.nrg[0]')
-	if [[ $llv1 =~ $re ]] ; then
-		echo $llv1 > /var/www/html/openWB/ramdisk/llvs11
-	fi
-	llv2=$(echo $output | jq -r '.nrg[1]')
-	if [[ $llv2 =~ $re ]] ; then
-		echo $llv2 > /var/www/html/openWB/ramdisk/llvs12
-	fi
-	llv3=$(echo $output | jq -r '.nrg[2]')
-	if [[ $llv3 =~ $re ]] ; then
-		echo $llv3 > /var/www/html/openWB/ramdisk/llvs13
-	fi
-	llkwh=$(echo $output | jq -r '.eto')
-	llkwh=$(echo "scale=3;$llkwh / 10" |bc)
-	if [[ $llkwh =~ $rekwh ]] ; then
-		echo $llkwh > /var/www/html/openWB/ramdisk/llkwhs1
-	fi
-	rfid=$(echo $output | jq -r '.uby')
-	oldrfid=$(</var/www/html/openWB/ramdisk/tmpgoelp2rfid)
-	if [[ $rfid != $oldrfid ]] ; then
-		echo $rfid > /var/www/html/openWB/ramdisk/readtag
-		echo $rfid > /var/www/html/openWB/ramdisk/tmpgoelp2rfid
-	fi
-	#car status 1 Ladestation bereit, kein Auto
-	#car status 2 Auto lädt
-	#car status 3 Warte auf Fahrzeug
-	#car status 4 Ladung beendet, Fahrzeug verbunden
-	car=$(echo $output | jq -r '.car')
-	if [[ $car == "1" ]] ; then
-		echo 0 > /var/www/html/openWB/ramdisk/plugstats1
-	else
-		echo 1 > /var/www/html/openWB/ramdisk/plugstats1
-	fi
-	if [[ $car == "2" ]] ; then
-		echo 1 > /var/www/html/openWB/ramdisk/chargestats1
-	else
-		echo 0 > /var/www/html/openWB/ramdisk/chargestats1
+	#check whether goe has 1to3phase switch capability => new HWV3 and new API V2
+	fsp=$(echo $output | jq -r '.fsp')
+	if [[ ! $fsp =~ $re ]] ; then 
+		watt=$(echo $output | jq -r '.nrg[11]')
+		watt=$(echo "scale=0;$watt * 10 /1" |bc)
+		if [[ $watt =~ $re ]] ; then
+			echo $watt > /var/www/html/openWB/ramdisk/llaktuells1
+		fi
+		lla1=$(echo $output | jq -r '.nrg[4]')
+		lla1=$(echo "scale=0;$lla1 / 10" |bc)
+		if [[ $lla1 =~ $re ]] ; then
+			echo $lla1 > /var/www/html/openWB/ramdisk/llas11
+		fi
+		lla2=$(echo $output | jq -r '.nrg[5]')
+		lla2=$(echo "scale=0;$lla2 / 10" |bc)
+		if [[ $lla2 =~ $re ]] ; then
+			echo $lla2 > /var/www/html/openWB/ramdisk/llas12
+		fi
+		lla3=$(echo $output | jq -r '.nrg[6]')
+		lla3=$(echo "scale=0;$lla3 / 10" |bc)
+		if [[ $lla3 =~ $re ]] ; then
+			echo $lla3 > /var/www/html/openWB/ramdisk/llas13
+		fi
+		llv1=$(echo $output | jq -r '.nrg[0]')
+		if [[ $llv1 =~ $re ]] ; then
+			echo $llv1 > /var/www/html/openWB/ramdisk/llvs11
+		fi
+		llv2=$(echo $output | jq -r '.nrg[1]')
+		if [[ $llv2 =~ $re ]] ; then
+			echo $llv2 > /var/www/html/openWB/ramdisk/llvs12
+		fi
+		llv3=$(echo $output | jq -r '.nrg[2]')
+		if [[ $llv3 =~ $re ]] ; then
+			echo $llv3 > /var/www/html/openWB/ramdisk/llvs13
+		fi
+		llkwh=$(echo $output | jq -r '.eto')
+		llkwh=$(echo "scale=3;$llkwh / 10" |bc)
+		if [[ $llkwh =~ $rekwh ]] ; then
+			echo $llkwh > /var/www/html/openWB/ramdisk/llkwhs1
+		fi
+		rfid=$(echo $output | jq -r '.uby')
+		oldrfid=$(</var/www/html/openWB/ramdisk/tmpgoelp2rfid)
+		if [[ $rfid != $oldrfid ]] ; then
+			echo $rfid > /var/www/html/openWB/ramdisk/readtag
+			echo $rfid > /var/www/html/openWB/ramdisk/tmpgoelp2rfid
+		fi
+		#car status 1 Ladestation bereit, kein Auto
+		#car status 2 Auto lädt
+		#car status 3 Warte auf Fahrzeug
+		#car status 4 Ladung beendet, Fahrzeug verbunden
+		car=$(echo $output | jq -r '.car')
+		if [[ $car == "1" ]] ; then
+			echo 0 > /var/www/html/openWB/ramdisk/plugstats1
+		else
+			echo 1 > /var/www/html/openWB/ramdisk/plugstats1
+		fi
+		if [[ $car == "2" ]] ; then
+			echo 1 > /var/www/html/openWB/ramdisk/chargestats1
+		else
+			echo 0 > /var/www/html/openWB/ramdisk/chargestats1
+		fi
+	else 
+		output=$(curl --connect-timeout $goetimeoutlp2 -s http://$goeiplp2/api/status)
+		if [[ $? == "0" ]] ; then
+			watt=$(echo $output | jq -r '.nrg[11]')
+			watt=$(echo "scale=0;$watt /1" |bc)
+			if [[ $watt =~ $re ]] ; then
+				echo $watt > /var/www/html/openWB/ramdisk/llaktuells1
+			fi
+			lla1=$(echo $output | jq -r '.nrg[4]')
+			lla1=$(echo "scale=0;$lla1" |bc)
+			if [[ $lla1 =~ $rekwh ]] ; then
+				echo $lla1 > /var/www/html/openWB/ramdisk/llas11
+			fi
+			lla2=$(echo $output | jq -r '.nrg[5]')
+			lla2=$(echo "scale=0;$lla2" |bc)
+			if [[ $lla2 =~ $rekwh ]] ; then
+				echo $lla2 > /var/www/html/openWB/ramdisk/llas12
+			fi
+			lla3=$(echo $output | jq -r '.nrg[6]')
+			lla3=$(echo "scale=0;$lla3" |bc)
+			if [[ $lla3 =~ $rekwh ]] ; then
+				echo $lla3 > /var/www/html/openWB/ramdisk/llas13
+			fi
+			llv1=$(echo $output | jq -r '.nrg[0]')
+			if [[ $llv1 =~ $re ]] ; then
+				echo $llv1 > /var/www/html/openWB/ramdisk/llvs11
+			fi
+			llv2=$(echo $output | jq -r '.nrg[1]')
+			if [[ $llv2 =~ $re ]] ; then
+				echo $llv2 > /var/www/html/openWB/ramdisk/llvs12
+			fi
+			llv3=$(echo $output | jq -r '.nrg[2]')
+			if [[ $llv3 =~ $re ]] ; then
+				echo $llv3 > /var/www/html/openWB/ramdisk/llvs13
+			fi
+			llkwh=$(echo $output | jq -r '.eto')
+			llkwh=$(echo "scale=3;$llkwh / 1000" |bc)
+			if [[ $llkwh =~ $rekwh ]] ; then
+				echo $llkwh > /var/www/html/openWB/ramdisk/llkwhs1
+			fi
+			rfid=$(echo $output | jq -r '.trx')
+			if [[ $rfid == "null" ]] ; then
+				rfid="0"
+			fi
+			oldrfid=$(</var/www/html/openWB/ramdisk/tmpgoelp2rfid)
+			if [[ $rfid != $oldrfid ]] ; then
+				echo $rfid > /var/www/html/openWB/ramdisk/readtag
+				echo $rfid > /var/www/html/openWB/ramdisk/tmpgoelp2rfid
+			fi
+			#car status 1 Ladestation bereit, kein Auto
+			#car status 2 Auto lädt
+			#car status 3 Warte auf Fahrzeug
+			#car status 4 Ladung beendet, Fahrzeug verbunden
+			car=$(echo $output | jq -r '.car')
+			if [[ $car == "2" ]] || [[ $car == "3" ]] || [[ $car == "4" ]] ; then
+				echo 1 > /var/www/html/openWB/ramdisk/plugstats1
+			else
+				echo 0 > /var/www/html/openWB/ramdisk/plugstats1
+			fi
+			if [[ $car == "2" ]] ; then
+				echo 1 > /var/www/html/openWB/ramdisk/chargestats1
+			else
+				echo 0 > /var/www/html/openWB/ramdisk/chargestats1
+			fi
+		fi
 	fi
 fi

--- a/modules/goelp3/main.sh
+++ b/modules/goelp3/main.sh
@@ -4,62 +4,131 @@ rekwh='^[-+]?[0-9]+\.?[0-9]*$'
 
 output=$(curl --connect-timeout $goetimeoutlp3 -s http://$goeiplp3/status)
 if [[ $? == "0" ]] ; then
-	watt=$(echo $output | jq -r '.nrg[11]')
-	watt=$(echo "scale=0;$watt * 10 /1" |bc)
-	if [[ $watt =~ $re ]] ; then
-		echo $watt > /var/www/html/openWB/ramdisk/llaktuells2
-	fi
-	lla1=$(echo $output | jq -r '.nrg[4]')
-	lla1=$(echo "scale=0;$lla1 / 10" |bc)
-	if [[ $lla1 =~ $re ]] ; then
-		echo $lla1 > /var/www/html/openWB/ramdisk/llas21
-	fi
-	lla2=$(echo $output | jq -r '.nrg[5]')
-	lla2=$(echo "scale=0;$lla2 / 10" |bc)
-	if [[ $lla2 =~ $re ]] ; then
-		echo $lla2 > /var/www/html/openWB/ramdisk/llas22
-	fi
-	lla3=$(echo $output | jq -r '.nrg[6]')
-	lla3=$(echo "scale=0;$lla3 / 10" |bc)
-	if [[ $lla3 =~ $re ]] ; then
-		echo $lla3 > /var/www/html/openWB/ramdisk/llas23
-	fi
-	llv1=$(echo $output | jq -r '.nrg[0]')
-	if [[ $llv1 =~ $re ]] ; then
-		echo $llv1 > /var/www/html/openWB/ramdisk/llvs21
-	fi
-	llv2=$(echo $output | jq -r '.nrg[1]')
-	if [[ $llv2 =~ $re ]] ; then
-		echo $llv2 > /var/www/html/openWB/ramdisk/llvs22
-	fi
-	llv3=$(echo $output | jq -r '.nrg[2]')
-	if [[ $llv3 =~ $re ]] ; then
-		echo $llv3 > /var/www/html/openWB/ramdisk/llvs23
-	fi
-	llkwh=$(echo $output | jq -r '.eto')
-	llkwh=$(echo "scale=3;$llkwh / 10" |bc)
-	if [[ $llkwh =~ $rekwh ]] ; then
-		echo $llkwh > /var/www/html/openWB/ramdisk/llkwhs2
-	fi
-	rfid=$(echo $output | jq -r '.uby')
-	oldrfid=$(</var/www/html/openWB/ramdisk/tmpgoelp3rfid)
-	if [[ $rfid != $oldrfid ]] ; then
-		echo $rfid > /var/www/html/openWB/ramdisk/readtag
-		echo $rfid > /var/www/html/openWB/ramdisk/tmpgoelp3rfid
-	fi
-	#car status 1 Ladestation bereit, kein Auto
-	#car status 2 Auto lädt
-	#car status 3 Warte auf Fahrzeug
-	#car status 4 Ladung beendet, Fahrzeug verbunden
-	car=$(echo $output | jq -r '.car')
-	if [[ $car == "1" ]] ; then
-		echo 0 > /var/www/html/openWB/ramdisk/plugstatlp3
-	else
-		echo 1 > /var/www/html/openWB/ramdisk/plugstatlp3
-	fi
-	if [[ $car == "2" ]] ; then
-		echo 1 > /var/www/html/openWB/ramdisk/chargestatlp3
-	else
-		echo 0 > /var/www/html/openWB/ramdisk/chargestatlp3
-	fi
+    #check whether goe has 1to3phase switch capability => new HWV3 and new API V2
+    fsp=$(echo $output | jq -r '.fsp')
+    if [[ ! $fsp =~ $re ]] ; then 
+        watt=$(echo $output | jq -r '.nrg[11]')
+        watt=$(echo "scale=0;$watt * 10 /1" |bc)
+        if [[ $watt =~ $re ]] ; then
+            echo $watt > /var/www/html/openWB/ramdisk/llaktuells2
+        fi
+        lla1=$(echo $output | jq -r '.nrg[4]')
+        lla1=$(echo "scale=0;$lla1 / 10" |bc)
+        if [[ $lla1 =~ $re ]] ; then
+            echo $lla1 > /var/www/html/openWB/ramdisk/llas21
+        fi
+        lla2=$(echo $output | jq -r '.nrg[5]')
+        lla2=$(echo "scale=0;$lla2 / 10" |bc)
+        if [[ $lla2 =~ $re ]] ; then
+            echo $lla2 > /var/www/html/openWB/ramdisk/llas22
+        fi
+        lla3=$(echo $output | jq -r '.nrg[6]')
+        lla3=$(echo "scale=0;$lla3 / 10" |bc)
+        if [[ $lla3 =~ $re ]] ; then
+            echo $lla3 > /var/www/html/openWB/ramdisk/llas23
+        fi
+        llv1=$(echo $output | jq -r '.nrg[0]')
+        if [[ $llv1 =~ $re ]] ; then
+            echo $llv1 > /var/www/html/openWB/ramdisk/llvs21
+        fi
+        llv2=$(echo $output | jq -r '.nrg[1]')
+        if [[ $llv2 =~ $re ]] ; then
+            echo $llv2 > /var/www/html/openWB/ramdisk/llvs22
+        fi
+        llv3=$(echo $output | jq -r '.nrg[2]')
+        if [[ $llv3 =~ $re ]] ; then
+            echo $llv3 > /var/www/html/openWB/ramdisk/llvs23
+        fi
+        llkwh=$(echo $output | jq -r '.eto')
+        llkwh=$(echo "scale=3;$llkwh / 10" |bc)
+        if [[ $llkwh =~ $rekwh ]] ; then
+            echo $llkwh > /var/www/html/openWB/ramdisk/llkwhs2
+        fi
+        rfid=$(echo $output | jq -r '.uby')
+        oldrfid=$(</var/www/html/openWB/ramdisk/tmpgoelp3rfid)
+        if [[ $rfid != $oldrfid ]] ; then
+            echo $rfid > /var/www/html/openWB/ramdisk/readtag
+            echo $rfid > /var/www/html/openWB/ramdisk/tmpgoelp3rfid
+        fi
+        #car status 1 Ladestation bereit, kein Auto
+        #car status 2 Auto lädt
+        #car status 3 Warte auf Fahrzeug
+        #car status 4 Ladung beendet, Fahrzeug verbunden
+        car=$(echo $output | jq -r '.car')
+        if [[ $car == "1" ]] ; then
+            echo 0 > /var/www/html/openWB/ramdisk/plugstatlp3
+        else
+            echo 1 > /var/www/html/openWB/ramdisk/plugstatlp3
+        fi
+        if [[ $car == "2" ]] ; then
+            echo 1 > /var/www/html/openWB/ramdisk/chargestatlp3
+        else
+            echo 0 > /var/www/html/openWB/ramdisk/chargestatlp3
+        fi
+    else 
+        output=$(curl --connect-timeout $goetimeoutlp3 -s http://$goeiplp3/api/status)
+        if [[ $? == "0" ]] ; then
+            watt=$(echo $output | jq -r '.nrg[11]')
+            watt=$(echo "scale=0;$watt /1" |bc)
+            if [[ $watt =~ $re ]] ; then
+                echo $watt > /var/www/html/openWB/ramdisk/llaktuells2
+            fi
+            lla1=$(echo $output | jq -r '.nrg[4]')
+            lla1=$(echo "scale=0;$lla1" |bc)
+            if [[ $lla1 =~ $rekwh ]] ; then
+                echo $lla1 > /var/www/html/openWB/ramdisk/llas21
+            fi
+            lla2=$(echo $output | jq -r '.nrg[5]')
+            lla2=$(echo "scale=0;$lla2" |bc)
+            if [[ $lla2 =~ $rekwh ]] ; then
+                echo $lla2 > /var/www/html/openWB/ramdisk/llas22
+            fi
+            lla3=$(echo $output | jq -r '.nrg[6]')
+            lla3=$(echo "scale=0;$lla3" |bc)
+            if [[ $lla3 =~ $rekwh ]] ; then
+                echo $lla3 > /var/www/html/openWB/ramdisk/llas23
+            fi
+            llv1=$(echo $output | jq -r '.nrg[0]')
+            if [[ $llv1 =~ $re ]] ; then
+                echo $llv1 > /var/www/html/openWB/ramdisk/llvs21
+            fi
+            llv2=$(echo $output | jq -r '.nrg[1]')
+            if [[ $llv2 =~ $re ]] ; then
+                echo $llv2 > /var/www/html/openWB/ramdisk/llvs22
+            fi
+            llv3=$(echo $output | jq -r '.nrg[2]')
+            if [[ $llv3 =~ $re ]] ; then
+                echo $llv3 > /var/www/html/openWB/ramdisk/llvs23
+            fi
+            llkwh=$(echo $output | jq -r '.eto')
+            llkwh=$(echo "scale=3;$llkwh / 1000" |bc)
+            if [[ $llkwh =~ $rekwh ]] ; then
+                echo $llkwh > /var/www/html/openWB/ramdisk/llkwhs2
+            fi
+            rfid=$(echo $output | jq -r '.trx')
+            if [[ $rfid == "null" ]] ; then
+                rfid="0"
+            fi
+            oldrfid=$(</var/www/html/openWB/ramdisk/tmpgoelp3rfid)
+            if [[ $rfid != $oldrfid ]] ; then
+                echo $rfid > /var/www/html/openWB/ramdisk/readtag
+                echo $rfid > /var/www/html/openWB/ramdisk/tmpgoelp3rfid
+            fi
+            #car status 1 Ladestation bereit, kein Auto
+            #car status 2 Auto lädt
+            #car status 3 Warte auf Fahrzeug
+            #car status 4 Ladung beendet, Fahrzeug verbunden
+            car=$(echo $output | jq -r '.car')
+            if [[ $car == "2" ]] || [[ $car == "3" ]] || [[ $car == "4" ]] ; then
+                echo 1 > /var/www/html/openWB/ramdisk/plugstatlp3
+            else
+                echo 0 > /var/www/html/openWB/ramdisk/plugstatlp3
+            fi
+            if [[ $car == "2" ]] ; then
+                echo 1 > /var/www/html/openWB/ramdisk/chargestatlp3
+            else
+                echo 0 > /var/www/html/openWB/ramdisk/chargestatlp3
+            fi
+        fi
+    fi
 fi

--- a/runs/set-current.sh
+++ b/runs/set-current.sh
@@ -201,25 +201,45 @@ function setChargingCurrenthttp () {
 # 3: goeiplp1
 function setChargingCurrentgoe () {
 	if [[ $evsecon == "goe" ]]; then
-		if [[ $current -eq 0 ]]; then
-			output=$(curl --connect-timeout "$goetimeoutlp1" -s "http://$goeiplp1/status")
-			state=$(echo "$output" | jq -r '.alw')
-			if ((state == "1")) ; then
-				curl --silent --connect-timeout "$goetimeoutlp1" -s "http://$goeiplp1/mqtt?payload=alw=0" > /dev/null
+		output=$(curl --connect-timeout "$goetimeoutlp1" -s "http://$goeiplp1/status")
+		#check whether goe has 1to3phase switch capability => new HWV3 and new API V2
+		digit='^[0-9]$'
+		fsp=$(echo "$output" | jq -r '.fsp')
+		if [[ ! $fsp =~ $digit ]] ; then
+			if [[ $current -eq 0 ]]; then
+				state=$(echo "$output" | jq -r '.alw')
+				if ((state == "1")) ; then
+					curl --silent --connect-timeout "$goetimeoutlp1" -s "http://$goeiplp1/mqtt?payload=alw=0" > /dev/null
+				fi
+			else
+				fwv=$(echo "$output" | jq -r '.fwv' | grep -Po "[1-9]\d{1,2}")
+				state=$(echo "$output" | jq -r '.alw')
+				if ((state == "0")) ; then
+					 curl --silent --connect-timeout "$goetimeoutlp1" -s "http://$goeiplp1/mqtt?payload=alw=1" > /dev/null
+				fi
+				oldgoecurrent=$(echo "$output" | jq -r '.amp')
+				if (( oldgoecurrent != $current )) ; then
+					if ((fwv >= 40)) ; then
+						curl --silent --connect-timeout "$goetimeoutlp1" -s "http://$goeiplp1/mqtt?payload=amx=$current" > /dev/null
+					else
+						curl --silent --connect-timeout "$goetimeoutlp1" -s "http://$goeiplp1/mqtt?payload=amp=$current" > /dev/null
+					fi
+				fi
 			fi
 		else
-			output=$(curl --connect-timeout "$goetimeoutlp1" -s "http://$goeiplp1/status")
-			fwv=$(echo "$output" | jq -r '.fwv' | grep -Po "[1-9]\d{1,2}")
-			state=$(echo "$output" | jq -r '.alw')
-			if ((state == "0")) ; then
-				 curl --silent --connect-timeout "$goetimeoutlp1" -s "http://$goeiplp1/mqtt?payload=alw=1" > /dev/null
-			fi
-			oldgoecurrent=$(echo "$output" | jq -r '.amp')
-			if (( oldgoecurrent != current )) ; then
-				if ((fwv >= 40)) ; then
-					curl --silent --connect-timeout "$goetimeoutlp1" -s "http://$goeiplp1/mqtt?payload=amx=$current" > /dev/null
-				else
-					curl --silent --connect-timeout "$goetimeoutlp1" -s "http://$goeiplp1/mqtt?payload=amp=$current" > /dev/null
+			output=$(curl --connect-timeout "$goetimeoutlp1" -s "http://$goeiplp1/api/status")
+			state=$(echo "$output" | jq -r '.frc')
+			if [[ $current -eq 0 ]]; then
+				if ((state == "0")) ; then
+					curl --silent --connect-timeout "$goetimeoutlp1" -s "http://$goeiplp1/api/set?frc=1" > /dev/null
+				fi
+			else
+				if ((state == "1")) ; then
+					curl --silent --connect-timeout "$goetimeoutlp1" -s "http://$goeiplp1/api/set?frc=0" > /dev/null
+				fi
+				oldgoecurrent=$(echo "$output" | jq -r '.amp')
+				if (( oldgoecurrent != current )) ; then
+					curl --silent --connect-timeout "$goetimeoutlp1" -s "http://$goeiplp1/api/set?amp=$current" > /dev/null
 				fi
 			fi
 		fi


### PR DESCRIPTION
Mit der HW-Generation V3 des Go-e chargers wurde eine neue Version der API eingeführt (https://github.com/goecharger/go-eCharger-API-v2).
Die HWv3 kann anhand des Vorhandenseins des Parameters fsp (1-3 Phasenumschaltung) detektiert werden, da die HWv2
diesen nicht unterstützt. Dieser Parameter wird nur gelesen bzw. auf tatsächlich Vorhandensein überprüft.
Der Vorteil der APIv2 ist im Moment das der Zählerstand nicht mehr nur in ganzen kWh so wie in APIv1, sondern mit drei Nachkommastellen (so wie der der openWB selbst - GoE ist natürlich ungenauer, da nicht MID geeicht) zurückgeliefert wird.
Mit der Änderung werden somit sowohl "ältere" Go-e (mit APIv1) als auch "neuere" mit HWv3 (mit APIv2) automatisch erkannt und unterstützt.
Die Unterstützung ist für LP1 bis LP3 eingebaut.