### PR TITLE
HTTP Modul: Akzeptiere leeres Feld, Phasepfade validieren, Code aufräumen und optimieren

### DIFF
--- a/packages/modules/devices/http/api.py
+++ b/packages/modules/devices/http/api.py
@@ -14,7 +14,7 @@ def _request_value(url: str) -> float:
 
 
 def create_request_function(url: str, path: Optional[str]) -> Callable[[], Optional[float]]:
-    if path == "none" or path is None:
+    if path is None:
         return lambda: None
     else:
         return functools.partial(_request_value, url + path)

--- a/packages/modules/devices/http/api.py
+++ b/packages/modules/devices/http/api.py
@@ -1,6 +1,6 @@
 import functools
 import logging
-from typing import Callable, Optional
+from typing import Callable, Optional, Iterable, List
 
 from modules.common import req
 
@@ -18,3 +18,15 @@ def create_request_function(url: str, path: Optional[str]) -> Callable[[], Optio
         return lambda: None
     else:
         return functools.partial(_request_value, url + path)
+
+
+def create_request_function_array(url: str, paths: Iterable[Optional[str]]) -> Callable[[], Optional[List[float]]]:
+    functions = []  # type: List[Callable[[], float]]
+    for path in paths:
+        if path is not None:
+            functions.append(functools.partial(_request_value, url + path))
+        elif functions:
+            raise Exception("Expected all or no paths to be None, got: <%s>" % paths)
+    if functions:
+        return lambda: [function() for function in functions]
+    return lambda: None

--- a/packages/modules/devices/http/api.py
+++ b/packages/modules/devices/http/api.py
@@ -1,32 +1,32 @@
 import functools
 import logging
-from typing import Callable, Optional, Iterable, List
+from typing import Callable, Optional, Iterable, List, TypeVar
 
-from modules.common import req
+from requests import Session
 
 log = logging.getLogger(__name__)
+T = TypeVar('T')
+RequestFunction = Callable[[Session], T]
 
 
-def _request_value(url: str) -> float:
-    response_text = req.get_http_session().get(url, timeout=5).text
-    log.debug("Antwort auf %s: %s", url, response_text)
-    return float(response_text.replace("\n", ""))
+def _request_value(url: str, session: Session) -> float:
+    return float(session.get(url, timeout=5).text.replace("\n", ""))
 
 
-def create_request_function(url: str, path: Optional[str]) -> Callable[[], Optional[float]]:
+def create_request_function(url: str, path: Optional[str]) -> RequestFunction[Optional[float]]:
     if path is None:
-        return lambda: None
+        return lambda _: None
     else:
         return functools.partial(_request_value, url + path)
 
 
-def create_request_function_array(url: str, paths: Iterable[Optional[str]]) -> Callable[[], Optional[List[float]]]:
-    functions = []  # type: List[Callable[[], float]]
+def create_request_function_array(url: str, paths: Iterable[Optional[str]]) -> RequestFunction[Optional[List[float]]]:
+    functions = []  # type: List[RequestFunction[float]]
     for path in paths:
         if path is not None:
             functions.append(functools.partial(_request_value, url + path))
         elif functions:
             raise Exception("Expected all or no paths to be None, got: <%s>" % paths)
     if functions:
-        return lambda: [function() for function in functions]
+        return lambda session: [function(session) for function in functions]
     return lambda: None

--- a/packages/modules/devices/http/api.py
+++ b/packages/modules/devices/http/api.py
@@ -13,7 +13,7 @@ def _request_value(url: str) -> float:
     return float(response_text.replace("\n", ""))
 
 
-def create_request_function(url: str, path: Optional[str]) -> Callable[[], float]:
+def create_request_function(url: str, path: Optional[str]) -> Callable[[], Optional[float]]:
     if path == "none" or path is None:
         return lambda: None
     else:

--- a/packages/modules/devices/http/bat.py
+++ b/packages/modules/devices/http/bat.py
@@ -1,6 +1,8 @@
 #!/usr/bin/env python3
 from typing import Dict, Union
 
+from requests import Session
+
 from dataclass_utils import dataclass_from_dict
 from modules.common.component_state import BatState
 from modules.common.component_type import ComponentDescriptor
@@ -24,16 +26,16 @@ class HttpBat:
         self.__get_exported = create_request_function(url, self.component_config.configuration.exported_path)
         self.__get_soc = create_request_function(url, self.component_config.configuration.soc_path)
 
-    def update(self) -> None:
-        imported = self.__get_imported()
-        exported = self.__get_exported()
-        power = self.__get_power()
+    def update(self, session: Session) -> None:
+        imported = self.__get_imported(session)
+        exported = self.__get_exported(session)
+        power = self.__get_power(session)
         if imported is None or exported is None:
             imported, exported = self.sim_counter.sim_count(power)
 
         bat_state = BatState(
             power=power,
-            soc=self.__get_soc(),
+            soc=self.__get_soc(session),
             imported=imported,
             exported=exported
         )

--- a/packages/modules/devices/http/counter.py
+++ b/packages/modules/devices/http/counter.py
@@ -7,7 +7,7 @@ from modules.common.component_type import ComponentDescriptor
 from modules.common.fault_state import ComponentInfo
 from modules.common.simcount import SimCounter
 from modules.common.store import get_counter_value_store
-from modules.devices.http.api import create_request_function
+from modules.devices.http.api import create_request_function, create_request_function_array
 from modules.devices.http.config import HttpCounterSetup
 
 
@@ -22,22 +22,21 @@ class HttpCounter:
         self.__get_power = create_request_function(url, self.component_config.configuration.power_path)
         self.__get_imported = create_request_function(url, self.component_config.configuration.imported_path)
         self.__get_exported = create_request_function(url, self.component_config.configuration.exported_path)
-        self.__get_currents = [
-            create_request_function(url,
-                                    getattr(self.component_config.configuration, "current_l" + str(i) + "_path"))
-            for i in range(1, 4)
-        ]
+        self.__get_currents = create_request_function_array(url, [
+            component_config.configuration.current_l1_path,
+            component_config.configuration.current_l2_path,
+            component_config.configuration.current_l3_path,
+        ])
 
     def update(self):
         imported = self.__get_imported()
         exported = self.__get_exported()
-        currents = [getter() for getter in self.__get_currents]
         power = self.__get_power()
         if imported is None or exported is None:
             imported, exported = self.sim_counter.sim_count(power)
 
         counter_state = CounterState(
-            currents=None if any(c is None for c in currents) else currents,
+            currents=self.__get_currents(),
             imported=imported,
             exported=exported,
             power=power

--- a/packages/modules/devices/http/counter.py
+++ b/packages/modules/devices/http/counter.py
@@ -28,15 +28,15 @@ class HttpCounter:
             component_config.configuration.current_l3_path,
         ])
 
-    def update(self):
-        imported = self.__get_imported()
-        exported = self.__get_exported()
-        power = self.__get_power()
+    def update(self, session):
+        imported = self.__get_imported(session)
+        exported = self.__get_exported(session)
+        power = self.__get_power(session)
         if imported is None or exported is None:
             imported, exported = self.sim_counter.sim_count(power)
 
         counter_state = CounterState(
-            currents=self.__get_currents(),
+            currents=self.__get_currents(session),
             imported=imported,
             exported=exported,
             power=power

--- a/packages/modules/devices/http/device.py
+++ b/packages/modules/devices/http/device.py
@@ -4,6 +4,7 @@ import re
 from typing import Union, List
 
 from helpermodules.cli import run_using_positional_cli_args
+from modules.common import req
 from modules.common.abstract_device import DeviceDescriptor
 from modules.common.configurable_device import ConfigurableDevice, ComponentFactoryByType, IndependentComponentUpdater
 from modules.devices.http.bat import HttpBat
@@ -25,6 +26,7 @@ def create_device(device_config: HTTP):
     def create_inverter_component(component_config: HttpInverterSetup):
         return HttpInverter(device_config.id, component_config, device_config.configuration.url)
 
+    session = req.get_http_session()
     return ConfigurableDevice(
         device_config=device_config,
         component_factory=ComponentFactoryByType(
@@ -32,7 +34,7 @@ def create_device(device_config: HTTP):
             counter=create_counter_component,
             inverter=create_inverter_component,
         ),
-        component_updater=IndependentComponentUpdater(lambda component: component.update())
+        component_updater=IndependentComponentUpdater(lambda component: component.update(session))
     )
 
 

--- a/packages/modules/devices/http/device.py
+++ b/packages/modules/devices/http/device.py
@@ -41,9 +41,7 @@ def create_paths_dict(**kwargs):
     result = {}
     host_scheme = None
     for key, path in kwargs.items():
-        if path == "none":
-            result[key] = "none"
-        else:
+        if path != "none" and path != "":
             match = regex.search(path)
             if match is None:
                 raise Exception("Invalid URL <" + path + ">: Absolute HTTP or HTTPS URL required")


### PR DESCRIPTION
Dieser PR enthält 4 commits, die sich mit Verbesserungen am HTTP-Modul beschäftigen.

1. Commit: HTTP module: fix return type of `create_request_function`:
    Das ist offenbar ein Fehler, den ich in #2337 reingebracht habe. Vor dem PR konnte das Ergebnis vom Code her nicht `None` sein, von der Signatur her aber schon. Dummerweise hatte ich beides geändert, so dass es wieder nicht passt.
2. Commit: HTTP module: In legacy accept empty path as "none", use configuration default instead of fixed string "none" if option is not set
    Es erscheint mir intuitiver das Feld auf der Konfigurationsseite leer zu lassen statt dort "none" reinzuschreiben. Wie offenbar auch [jemand anderes im Forum](https://openwb.de/forum/viewtopic.php?p=75302#p75302). Mit diesem Commit wird ein leeres Feld genau so behandelt wie "none". Außerdem hat der alte Code bisher in diesem Fall auch den String "none" als Option für die Konfiguration verwendet. Das war auch mal so korrekt, aber seit bb168d0b9ce9028991ca6ef19d92b61f85170bf1 gibt es die Konfigurationsklassen, die Defaultwerte haben und der Defaultwert ist seit dem `None` und nicht mehr `"none"`. Statt dass hier mitzuziehen kam dann in 9a977210676cc68a668ec54d52aa03ba1e0b4c75 support in der API-Funktion hinzu um auch da noch `"none"` zu unterstützen. Das ist unnötig kompliziert. Dieser commit eliminiert das.
3. Commit: HTTP module: for currents validate that all or no phases have a path to avoid surprises that paths are ignored. Analyse paths array at configuration time
    Aktuell ist es so, dass wenn nur ein Teil der Phasen einen Pfad konfiguriert hat, dann werden die konfigurierten Phasen stillschweigend ignoriert. Das ist aber höchstwahrscheinlich ein Versehen vom Nutzer und keine Absicht. Da es noch nichtmal eine Ausgabe im Log gibt hat das das Potential viel unnöltiges Kopfzerbrechen zu bereiten. Dieser commit ändert das ganze so, dass zur Config-time bereits die Pfade analysiert werden und entschieden wird ob das so korrekt ist und wenn ja ob es etwas zum Abrufen gibt oder nicht. In V2 hat diese Verschiebung einen minimalen Performancevorteil, in beiden Versionen ist es nun ein klarer Fehler nur einen Teil der Phasen zu konfigurieren.
4. Commit: HTTP module: use persistent session object in order to benefit from HTTP persistent connection
    Das ist eine reine Performanceoptimierung. Das HTTP-Modul baut in kürzester Zeit bis zu 12 Verbindungen auf und ab. Connection-Pooling ist hier sinnvoll um Ressourcen zu sparen. Das geht aber nur, wenn alle Anfragen das gleiche Sessionobjekt verwenden. Daher wird jetzt für das komplette Modul nur ein Sessionobjekt erzeugt und geteilt.

!Die Änderungen sind noch ungetestet!