### PR TITLE
set interval on debug to 2 Minutes

### DIFF
--- a/modules/soc_eq/main.sh
+++ b/modules/soc_eq/main.sh
@@ -77,7 +77,7 @@ else
 	tmpintervall=$(( 60 * 6 ))
 fi
 if (( socDebug > 0 )); then
-	tmpintervall=6
+	tmpintervall=12
 fi
 
 if (( soctimer < tmpintervall )); then


### PR DESCRIPTION
API documentation says only one request all 2 minutes. As we had Returncode 400 Errors on systems using Debug Level 1 / 2 this is the Change to be in the specification