### PR TITLE
json module: make sure values retrieved are float. Be fail-fast if not.

### DIFF
--- a/packages/modules/json/bat.py
+++ b/packages/modules/json/bat.py
@@ -23,15 +23,15 @@ class JsonBat:
     def update(self, response) -> None:
         config = self.component_config.configuration
 
-        power = jq.compile(config.jq_power).input(response).first()
+        power = float(jq.compile(config.jq_power).input(response).first())
         if config.jq_soc != "":
-            soc = jq.compile(config.jq_soc).input(response).first()
+            soc = float(jq.compile(config.jq_soc).input(response).first())
         else:
             soc = 0
 
         if config.jq_imported is not None and config.jq_exported is not None:
-            imported = jq.compile(config.jq_imported).input(response).first()
-            exported = jq.compile(config.jq_exported).input(response).first()
+            imported = float(jq.compile(config.jq_imported).input(response).first())
+            exported = float(jq.compile(config.jq_exported).input(response).first())
         else:
             imported, exported = self.__sim_counter.sim_count(power)
 

--- a/packages/modules/json/counter.py
+++ b/packages/modules/json/counter.py
@@ -23,13 +23,13 @@ class JsonCounter:
     def update(self, response):
         config = self.component_config.configuration
 
-        power = jq.compile(config.jq_power).input(response).first()
+        power = float(jq.compile(config.jq_power).input(response).first())
         # ToDo: add current or power per phase
         if config.jq_exported is None or config.jq_exported is None:
             imported, exported = self.__sim_counter.sim_count(power)
         else:
-            imported = jq.compile(config.jq_imported).input(response).first()
-            exported = jq.compile(config.jq_exported).input(response).first()
+            imported = float(jq.compile(config.jq_imported).input(response).first())
+            exported = float(jq.compile(config.jq_exported).input(response).first())
 
         counter_state = CounterState(
             imported=imported,

--- a/packages/modules/json/inverter.py
+++ b/packages/modules/json/inverter.py
@@ -29,7 +29,7 @@ class JsonInverter:
         if config.jq_exported is None:
             _, exported = self.__sim_counter.sim_count(power)
         else:
-            exported = jq.compile(config.jq_exported).input(response).first()
+            exported = float(jq.compile(config.jq_exported).input(response).first())
 
         inverter_state = InverterState(
             power=power,


### PR DESCRIPTION
Wenn man im JSON-Modul Werte produziert, die kein `float` (oder `int` würde wohl auch durchgehen) produziert, dann führt das zu unlustigen Folgefehlern (siehe [Forum](https://www.openwb.de/forum/viewtopic.php?p=74189&sid=6e27938887d9c2fb5a32acb231d903e3#p74189). Mit dem PR wird sofort immer ein `float` aus den gelesenen Werten gemacht. Wann das nicht geht fliegt sofort eine Exception, die die Suche nach der Ursache erleichtert.