### PR TITLE
Add VIN selector to SoC PSA

### DIFF
--- a/modules/soc_psa/main.sh
+++ b/modules/soc_psa/main.sh
@@ -34,6 +34,7 @@ case $CHARGEPOINT in
 		password=$psa_passlp2
 		clientId=$psa_clientidlp2
 		clientSecret=$psa_clientsecretlp2
+		vehicleId=$psa_vinlp2
 		soccalc=$psa_soccalclp2
 		manufacturer=$psa_manufacturerlp2
 		socOnlineIntervall=$psa_intervallp2
@@ -59,6 +60,7 @@ case $CHARGEPOINT in
 		password=$psa_passlp1
 		clientId=$psa_clientidlp1
 		clientSecret=$psa_clientsecretlp1
+		vehicleId=$psa_vinlp1
 		soccalc=$psa_soccalclp1
 		manufacturer=$psa_manufacturerlp1
 		socOnlineIntervall=$psa_intervallp1
@@ -100,7 +102,7 @@ if (($soccalc == 0)); then #manual calculation not enabled, using existing logic
 		incrementTimer
 	else
 		echo 0 > $soctimerfile
-		sudo python $MODULEDIR/psasoc.py $CHARGEPOINT $username $password $clientId $clientSecret $manufacturer $soccalc
+		sudo python $MODULEDIR/psasoc.py $CHARGEPOINT $username $password $clientId $clientSecret $manufacturer $soccalc $vehicleId
 		if [[ $? == 0 ]]; then
 			openwbDebugLog ${DMOD} 0 "Lp$CHARGEPOINT: Fetched from $manufacturer: $(<$psaSocFile)%"
 		else
@@ -113,7 +115,7 @@ else	# manual calculation enabled, combining PSA module with manual calc method
 		openwbDebugLog ${DMOD} 0 "Lp$CHARGEPOINT: Charging started. Fetching SoC from $manufacturer out of order."
 		soctimer=0
 		echo 0 > $soctimerfile
-		sudo python $MODULEDIR/psasoc.py $CHARGEPOINT $username $password $clientId $clientSecret $manufacturer $soccalc
+		sudo python $MODULEDIR/psasoc.py $CHARGEPOINT $username $password $clientId $clientSecret $manufacturer $soccalc $vehicleId
 		if [[ $? == 0 ]]; then
 			echo $(<$psaSocFile) > $socFile
 			echo $(<$psaSocFile) > $manualSocFile
@@ -132,7 +134,7 @@ else	# manual calculation enabled, combining PSA module with manual calc method
 		else
 			openwbDebugLog ${DMOD} 0 "Lp$CHARGEPOINT: Fetching SoC from $manufacturer"
 			echo 0 > $soctimerfile
-			sudo python $MODULEDIR/psasoc.py $CHARGEPOINT $username $password $clientId $clientSecret $manufacturer $soccalc
+			sudo python $MODULEDIR/psasoc.py $CHARGEPOINT $username $password $clientId $clientSecret $manufacturer $soccalc $vehicleId
 			if [[ $? == 0 ]]; then
 				# if fetched SoC is equal from last used fetched SoC and car is plugged in
 				if [[ $(<$psaSocFile) == $(<$psaSocFile_last) ]] && [[ $(($(<$plugstat))) == 1 ]]; then

--- a/modules/soc_psa/main.sh
+++ b/modules/soc_psa/main.sh
@@ -102,7 +102,7 @@ if (($soccalc == 0)); then #manual calculation not enabled, using existing logic
 		incrementTimer
 	else
 		echo 0 > $soctimerfile
-		sudo python $MODULEDIR/psasoc.py $CHARGEPOINT $username $password $clientId $clientSecret $manufacturer $soccalc $vehicleId
+		sudo python "$MODULEDIR/psasoc.py" "$CHARGEPOINT" "$username" "$password" "$clientId" "$clientSecret" "$manufacturer" "$soccalc" "$vehicleId"
 		if [[ $? == 0 ]]; then
 			openwbDebugLog ${DMOD} 0 "Lp$CHARGEPOINT: Fetched from $manufacturer: $(<$psaSocFile)%"
 		else
@@ -115,7 +115,7 @@ else	# manual calculation enabled, combining PSA module with manual calc method
 		openwbDebugLog ${DMOD} 0 "Lp$CHARGEPOINT: Charging started. Fetching SoC from $manufacturer out of order."
 		soctimer=0
 		echo 0 > $soctimerfile
-		sudo python $MODULEDIR/psasoc.py $CHARGEPOINT $username $password $clientId $clientSecret $manufacturer $soccalc $vehicleId
+		sudo python "$MODULEDIR/psasoc.py" "$CHARGEPOINT" "$username" "$password" "$clientId" "$clientSecret" "$manufacturer" "$soccalc" "$vehicleId"
 		if [[ $? == 0 ]]; then
 			echo $(<$psaSocFile) > $socFile
 			echo $(<$psaSocFile) > $manualSocFile
@@ -134,7 +134,7 @@ else	# manual calculation enabled, combining PSA module with manual calc method
 		else
 			openwbDebugLog ${DMOD} 0 "Lp$CHARGEPOINT: Fetching SoC from $manufacturer"
 			echo 0 > $soctimerfile
-			sudo python $MODULEDIR/psasoc.py $CHARGEPOINT $username $password $clientId $clientSecret $manufacturer $soccalc $vehicleId
+			sudo python "$MODULEDIR/psasoc.py" "$CHARGEPOINT" "$username" "$password" "$clientId" "$clientSecret" "$manufacturer" "$soccalc" "$vehicleId"
 			if [[ $? == 0 ]]; then
 				# if fetched SoC is equal from last used fetched SoC and car is plugged in
 				if [[ $(<$psaSocFile) == $(<$psaSocFile_last) ]] && [[ $(($(<$plugstat))) == 1 ]]; then

--- a/modules/soc_psa/psasoc.py
+++ b/modules/soc_psa/psasoc.py
@@ -34,6 +34,7 @@ client_id=str(sys.argv[4])
 client_secret=str(sys.argv[5])
 manufacturer=str(sys.argv[6])
 soccalc=str(sys.argv[7])
+vehicleId=str(sys.argv[8])
 
 named_tuple = time.localtime() # get struct_time
 time_string = time.strftime("%m/%d/%Y, %H:%M:%S psasoc lp"+chargepoint, named_tuple)
@@ -93,8 +94,17 @@ f.write(responsetext.encode("utf-8"))
 f.write(str(responestatus))
 f.close()
 vin_list = json.loads(responsetext)
-vin_id  = vin_list ['_embedded']['vehicles'][0]['id']
-vin_vin  = vin_list ['_embedded']['vehicles'][0]['vin']
+
+# search for entry of entered VIN
+vin_selected = filter(lambda x: x['vin'] == vehicleId, vin_list['_embedded']['vehicles'])
+vin_id = vin_selected [0]['id']
+vin_vin = vin_selected [0]['vin']
+
+f = open('/var/www/html/openWB/ramdisk/psareply2filterVINlp'+chargepoint, 'w')
+f.write('VIN: ' + str(vin_vin))
+f.write(', ID: ' + str(vin_id))
+f.close()
+
 payload = {'client_id':client_id}
 data = urllib.urlencode(payload) 
 data = data.encode('Big5')

--- a/modules/soc_psa/psasoc.py
+++ b/modules/soc_psa/psasoc.py
@@ -34,7 +34,11 @@ client_id=str(sys.argv[4])
 client_secret=str(sys.argv[5])
 manufacturer=str(sys.argv[6])
 soccalc=str(sys.argv[7])
-vehicleId=str(sys.argv[8])
+
+# VehicleId is optional
+vehicleId = False
+if (len(sys.argv) > 8 ):
+	vehicleId=str(sys.argv[8])
 
 named_tuple = time.localtime() # get struct_time
 time_string = time.strftime("%m/%d/%Y, %H:%M:%S psasoc lp"+chargepoint, named_tuple)
@@ -95,10 +99,16 @@ f.write(str(responestatus))
 f.close()
 vin_list = json.loads(responsetext)
 
-# search for entry of entered VIN
-vin_selected = filter(lambda x: x['vin'] == vehicleId, vin_list['_embedded']['vehicles'])
-vin_id = vin_selected [0]['id']
-vin_vin = vin_selected [0]['vin']
+# if VIN is not given, first car will be selected:
+if not vehicleId:
+    vin_id = vin_list ['_embedded']['vehicles'][0]['id']
+    vin_vin = vin_list ['_embedded']['vehicles'][0]['vin']
+
+else:
+    # search for entry of given VIN
+    vin_selected = filter(lambda x: x['vin'] == vehicleId, vin_list['_embedded']['vehicles'])
+    vin_id = vin_selected [0]['id']
+    vin_vin = vin_selected [0]['vin']
 
 f = open('/var/www/html/openWB/ramdisk/psareply2filterVINlp'+chargepoint, 'w')
 f.write('VIN: ' + str(vin_vin))

--- a/modules/soc_psa/psasoc.py
+++ b/modules/soc_psa/psasoc.py
@@ -9,6 +9,7 @@ import urllib
 import requests
 import base64
 import logging
+
 #these two lines enable debugging at httplib level (requests->urllib3->http.client)
 # You will see the REQUEST, including HEADERS and DATA, and RESPONSE with HEADERS but without DATA.
 # The only thing missing will be the response.body which is not logged.
@@ -16,6 +17,7 @@ try:
     import http.client as http_client
 except ImportError: # Python 2
     import httplib as http_client
+
 # to enable http trace set swbedug = 1
 swdebug = 0
 if swdebug == 1:
@@ -28,17 +30,17 @@ if swdebug == 1:
    requests_log.propagate = True
 
 chargepoint=str(sys.argv[1])
-userID=str(sys.argv[2])
+user_id=str(sys.argv[2])
 password=str(sys.argv[3])
 client_id=str(sys.argv[4])
 client_secret=str(sys.argv[5])
 manufacturer=str(sys.argv[6])
 soccalc=str(sys.argv[7])
 
-# VehicleId is optional
-vehicleId = False
+# vehicle_vin is optional
+vehicle_vin = False
 if (len(sys.argv) > 8 ):
-	vehicleId=str(sys.argv[8])
+	vehicle_vin=str(sys.argv[8])
 
 named_tuple = time.localtime() # get struct_time
 time_string = time.strftime("%m/%d/%Y, %H:%M:%S psasoc lp"+chargepoint, named_tuple)
@@ -62,88 +64,97 @@ elif (manufacturer == "Opel"):
 elif (manufacturer == "Vauxhall"):
 	brand = 'vauxhall.co.uk'
 	realm = 'clientsB2CVauxhall'
-vin='?'
-data = {'realm': realm,'grant_type':'password','password':password,'username': userID,'scope': scope}
+
+# oAuth2 login
+data = {'realm': realm,'grant_type':'password','password':password,'username': user_id,'scope': scope}
 headers = {'Content-Type':'application/x-www-form-urlencoded','Authorization': 'Basic %s' % encoded_u}
 reg = 'https://idpcvs.' + brand + '/am/oauth2/access_token'
+
 f = open('/var/www/html/openWB/ramdisk/psareq1lp'+chargepoint, 'w')
 f.write(str(reg))
 f.write(str(data))
 f.write(str(headers))
 f.close()
+
 response=requests.post(reg,  data=data, headers=headers )
 responsetext  = response.text
 responestatus = response.status_code
+
 f = open('/var/www/html/openWB/ramdisk/psareply1lp'+chargepoint, 'w')
 f.write(responsetext.encode("utf-8"))
 f.write(str(responestatus))
 f.close()
+
 psa_config = json.loads(responsetext)
 acc_token = psa_config['access_token']
+
+# get Vehicles
 payload = {'client_id':client_id}
 data = urllib.urlencode(payload) 
 data = data.encode('Big5')
 reg = 'https://api.groupe-psa.com/connectedcar/v4/user/vehicles?' + data
 headers = {'Accept':'application/hal+json','Authorization': 'Bearer %s' % acc_token,'x-introspect-realm': realm}
+
 f = open('/var/www/html/openWB/ramdisk/psareq2lp'+chargepoint, 'w')
 f.write(str(reg))
 f.write(str(data))
 f.write(str(headers))
 f.close()
+
 response=requests.get(reg,headers=headers )
-f = open('/var/www/html/openWB/ramdisk/psareply2lp'+chargepoint, 'w')
 responsetext  = response.text
 responestatus = response.status_code
+
+f = open('/var/www/html/openWB/ramdisk/psareply2lp'+chargepoint, 'w')
 f.write(responsetext.encode("utf-8"))
 f.write(str(responestatus))
 f.close()
-vin_list = json.loads(responsetext)
 
-# if VIN is not given, first car will be selected:
-if not vehicleId:
-    vin_id = vin_list ['_embedded']['vehicles'][0]['id']
-    vin_vin = vin_list ['_embedded']['vehicles'][0]['vin']
+vehicle_response = json.loads(responsetext)
+vehicles = vehicle_response['_embedded']['vehicles']
 
-else:
-    # search for entry of given VIN
-    vin_selected = filter(lambda x: x['vin'] == vehicleId, vin_list['_embedded']['vehicles'])
-    vin_id = vin_selected [0]['id']
-    vin_vin = vin_selected [0]['vin']
+# Filter List for given VIN or select first entry
+vehicle_selected = next(vehicle for vehicle in vehicles if vehicle['vin'] == vehicle_vin) if vehicle_vin else vehicles[0]
+vehicle_id = vehicle_selected['id']
 
 f = open('/var/www/html/openWB/ramdisk/psareply2filterVINlp'+chargepoint, 'w')
-f.write('VIN: ' + str(vin_vin))
-f.write(', ID: ' + str(vin_id))
+f.write('VIN: ' + str(vehicle_selected['vin']))
+f.write(', ID: ' + str(vehicle_id))
 f.close()
 
+# get Vehicles Status
 payload = {'client_id':client_id}
 data = urllib.urlencode(payload) 
 data = data.encode('Big5')
 '/user/vehicles/{id}/status'
-reg = 'https://api.groupe-psa.com/connectedcar/v4/user/vehicles/'  + vin_id + '/status?' + data
+reg = 'https://api.groupe-psa.com/connectedcar/v4/user/vehicles/'  + vehicle_id + '/status?' + data
 headers = {'Accept':'application/hal+json','Authorization': 'Bearer %s' % acc_token,'x-introspect-realm': realm}
+
 f = open('/var/www/html/openWB/ramdisk/psareq3lp'+chargepoint, 'w')
 f.write(str(reg))
 f.write(str(data))
 f.write(str(headers))
 f.close()
+
 response=requests.get(reg,headers=headers )
-f = open('/var/www/html/openWB/ramdisk/psareply3lp'+chargepoint, 'w')
 responsetext  = response.text
 responestatus = response.status_code
+
+f = open('/var/www/html/openWB/ramdisk/psareply3lp'+chargepoint, 'w')
 f.write(responsetext.encode("utf-8"))
 f.write(str(responestatus))
 f.close()
-batt = json.loads(responsetext)
 
-# filter to only include type=Electric but remove all others. Seen type=Fuel and type=Electric being returned.
-batt = filter(lambda x: x['type'] == 'Electric', batt['energy'])
-soc = batt[0]['level']
+status_response = json.loads(responsetext)
+energies = status_response['energy']
 
-#soc = batt['energy'][0]['level']
-#print(time_string,'soc lp'+chargepoint,soc)
+# Filter to only include type=Electric but remove all others. Seen type=Fuel and type=Electric being returned.
+energy_selected = next(energy for energy in energies if energy['type'] == 'Electric')
+soc = energy_selected['level']
+fetchedsoctime = energy_selected['updatedAt']
 
 if (int(soccalc) == 0):
-	#manual calculation not enabled, using existing logic
+	# manual calculation not enabled, using existing logic
 	if (int(chargepoint) == 1):
 		f = open('/var/www/html/openWB/ramdisk/soc', 'w')
 	if (int(chargepoint) == 2):
@@ -151,7 +162,7 @@ if (int(soccalc) == 0):
 	f.write(str(soc))
 	f.close()
 else:
-	#manual calculation  enabled, using new logic with timestamp
+	# manual calculation  enabled, using new logic with timestamp
 	if (int(chargepoint) == 1):
 		f = open('/var/www/html/openWB/ramdisk/psasoc', 'w')
 	if (int(chargepoint) == 2):
@@ -159,7 +170,6 @@ else:
 	f.write(str(soc))
 	f.close()
 	# getting timestamp of fetched SoC
-	fetchedsoctime = batt[0]['updatedAt']
 	soct = time.strptime(fetchedsoctime, "%Y-%m-%dT%H:%M:%SZ")
 	soctime = time.mktime(soct)
 	# adding one hour to UTC to get CET

--- a/runs/updateConfig.sh
+++ b/runs/updateConfig.sh
@@ -2063,6 +2063,12 @@ updateConfig(){
 	if ! grep -Fq "psa_manufacturerlp2=" $ConfigFile; then
 		echo "psa_manufacturerlp2=Peugeot" >> $ConfigFile
 	fi
+	if ! grep -Fq "psa_vinlp1=" $ConfigFile; then
+		echo "psa_vinlp1=''" >> $ConfigFile
+	fi
+	if ! grep -Fq "psa_vinlp2=" $ConfigFile; then
+		echo "psa_vinlp2=''" >> $ConfigFile
+	fi  
 	if ! grep -Fq "soc_eq_client_id_lp1=" $ConfigFile; then
 		{
 			echo "soc_eq_client_id_lp1=ID"

--- a/runs/updateConfig.sh
+++ b/runs/updateConfig.sh
@@ -1834,7 +1834,7 @@ updateConfig(){
 		echo "slaveModeSlowRamping=1" >> $ConfigFile
 	fi
 	if ! grep -Fq "slaveModeMinimumAdjustmentInterval=" $ConfigFile; then
-    	echo "slaveModeMinimumAdjustmentInterval=15" >> $ConfigFile
+		echo "slaveModeMinimumAdjustmentInterval=15" >> $ConfigFile
 	fi
 	if ! grep -Fq "standardSocketInstalled=" /var/www/html/openWB/openwb.conf
 	then

--- a/web/settings/modulconfiglp.php
+++ b/web/settings/modulconfiglp.php
@@ -1844,6 +1844,9 @@
 										<label for="psa_vinlp1" class="col-md-4 col-form-label">VIN</label>
 										<div class="col">
 											<input class="form-control" type="text" name="psa_vinlp1" id="psa_vinlp1" value="<?php echo $psa_vinlp1old ?>">
+											<span class="form-text small">
+												VIN des gewünschten Fahrzeugs. Wird keine VIN angegeben, wird das erste Fahrzeug aus dem Account verwendet.
+											</span>
 										</div>
 									</div>
 									<div class="form-row mb-1">
@@ -3542,6 +3545,9 @@
 										<label for="psa_vinlp2" class="col-md-4 col-form-label">VIN</label>
 										<div class="col">
 											<input class="form-control" type="text" name="psa_vinlp2" id="psa_vinlp2" value="<?php echo $psa_vinlp2old ?>">
+											<span class="form-text small">
+												VIN des gewünschten Fahrzeugs. Wird keine VIN angegeben, wird das erste Fahrzeug aus dem Account verwendet.
+											</span>
 										</div>
 									</div>
 									<div class="form-row mb-1">

--- a/web/settings/modulconfiglp.php
+++ b/web/settings/modulconfiglp.php
@@ -1841,6 +1841,12 @@
 										</div>
 									</div>
 									<div class="form-row mb-1">
+										<label for="psa_vinlp1" class="col-md-4 col-form-label">VIN</label>
+										<div class="col">
+											<input class="form-control" type="text" name="psa_vinlp1" id="psa_vinlp1" value="<?php echo $psa_vinlp1old ?>">
+										</div>
+									</div>
+									<div class="form-row mb-1">
 										<label for="psa_intervallp1" class="col-md-4 col-form-label">Abfrageintervall</label>
 										<div class="col">
 											<input class="form-control" type="number" min="1" step="1" name="psa_intervallp1" id="psa_intervallp1" value="<?php echo $psa_intervallp1old ?>">
@@ -3530,6 +3536,12 @@
 										<label for="psa_clientsecretlp2" class="col-md-4 col-form-label">Client-Secret</label>
 										<div class="col">
 											<input class="form-control" type="text" name="psa_clientsecretlp2" id="psa_clientsecretlp2" value="<?php echo $psa_clientsecretlp2old ?>">
+										</div>
+									</div>
+									<div class="form-row mb-1">
+										<label for="psa_vinlp2" class="col-md-4 col-form-label">VIN</label>
+										<div class="col">
+											<input class="form-control" type="text" name="psa_vinlp2" id="psa_vinlp2" value="<?php echo $psa_vinlp2old ?>">
 										</div>
 									</div>
 									<div class="form-row mb-1">


### PR DESCRIPTION
Die aktuelle Implementierung des SoC PSA Moduls unterstützt aktuell nur das erste Fahrzeug im Account.
Ist das gewünsche Fahrzeug nicht an der ersten Stelle, ist ein Auslesen des SOC nicht möglich.

Dieses Ticket fügt die VIN als optionalen Eingabeparameter zur API hinzu.
Wurde eine VIN angegeben, wird der SoC für dieses Fahrzeug abgerufen.

Forum SoC Modul: https://openwb.de/forum/viewtopic.php?p=75190#p75190