### PR TITLE
Python Log im Smarthome... diverse Korrekturen

### DIFF
--- a/modules/smarthome/http/off.py
+++ b/modules/smarthome/http/off.py
@@ -1,27 +1,17 @@
 #!/usr/bin/python3
 import sys
-import os
-import time
-import json
-import getopt
-import socket
-import struct
-import codecs
-import binascii
-import urllib.request
+import logging
+from smarthome.smartlog import initlog
+from urllib.request import Request, urlopen
 from urllib.parse import urlparse
-named_tuple = time.localtime() # getstruct_time
-time_string = time.strftime("%m/%d/%Y, %H:%M:%S http off.py", named_tuple)
-devicenumber=str(sys.argv[1])
-uberschuss=int(sys.argv[3])
-url=str(sys.argv[4])
+devicenumber = int(sys.argv[1])
+uberschuss = int(sys.argv[3])
+url = str(sys.argv[4])
+initlog("http", devicenumber)
+log = logging.getLogger("http")
 if not urlparse(url).scheme:
-   url = 'http://' + url
-file_string= '/var/www/html/openWB/ramdisk/smarthome_device_' + str(devicenumber) + '_http.log'
-if os.path.isfile(file_string):
-   f = open( file_string , 'a')
-else:
-   f = open( file_string , 'w')
-print ('%s devicenr %s url %s)' % (time_string,devicenumber,url),file=f)
-f.close()
-urllib.request.urlopen(url, timeout=5)
+    url = 'http://' + url
+log.info('off devicenr %d url %s' % (devicenumber, url))
+headers = {'User-Agent': 'Mozilla/5.0'}
+request = Request(url, headers=headers)
+urlopen(request, timeout=5).read()

--- a/modules/smarthome/http/on.py
+++ b/modules/smarthome/http/on.py
@@ -1,27 +1,17 @@
 #!/usr/bin/python3
 import sys
-import os
-import time
-import json
-import getopt
-import socket
-import struct
-import codecs
-import binascii
-import urllib.request
+import logging
+from smarthome.smartlog import initlog
+from urllib.request import Request, urlopen
 from urllib.parse import urlparse
-named_tuple = time.localtime() # getstruct_time
-time_string = time.strftime("%m/%d/%Y, %H:%M:%S http on.py", named_tuple)
-devicenumber=str(sys.argv[1])
-uberschuss=int(sys.argv[3])
-url=str(sys.argv[4])
+devicenumber = int(sys.argv[1])
+uberschuss = int(sys.argv[3])
+url = str(sys.argv[4])
+initlog("http", devicenumber)
+log = logging.getLogger("http")
 if not urlparse(url).scheme:
-   url = 'http://' + url
-file_string= '/var/www/html/openWB/ramdisk/smarthome_device_' + str(devicenumber) + '_http.log'
-if os.path.isfile(file_string):
-   f = open( file_string , 'a')
-else:
-   f = open( file_string , 'w')
-print ('%s devicenr %s url %s' % (time_string,devicenumber,url),file=f)
-f.close()
-urllib.request.urlopen(url, timeout=5)
+    url = 'http://' + url
+log.info('on devicenr %d url %s' % (devicenumber, url))
+headers = {'User-Agent': 'Mozilla/5.0'}
+request = Request(url, headers=headers)
+urlopen(request, timeout=5).read()

--- a/modules/smarthome/nxdacxx/off.py
+++ b/modules/smarthome/nxdacxx/off.py
@@ -1,25 +1,25 @@
 #!/usr/bin/python3
 import sys
 import os
-import time
-named_tuple = time.localtime()   # getstruct_time
-time_string = time.strftime("%m/%d/%Y, %H:%M:%S N4DAC02 off.py", named_tuple)
-devicenumber = str(sys.argv[1])
+import logging
+from smarthome.smartlog import initlog
+from pymodbus.client.sync import ModbusTcpClient
+devicenumber = int(sys.argv[1])
 ipadr = str(sys.argv[2])
 uberschuss = int(sys.argv[3])
+port = int(sys.argv[4])
+dactyp = int(sys.argv[5])
 bp = '/var/www/html/openWB/ramdisk/smarthome_device_'
-file_string = bp + str(devicenumber) + '_N4DAC02.log'
 file_stringpv = bp + str(devicenumber) + '_pv'
 file_stringcount = bp + str(devicenumber) + '_count'
 file_stringcount5 = bp + str(devicenumber) + '_count5'
-if os.path.isfile(file_string):
-    pass
-else:
-    with open(file_string, 'w') as f:
-        print('N4DAC02 start log', file=f)
-with open(file_string, 'a') as f:
-    print('%s devicenr %s ipadr %s'
-          % (time_string, devicenumber, ipadr), file=f)
+initlog("DAC", devicenumber)
+log = logging.getLogger("DAC")
+log.info('off devicenr %d ipadr %s dactyp %d' % (devicenumber, ipadr, dactyp))
+if dactyp == 2:
+    client = ModbusTcpClient(ipadr, port=port)
+    # DO1 ausschalten um SGready zu sperren
+    rq = client.write_coil(0, False)
 pvmodus = 0
 if os.path.isfile(file_stringpv):
     with open(file_stringpv, 'r') as f:

--- a/modules/smarthome/nxdacxx/on.py
+++ b/modules/smarthome/nxdacxx/on.py
@@ -1,25 +1,24 @@
 #!/usr/bin/python3
 import sys
-import os
-import time
-named_tuple = time.localtime()   # getstruct_time
-time_string = time.strftime("%m/%d/%Y, %H:%M:%S N4DAC02 on.py", named_tuple)
-devicenumber = str(sys.argv[1])
+import logging
+from smarthome.smartlog import initlog
+from pymodbus.client.sync import ModbusTcpClient
+devicenumber = int(sys.argv[1])
 ipadr = str(sys.argv[2])
 uberschuss = int(sys.argv[3])
+port = int(sys.argv[4])
+dactyp = int(sys.argv[5])
+initlog("DAC", devicenumber)
+log = logging.getLogger("DAC")
 bp = '/var/www/html/openWB/ramdisk/smarthome_device_'
-file_string = bp + str(devicenumber) + '_N4DAC02.log'
 file_stringpv = bp + str(devicenumber) + '_pv'
 file_stringcount = bp + str(devicenumber) + '_count'
 file_stringcount5 = bp + str(devicenumber) + '_count5'
-if os.path.isfile(file_string):
-    pass
-else:
-    with open(file_string, 'w') as f:
-        print('N4DAC02 start log', file=f)
-with open(file_string, 'a') as f:
-    print('%s devicenr %s ipadr %s' %
-          (time_string, devicenumber, ipadr), file=f)
+log.info('on devicenr %d ipadr %s dactyp %d' % (devicenumber, ipadr, dactyp))
+if dactyp == 2:
+    client = ModbusTcpClient(ipadr, port=port)
+    # DO1 einschalten um SGready zu aktivieren
+    rq = client.write_coil(0, True)
 pvmodus = 1
 with open(file_stringpv, 'w') as f:
     f.write(str(pvmodus))

--- a/modules/smarthome/nxdacxx/watt.py
+++ b/modules/smarthome/nxdacxx/watt.py
@@ -1,23 +1,23 @@
 #!/usr/bin/python3
 import sys
 import os
-import time
-import json
 from pymodbus.client.sync import ModbusTcpClient
-named_tuple = time.localtime()   # getstruct_time
-time_string = time.strftime("%m/%d/%Y, %H:%M:%S N4DAC02 watty.py", named_tuple)
-devicenumber = str(sys.argv[1])
+import logging
+from smarthome.smartlog import initlog
+from smarthome.smartret import writeret
+devicenumber = int(sys.argv[1])
 ipadr = str(sys.argv[2])
 uberschuss = int(sys.argv[3])
 maxpower = int(sys.argv[4])
 forcesend = int(sys.argv[5])
 port = int(sys.argv[6])
 dactyp = int(sys.argv[7])
-# forcesend = 0 default acthor time period applies
+initlog("DAC", devicenumber)
+log = logging.getLogger("DAC")
+# forcesend = 0 default time period applies
 # forcesend = 1 default overwritten send now
 # forcesend = 9 default overwritten no send
 bp = '/var/www/html/openWB/ramdisk/smarthome_device_'
-file_string = bp + str(devicenumber) + '_N4DAC02.log'
 file_stringpv = bp + str(devicenumber) + '_pv'
 file_stringcount = bp + str(devicenumber) + '_count'
 file_stringcount5 = bp + str(devicenumber) + '_count5'
@@ -71,16 +71,10 @@ if count5 == 0:
     if count1 > 80:
         count1 = 0
     if count1 < 3:
-        if os.path.isfile(file_string):
-            pass
-        else:
-            with open(file_string, 'w') as f:
-                print('N4DAC02 start log', file=f)
-        with open(file_string, 'a') as f:
-            helpstr = '%s devicenr %s ipadr %s ueberschuss %6d port %4d'
-            helpstr += ' maxueberschuss %6d pvmodus %1d modbuswrite %1d'
-            print(helpstr % (time_string, devicenumber, ipadr, uberschuss,
-                             port, maxpower, pvmodus, modbuswrite), file=f)
+        helpstr = 'devicenr %d ipadr %s ueberschuss %6d port %4d'
+        helpstr += ' maxueberschuss %6d pvmodus %1d modbuswrite %1d'
+        log.info(helpstr % (devicenumber, ipadr, uberschuss,
+                 port, maxpower, pvmodus, modbuswrite))
     # modbus write
     if modbuswrite == 1:
         client = ModbusTcpClient(ipadr, port=port)
@@ -88,14 +82,21 @@ if count5 == 0:
             # 10 Volts are 1000
             volt = int((neupower * 1000) / maxpower)
             rq = client.write_register(1, volt, unit=1)
-        else:
+        elif dactyp == 1:
             # 10 volts are 4000
             volt = int((neupower * 4000) / maxpower)
             rq = client.write_register(0x01f4, volt, unit=1)
+        elif dactyp == 2:
+            volt = int((neupower * 4095) / maxpower)
+            if volt < 370:
+                volt = 370
+            #  ausgabe nicht kleiner 0,9V sonst Leistungsregelung der WP aus
+            rq = client.write_register(0, volt, unit=1)
+        else:
+            pass
         if count1 < 3:
-            with open(file_string, 'a') as f:
-                print('%s devicenr %s ipadr %s Volt %6d dactyp %d written by modbus ' %
-                      (time_string, devicenumber, ipadr, volt, dactyp), file=f)
+            log.info('devicenr %d ipadr %s Volt %6d dactyp %d written by modbus ' %
+                     (devicenumber, ipadr, volt, dactyp))
     with open(file_stringcount, 'w') as f:
         f.write(str(count1))
 else:
@@ -104,6 +105,4 @@ else:
 answer = '{"power":' + str(aktpower) + ',"powerc":' + str(powerc)
 answer += ',"send":' + str(modbuswrite) + ',"sendpower":' + str(volt)
 answer += ',"on":' + str(pvmodus) + '}'
-with open('/var/www/html/openWB/ramdisk/smarthome_device_ret' +
-          str(devicenumber), 'w') as f1:
-    json.dump(answer, f1)
+writeret(answer, devicenumber)

--- a/modules/smarthome/ratiotherm/off.py
+++ b/modules/smarthome/ratiotherm/off.py
@@ -3,7 +3,7 @@ import os
 import sys
 import logging
 from smarthome.smartlog import initlog
-devicenumber = str(sys.argv[1])
+devicenumber = int(sys.argv[1])
 ipadr = str(sys.argv[2])
 uberschuss = int(sys.argv[3])
 bp = '/var/www/html/openWB/ramdisk/smarthome_device_'
@@ -13,7 +13,7 @@ file_stringcount = bp + str(devicenumber) + '_count'
 initlog("ratiotherm", devicenumber)
 log = logging.getLogger("ratiotherm")
 aktpower = 0
-log.info(" off devicenr %s ipadr %s ueberschuss %6d Akt Leistung  %6d"
+log.info(" off devicenr %d ipadr %s ueberschuss %6d Akt Leistung  %6d"
          % (devicenumber, ipadr, uberschuss, aktpower))
 pvmodus = 0
 if os.path.isfile(file_stringpv):

--- a/modules/smarthome/ratiotherm/on.py
+++ b/modules/smarthome/ratiotherm/on.py
@@ -2,7 +2,7 @@
 import sys
 import logging
 from smarthome.smartlog import initlog
-devicenumber = str(sys.argv[1])
+devicenumber = int(sys.argv[1])
 ipadr = str(sys.argv[2])
 uberschuss = int(sys.argv[3])
 bp = '/var/www/html/openWB/ramdisk/smarthome_device_'
@@ -14,7 +14,7 @@ log = logging.getLogger("ratiotherm")
 file_stringpv = bp + str(devicenumber) + '_pv'
 file_stringcount = bp + str(devicenumber) + '_count'
 aktpower = 0
-log.info(" on devicenr %s ipadr %s ueberschuss %6d Akt Leistung  %6d"
+log.info(" on devicenr %d ipadr %s ueberschuss %6d Akt Leistung  %6d"
          % (devicenumber, ipadr, uberschuss, aktpower))
 with open(file_stringpv, 'w') as f:
     f.write(str(1))

--- a/modules/smarthome/ratiotherm/watt.py
+++ b/modules/smarthome/ratiotherm/watt.py
@@ -1,12 +1,12 @@
 #!/usr/bin/python3
 import sys
 import os
-import json
 from pymodbus.payload import BinaryPayloadBuilder, Endian
 from pymodbus.client.sync import ModbusTcpClient
 import logging
 from smarthome.smartlog import initlog
-devicenumber = str(sys.argv[1])
+from smarthome.smartret import writeret
+devicenumber = int(sys.argv[1])
 ipadr = str(sys.argv[2])
 uberschuss = int(sys.argv[3])
 forcesend = int(sys.argv[4])
@@ -70,9 +70,9 @@ if count5 == 0:
         with open(file_stringpv, 'w') as f:
             f.write(str(pvmodus))
     if count1 < 3:
-        log.info(" watt devicenr %s ipadr %s ueberschuss %6d Akt Leistung  %6d"
+        log.info(" watt devicenr %d ipadr %s ueberschuss %6d Akt Leistung  %6d"
                  % (devicenumber, ipadr, uberschuss, aktpower))
-        log.info(" watt devicenr %s ipadr %s neupower %6d pvmodus %1d modbusw %1d"
+        log.info(" watt devicenr %d ipadr %s neupower %6d pvmodus %1d modbusw %1d"
                  % (devicenumber, ipadr, neupower, pvmodus, modbuswrite))
     # modbus write
     if modbuswrite == 1:
@@ -84,7 +84,7 @@ if count5 == 0:
         client = ModbusTcpClient(ipadr, port=502)
         client.write_register(100, pay[0], unit=1)
         if count1 < 3:
-            log.info(" watt devicenr %s ipadr %s written %6d %#4X"
+            log.info(" watt devicenr %d ipadr %s written %6d %#4X"
                      % (devicenumber, ipadr, pay[0], pay[0]))
 else:
     if pvmodus == 99:
@@ -92,6 +92,4 @@ else:
 answer = '{"power":' + str(aktpower) + ',"powerc":0'
 answer += ',"send":' + str(modbuswrite) + ',"sendpower":' + str(neupower)
 answer += ',"on":' + str(pvmodus) + '}'
-with open('/var/www/html/openWB/ramdisk/smarthome_device_ret' +
-          str(devicenumber), 'w') as f1:
-    json.dump(answer, f1)
+writeret(answer, devicenumber)

--- a/modules/smarthome/stiebel/off.py
+++ b/modules/smarthome/stiebel/off.py
@@ -1,33 +1,19 @@
 #!/usr/bin/python3
 import sys
-import os
-import time
-import json
-import getopt
-import socket
-import struct
-import codecs
-import binascii
 from pymodbus.client.sync import ModbusTcpClient
-named_tuple = time.localtime() # getstruct_time
-time_string = time.strftime("%m/%d/%Y, %H:%M:%S stiebel off.py", named_tuple)
-devicenumber=str(sys.argv[1])
-ipadr=str(sys.argv[2])
-uberschuss=int(sys.argv[3])
-# standard
-file_string= '/var/www/html/openWB/ramdisk/smarthome_device_' + str(devicenumber) + '_stiebel.log'
-file_stringpv= '/var/www/html/openWB/ramdisk/smarthome_device_' + str(devicenumber) + '_pv'
-if os.path.isfile(file_string):
-   f = open( file_string , 'a')
-else:
-   f = open( file_string , 'w')
-print ('%s devicenr %s ipadr %s ueberschuss %6d try to connect (modbus)' % (time_string,devicenumber,ipadr,uberschuss),file=f)
+import logging
+from smarthome.smartlog import initlog
+devicenumber = int(sys.argv[1])
+ipadr = str(sys.argv[2])
+uberschuss = int(sys.argv[3])
+initlog("stiebel", devicenumber)
+log = logging.getLogger("stiebel")
+file_stringpv = '/var/www/html/openWB/ramdisk/smarthome_device_' + str(devicenumber) + '_pv'
+log.info('off devicenr %d ipadr %s ueberschuss %6d try to connect (modbus)' % (devicenumber, ipadr, uberschuss))
 client = ModbusTcpClient(ipadr, port=502)
 # deactivate switch one (manual 4002)
 rq = client.write_register(4001, 0, unit=1)
-print ('%s devicenr %s ipadr %s ' % (time_string,devicenumber,ipadr),file=f)
-f.close()
+log.info('off devicenr %d ipadr %s ' % (devicenumber, ipadr))
 pvmodus = 0
-f = open( file_stringpv , 'w')
-f.write(str(pvmodus))
-f.close() 
+with open(file_stringpv, 'w') as f:
+    f.write(str(pvmodus))

--- a/modules/smarthome/stiebel/on.py
+++ b/modules/smarthome/stiebel/on.py
@@ -1,34 +1,18 @@
 #!/usr/bin/python3
 import sys
-import os
-import time
-import json
-import getopt
-import socket
-import struct
-import codecs
-import binascii
 from pymodbus.client.sync import ModbusTcpClient
-named_tuple = time.localtime() # getstruct_time
-time_string = time.strftime("%m/%d/%Y, %H:%M:%S stiebel on.py", named_tuple)
-devicenumber=str(sys.argv[1])
-ipadr=str(sys.argv[2])
-uberschuss=int(sys.argv[3])
-# standard
-# lesen
-# own log
-file_string= '/var/www/html/openWB/ramdisk/smarthome_device_' + str(devicenumber) + '_stiebel.log'
-file_stringpv= '/var/www/html/openWB/ramdisk/smarthome_device_' + str(devicenumber) + '_pv'
-if os.path.isfile(file_string):
-   f = open( file_string , 'a')
-else:
-   f = open( file_string , 'w')
-print ('%s devicenr %s ipadr %s ueberschuss %6d try to connect (modbus)' % (time_string,devicenumber,ipadr,uberschuss),file=f)
+import logging
+from smarthome.smartlog import initlog
+devicenumber = int(sys.argv[1])
+ipadr = str(sys.argv[2])
+uberschuss = int(sys.argv[3])
+initlog("stiebel", devicenumber)
+log = logging.getLogger("stiebel")
+file_stringpv = '/var/www/html/openWB/ramdisk/smarthome_device_' + str(devicenumber) + '_pv'
+log.info('on devicenr %d ipadr %s ueberschuss %6d try to connect (modbus)' % (devicenumber, ipadr, uberschuss))
 client = ModbusTcpClient(ipadr, port=502)
 # activate switch one (manual 4002)
 rq = client.write_register(4001, 1, unit=1)
-print ('%s devicenr %s ipadr %s ' % (time_string,devicenumber,ipadr),file=f)
-f.close()
-f = open( file_stringpv , 'w')
-f.write(str(1))
-f.close()
+log.info('on devicenr %d ipadr %s ' % (devicenumber, ipadr))
+with open(file_stringpv, 'w') as f:
+    f.write(str(1))

--- a/modules/smarthome/stiebel/watt.py
+++ b/modules/smarthome/stiebel/watt.py
@@ -1,29 +1,21 @@
 #!/usr/bin/python3
 import sys
 import os
-import time
-import json
-import getopt
-import socket
-import struct
-import codecs
-import binascii
-from pymodbus.client.sync import ModbusTcpClient
-named_tuple = time.localtime() # getstruct_time
-time_string = time.strftime("%m/%d/%Y, %H:%M:%S stiebel watty.py", named_tuple)
-devicenumber=str(sys.argv[1])
-ipadr=str(sys.argv[2])
-uberschuss=int(sys.argv[3])
-file_stringpv= '/var/www/html/openWB/ramdisk/smarthome_device_' + str(devicenumber) + '_pv'
+import logging
+from smarthome.smartlog import initlog
+from smarthome.smartret import writeret
+devicenumber = int(sys.argv[1])
+ipadr = str(sys.argv[2])
+uberschuss = int(sys.argv[3])
+initlog("stiebel", devicenumber)
+log = logging.getLogger("stiebel")
+file_stringpv = '/var/www/html/openWB/ramdisk/smarthome_device_' + str(devicenumber) + '_pv'
 # pv modus
 pvmodus = 0
 if os.path.isfile(file_stringpv):
-   f = open( file_stringpv , 'r')
-   pvmodus =int(f.read())
-   f.close()
+    with open(file_stringpv, 'r') as f:
+        pvmodus = int(f.read())
 aktpower = 0
 powerc = 0
-answer = '{"power":' + str(aktpower) + ',"powerc":' + str(powerc) + ',"on":' + str(pvmodus) + '} '
-f1 = open('/var/www/html/openWB/ramdisk/smarthome_device_ret' + str(devicenumber), 'w')
-json.dump(answer,f1)
-f1.close() 
+answer = '{"power":' + str(aktpower) + ',"powerc":' + str(powerc) + ',"on":' + str(pvmodus) + '}'
+writeret(answer, devicenumber)

--- a/packages/smarthome/smartlog.py
+++ b/packages/smarthome/smartlog.py
@@ -1,7 +1,7 @@
 import logging
 
 
-def initlog(name, devicenumber):
+def initlog(name: str, devicenumber: int) -> None:
     log = logging.getLogger(name)
     formatter = logging.Formatter('%(asctime)s %(levelname)s %(message)s')
     log.setLevel(logging.DEBUG)

--- a/packages/smarthome/smartret.py
+++ b/packages/smarthome/smartret.py
@@ -1,0 +1,8 @@
+import json
+
+
+def writeret(jsonstr: str, devicenumber: int) -> None:
+    fname = '/var/www/html/openWB/ramdisk/smarthome_device_ret'
+    fname += str(devicenumber)
+    with open(fname, 'w') as f1:
+        json.dump(jsonstr, f1)

--- a/runs/mqttsub.py
+++ b/runs/mqttsub.py
@@ -539,7 +539,7 @@ def on_message(client, userdata, msg):
                 else:
                     print( "invalid payload for topic '" + msg.topic + "': " + msg.payload.decode("utf-8"))
             if (msg.topic == "openWB/config/set/SmartHome/maxBatteryPower"):
-                if (0 <= int(msg.payload) <= 10000):
+                if (0 <= int(msg.payload) <= 30000):
                     f = open('/var/www/html/openWB/ramdisk/smarthomehandlermaxbatterypower', 'w')
                     f.write(msg.payload.decode("utf-8"))
                     f.close()

--- a/runs/usmarthome/smartnxdacxx.py
+++ b/runs/usmarthome/smartnxdacxx.py
@@ -1,21 +1,22 @@
 #!/usr/bin/python3
 from usmarthome.smartbase import Sbase
 from usmarthome.global0 import log
+from typing import Dict
 import subprocess
 
 
 class Snxdacxx(Sbase):
-    def __init__(self):
+    def __init__(self) -> None:
         # setting
         super().__init__()
         print('__init__ Snxdacxx executed')
-        self._smart_paramadd = {}
+        self._smart_paramadd = {}  # type: dict [str,str]
         self._device_nxdacxxueb = 0
         self._device_nxdacxxtype = 0
         self.device_nummer = 0
         self._dynregel = 1
 
-    def updatepar(self, input_param):
+    def updatepar(self, input_param: Dict[str, str]) -> None:
         super().updatepar(input_param)
         self._smart_paramadd = input_param.copy()
         self.device_nummer = int(self._smart_paramadd.get('device_nummer',
@@ -33,10 +34,10 @@ class Snxdacxx(Sbase):
                 self._device_nxdacxxtype = valueint
             else:
                 log.warning("(" + str(self.device_nummer) + ") " +
-                            __class__.__name__ + " überlesen " + key +
+                            "Snxdacxx überlesen " + key +
                             " " + value)
 
-    def getwatt(self, uberschuss, uberschussoffset):
+    def getwatt(self, uberschuss: int, uberschussoffset: int) -> None:
         self.prewatt(uberschuss, uberschussoffset)
         forcesend = self.checkbefsend()
         argumentList = ['python3', self._prefixpy + 'nxdacxx/watt.py',
@@ -60,7 +61,7 @@ class Snxdacxx(Sbase):
                            str(self._device_ip), str(e1)))
         self.postwatt()
 
-    def turndevicerelais(self, zustand, ueberschussberechnung, updatecnt):
+    def turndevicerelais(self, zustand: int, ueberschussberechnung: int, updatecnt: int) -> None:
         self.preturn(zustand, ueberschussberechnung, updatecnt)
         if (zustand == 1):
             pname = "/on.py"
@@ -68,7 +69,9 @@ class Snxdacxx(Sbase):
             pname = "/off.py"
         argumentList = ['python3', self._prefixpy + 'nxdacxx' + pname,
                         str(self.device_nummer), str(self._device_ip),
-                        str(self.devuberschuss)]
+                        str(self.devuberschuss),
+                        str(self._device_dacport),
+                        str(self._device_nxdacxxtype)]
         try:
             self.proc = subprocess.Popen(argumentList)
             self.proc.communicate()

--- a/web/settings/smarthomeconfig.php
+++ b/web/settings/smarthomeconfig.php
@@ -85,7 +85,7 @@ $numDevices = 9;
 											<option value="lambda" data-option="lambda">Lambda</option>
 											<option value="elwa" data-option="elwa">Elwa</option>
 											<option value="idm" data-option="idm">Idm</option>
-											<option value="NXDACXX" data-option="NXDACXX"> DAC 0.01V bis 10.0V</option>
+											<option value="NXDACXX" data-option="NXDACXX">DAC 0.01V bis 10.0V</option>
 											<option value="stiebel" data-option="stiebel">Stiebel</option>
 											<option value="ratiotherm" data-option="ratiotherm">Ratiotherm</option>
 											<option value="vampair" data-option="vampair">Vampair</option>
@@ -133,8 +133,8 @@ $numDevices = 9;
 										</span>
 										<span class="form-text small device<?php echo $devicenum; ?>-option device<?php echo $devicenum; ?>-option-NXDACXX hide">
 											DAC angesteuert über Lan. Der anliegende Überschuss wird in eine Voltzahl zwischen 0.01V und 10.0V umgewandelt. Bezug wird als 0 Volt übertragen.
-											Wenn die Einschaltbedingung erreicht ist wird alle 30 Sekunden der gerechnete Überschuss übertragen.<br>
-											Der konkrete Dac Typ wird im Type definiert<br>
+											Wenn die Einschaltbedingung erreicht ist, wird alle 30 Sekunden der gerechnete Überschuss übertragen.<br>
+											Der konkrete DAC Typ wird im Type definiert.<br>
 											Mit dem Parameter Updategerät kann eine abweichende Sekundenzahl angegeben werden.<br>
 											</span>
 											<span class="form-text small device<?php echo $devicenum; ?>-option device<?php echo $devicenum; ?>-option-ratiotherm hide">
@@ -227,15 +227,16 @@ $numDevices = 9;
 									<label for="device_nxdacxxuebDevices<?php echo $devicenum; ?>" class="col-md-4 col-form-label">Maximaler Überschuss</label>
 									<div class="col">
 										<input id="device_nxdacxxuebDevices<?php echo $devicenum; ?>" name="device_nxdacxxueb" class="form-control naturalNumber" type="number" inputmode="decimal" required min="0" max="32000" data-default="0" value="0" data-topicprefix="openWB/config/get/SmartHome/" data-topicsubgroup="Devices/<?php echo $devicenum; ?>/">
-										<span class="form-text small">Maximaler Überschuss in Watt = v10.0. Es wird kein grösserer Wert übertragen.</span>
+										<span class="form-text small">Maximal verwertbarer Überschuss des hier gewählten Gerät in Watt = v10.0. Es wird kein grösserer Wert übertragen.</span>
 									</div>
 								</div>
 									<div class="form-row mb-1">
-										<label for="device_nxdacxxtypeDevices<?php echo $devicenum; ?>" class="col-md-4 col-form-label">Dac Typ</label>
+										<label for="device_nxdacxxtypeDevices<?php echo $devicenum; ?>" class="col-md-4 col-form-label">DAC Typ</label>
 										<div class="col">
 											<select class="form-control" name="device_nxdacxxtype" id="device_nxdacxxtypeDevices<?php echo $devicenum; ?>" data-default="" data-topicprefix="openWB/config/get/SmartHome/" data-topicsubgroup="Devices/<?php echo $devicenum; ?>/">
 												<option value="0" data-option="0">N4Dac02</option>
 												<option value="1" data-option="1">DA02</option>
+												<option value="2" data-option="2">M120T von Pigeon</option>
 											</select>
 											<span class="form-text small">
 												Hier ist das installierte Modell auszuwählen.
@@ -243,7 +244,7 @@ $numDevices = 9;
 										</div>
 									</div>
 								<div class="form-row mb-1">
-									<label for="device_dacportDevices<?php echo $devicenum; ?>" class="col-md-4 col-form-label">Modbusport des Dac</label>
+									<label for="device_dacportDevices<?php echo $devicenum; ?>" class="col-md-4 col-form-label">Modbusport des DAC</label>
 									<div class="col">
 										<input id="device_dacportDevices<?php echo $devicenum; ?>" name="device_dacport" class="form-control naturalNumber" type="number" inputmode="decimal" required min="1" max="9999" data-default="8899" value="8899"  data-topicprefix="openWB/config/get/SmartHome/" data-topicsubgroup="Devices/<?php echo $devicenum; ?>/">
 										<span class="form-text small">
@@ -722,7 +723,7 @@ $numDevices = 9;
 												<input type="radio" name="device_homeConsumtionDevices<?php echo $devicenum; ?>" id="device_homeConsumtion<?php echo $devicenum; ?>1" data-option="1" value="1">Ja
 											</label>
 										</div>
-										<span class="form-text small">Diese Option sorgt dafür, dass das Gerät zusätzlich in den Hausverbrauch eingerechnet wird (Startseite, neues logging).</span>
+										<span class="form-text small">Bei Nein wird dass das Gerät vom Hausverbrauch abgezogen, bei Ja ist es im Hausverbrauch eingerechnet. (Startseite, neues logging).</span>
 									</div>
 								</div>
 							</div>
@@ -926,7 +927,7 @@ $numDevices = 9;
 								<div class="form-row mb-1">
 									<label for="maxBatteryPower" class="col-md-4 col-form-label">maximale Speicherladung in W</label>
 									<div class="col">
-										<input id="maxBatteryPower" name="maxBatteryPower" class="form-control naturalNumber" type="number" required="required" min="0" max="10000" value="0" data-default="0" data-topicprefix="openWB/config/get/SmartHome/">
+										<input id="maxBatteryPower" name="maxBatteryPower" class="form-control naturalNumber" type="number" required="required" min="0" max="30000" value="0" data-default="0" data-topicprefix="openWB/config/get/SmartHome/">
 									</div>
 								</div>
 							</div>


### PR DESCRIPTION
HTTP Gerät:
Es wurde auf Python Log umgestellt.
Es wurde im on / off trigger ein Browser Header genommen. Es wurde auf static Types umgestellt.
Dac Gerät:
Es wurde auf Python Log umgestellt.
Neuer Dac typ M120T von Pigeon
Es wurde auf static Types umgestellt.
Ratiotherm WP
Es wurde auf Python Log umgestellt.
Es wurde auf static Types umgestellt.
Stiebel WP
Es wurde auf Python Log umgestellt.
Es wurde auf static Types umgestellt.
Smarthome Config 2.0
Maximaler Speicherladung 30'000
Textkorrektur bei DAC
J/N Hausverbrauch  besser erklärt