### PR TITLE
E3DC als Farm

### DIFF
--- a/packages/modules/e3dc/counter.py
+++ b/packages/modules/e3dc/counter.py
@@ -1,30 +1,41 @@
 #!/usr/bin/env python3
 import logging
-from typing import Tuple, List
-
+from typing import Tuple, List, cast
 from modules.common import modbus
 from modules.common.component_state import CounterState
 from modules.common.component_type import ComponentDescriptor
 from modules.common.fault_state import ComponentInfo
 from modules.common.simcount._simcounter import SimCounter
-from modules.common.modbus import ModbusDataType, Endian
+from modules.common.modbus import ModbusDataType
 from modules.common.store import get_counter_value_store
 from modules.e3dc.config import E3dcCounterSetup
 
 log = logging.getLogger(__name__)
 
 
+def get_meter_phases(id: int, meters: List[int]) -> List[int]:
+    return next(meters[i+1:i+4] for i in reversed(range(0, len(meters), 4)) if meters[i] == id)
+
+
 def read_counter(client: modbus.ModbusTcpClient_) -> Tuple[int, List[int]]:
     log.debug("Beginning EVU update")
-    power = client.read_holding_registers(40073, ModbusDataType.INT_32, wordorder=Endian.Little, unit=1)
     # 40130,40131, 40132 je Phasenleistung in Watt
     # max 7 Leistungsmesser verbaut ab 40105, typ 1 ist evu
     # Modbus dokumentation Leistungsmesser von #0 bis #6
     # bei den meisten e3dc auf 40128
-    meters = client.read_holding_registers(40104, [ModbusDataType.INT_16] * 28, unit=1)
-    log.debug("power: %d, meters: %s", power, meters)
-    powers = next(meters[i+1:i+4] for i in reversed(range(0, len(meters), 4)) if meters[i] == 1)
-    log.debug("powers %s", powers)
+    # farm haben typ 5, normale e3dc haben nur typ 1 und keinen typ 5
+    # bei farm ist typ 1 vorhanden aber liefert immer 0
+    meters = []  # type : List[int]
+    meters = cast(List[int], client.read_holding_registers(40104, [ModbusDataType.INT_16] * 28, unit=1))
+    log.debug("meters: %s", meters)
+    try:
+        powers = get_meter_phases(5, meters)
+        log.debug("e3dc farm detected")
+    except StopIteration:
+        powers = get_meter_phases(1, meters)
+        log.debug("e3dc no farm detected")
+    power = sum(powers)  # power wird nicht mehr über modbus (40073) gelesen , da 0 bei Farm
+    log.debug("power: %d, powers %s", power, powers)
     return power, powers
 
 
@@ -37,13 +48,13 @@ class E3dcCounter:
         self.__store = get_counter_value_store(self.component_config.id)
         self.component_info = ComponentInfo.from_component_config(self.component_config)
 
-    def update(self, client: modbus.ModbusTcpClient_):
+    def update(self, client: modbus.ModbusTcpClient_) -> None:
         power, powers = read_counter(client)
         imported, exported = self.sim_counter.sim_count(power)
         counter_state = CounterState(
             imported=imported,
             exported=exported,
-            powers=powers,
+            powers=cast(List[float], powers),
             power=power
         )
         self.__store.set(counter_state)


### PR DESCRIPTION
Falls E3DC als Farm eingesetzt wird, wird eine anderer Leistungsmetertyp zur EVU Messung eingesetzt (Typ 5). Für normale E3DC Installationen  wird für die EVU Messung Typ 1 eingesetzt. Zusätzlich wird bei der E3DC Farm die Modbus Schnittstelle nicht vollständig durch E3DC versorgt und wird durch das Modul errechnet.