### PR TITLE
E3DC Farm und anderes....

### DIFF
--- a/packages/modules/devices/e3dc/config.py
+++ b/packages/modules/devices/e3dc/config.py
@@ -11,8 +11,8 @@ class E3dcConfiguration:
 @auto_str
 class E3dc:
     def __init__(self,
-                 name: str = "e3dc",
-                 type: str = "e3dc",
+                 name: str = "E3DC",
+                 type: str = "E3DC",
                  id: int = 0,
                  configuration: E3dcConfiguration = None) -> None:
         self.name = name
@@ -23,14 +23,14 @@ class E3dc:
 
 @auto_str
 class E3dcBatConfiguration:
-    def __init__(self):
+    def __init__(self) -> None:
         pass
 
 
 @auto_str
 class E3dcBatSetup(ComponentSetup[E3dcBatConfiguration]):
     def __init__(self,
-                 name: str = "e3dc Speicher",
+                 name: str = "E3DC Speicher",
                  type: str = "bat",
                  id: int = 0,
                  configuration: E3dcBatConfiguration = None) -> None:
@@ -40,14 +40,14 @@ class E3dcBatSetup(ComponentSetup[E3dcBatConfiguration]):
 
 @auto_str
 class E3dcCounterConfiguration:
-    def __init__(self):
+    def __init__(self) -> None:
         pass
 
 
 @auto_str
 class E3dcCounterSetup(ComponentSetup[E3dcCounterConfiguration]):
     def __init__(self,
-                 name: str = "e3dc Zähler",
+                 name: str = "E3DC Zähler",
                  type: str = "counter",
                  id: int = 0,
                  configuration: E3dcCounterConfiguration = None) -> None:
@@ -57,14 +57,14 @@ class E3dcCounterSetup(ComponentSetup[E3dcCounterConfiguration]):
 
 @auto_str
 class E3dcInverterConfiguration:
-    def __init__(self, read_ext: int = 0):
+    def __init__(self, read_ext: bool = False):
         self.read_ext = read_ext
 
 
 @auto_str
 class E3dcInverterSetup(ComponentSetup[E3dcInverterConfiguration]):
     def __init__(self,
-                 name: str = "E3dc Wechselrichter",
+                 name: str = "E3DC Wechselrichter",
                  type: str = "inverter",
                  id: int = 0,
                  configuration: E3dcInverterConfiguration = None) -> None:

--- a/packages/modules/devices/e3dc/counter.py
+++ b/packages/modules/devices/e3dc/counter.py
@@ -7,24 +7,35 @@ from modules.common.component_state import CounterState
 from modules.common.component_type import ComponentDescriptor
 from modules.common.fault_state import ComponentInfo
 from modules.common.simcount._simcounter import SimCounter
-from modules.common.modbus import ModbusDataType, Endian
+from modules.common.modbus import ModbusDataType
 from modules.common.store import get_counter_value_store
 from modules.devices.e3dc.config import E3dcCounterSetup
 
 log = logging.getLogger(__name__)
 
 
+def get_meter_phases(id: int, meters: List[int]) -> List[int]:
+    return next(meters[i+1:i+4] for i in reversed(range(0, len(meters), 4)) if meters[i] == id)
+
+
 def read_counter(client: modbus.ModbusTcpClient_) -> Tuple[int, List[int]]:
     log.debug("Beginning EVU update")
-    power = client.read_holding_registers(40073, ModbusDataType.INT_32, wordorder=Endian.Little, unit=1)
     # 40130,40131, 40132 je Phasenleistung in Watt
     # max 7 Leistungsmesser verbaut ab 40105, typ 1 ist evu
     # Modbus dokumentation Leistungsmesser von #0 bis #6
     # bei den meisten e3dc auf 40128
-    meters = client.read_holding_registers(40104, [ModbusDataType.INT_16] * 28, unit=1)
-    log.debug("power: %d, meters: %s", power, meters)
-    powers = next(meters[i+1:i+4] for i in reversed(range(0, len(meters), 4)) if meters[i] == 1)
-    log.debug("powers %s", powers)
+    # farm haben typ 5, normale e3dc haben nur typ 1 und keinen typ 5
+    # bei farm ist typ 1 vorhanden aber liefert immer 0
+    meters = list(map(int, client.read_holding_registers(40104, [ModbusDataType.INT_16] * 28, unit=1)))
+    log.debug("meters: %s", meters)
+    try:
+        powers = get_meter_phases(5, meters)
+        log.debug("e3dc farm detected")
+    except StopIteration:
+        powers = get_meter_phases(1, meters)
+        log.debug("e3dc no farm detected")
+    power = sum(powers)  # power wird nicht mehr über modbus (40073) gelesen , da 0 bei Farm
+    log.debug("power: %d, powers %s", power, powers)
     return power, powers
 
 
@@ -37,7 +48,7 @@ class E3dcCounter:
         self.__store = get_counter_value_store(self.component_config.id)
         self.component_info = ComponentInfo.from_component_config(self.component_config)
 
-    def update(self, client: modbus.ModbusTcpClient_):
+    def update(self, client: modbus.ModbusTcpClient_) -> None:
         power, powers = read_counter(client)
         imported, exported = self.sim_counter.sim_count(power)
         counter_state = CounterState(

--- a/packages/modules/devices/e3dc/device.py
+++ b/packages/modules/devices/e3dc/device.py
@@ -68,8 +68,7 @@ def create_legacy_device_config(address: str,
     return device_config
 
 
-def read_legacy_counter(address1: str,
-                        num: int):
+def read_legacy_counter(address1: str, num: int):
     component_config = E3dcCounterSetup(configuration=E3dcCounterConfiguration())
     component_config.id = num
     run_device_legacy(create_legacy_device_config(address1,
@@ -77,7 +76,7 @@ def read_legacy_counter(address1: str,
 
 
 def read_legacy_bat(address1: str,
-                    address2: str, read_ext: int,
+                    address2: str, read_extinput: int,
                     pv_module: str,
                     num: int) -> None:
     # für openwbv19 können mit der bisherigen parametrisierung zwei ip_addressen
@@ -86,9 +85,10 @@ def read_legacy_bat(address1: str,
     # in openwb v2.0 geht nur noch eine IP adresse und die Pv muss
     # separate ausgelesen werden
     addresses = [address for address in [address1, address2] if address != "none"]
+    read_ext = (read_extinput == 1)
     log.debug('e3dc IP-Adresse1: %s', address1)
     log.debug('e3dc IP-Adresse2: %s', address2)
-    log.debug('e3dc read_ext: %d', read_ext)
+    log.debug('e3dc read_ext: %s', read_ext)
     log.debug('e3dc pv_module: %s', pv_module)
     log.debug('e3dc id: %d', num)
     soc = 0   # type: Union[int, float]
@@ -97,12 +97,12 @@ def read_legacy_bat(address1: str,
     pv = 0
     pv_other = pv_module != "none"
     for address in addresses:
-        log.debug("Ip: %s, read_external %d pv_other %s", address, read_ext, pv_other)
+        log.debug("Ip: %s, read_external %s pv_other %s", address, read_ext, pv_other)
         with modbus.ModbusTcpClient_(address, port=502) as client:
             soc_tmp, power_tmp = read_bat(client)
             soc += soc_tmp
             power += power_tmp
-            pv_tmp, pv_external_tmp = read_inverter(client, read_ext)
+            pv_tmp, pv_external_tmp = read_inverter(client,  read_ext)
             pv += pv_tmp
             pv_external += pv_external_tmp
     soc /= len(addresses)

--- a/packages/modules/devices/e3dc/inverter.py
+++ b/packages/modules/devices/e3dc/inverter.py
@@ -15,14 +15,12 @@ from modules.devices.e3dc.config import E3dcInverterSetup
 log = logging.getLogger(__name__)
 
 
-def read_inverter(client: modbus.ModbusTcpClient_, read_ext) -> Tuple[int, int]:
+def read_inverter(client: modbus.ModbusTcpClient_, read_ext: bool) -> Tuple[int, int]:
     # 40067 PV Leistung
-    pv = client.read_holding_registers(40067, ModbusDataType.INT_32,
-                                       wordorder=Endian.Little, unit=1) * -1
-    if read_ext == 1:
+    pv = int(client.read_holding_registers(40067, ModbusDataType.INT_32, wordorder=Endian.Little, unit=1) * -1)
+    if read_ext:
         # 40075 externe PV Leistung
-        pv_external = client.read_holding_registers(40075, ModbusDataType.INT_32,
-                                                    wordorder=Endian.Little, unit=1)
+        pv_external = int(client.read_holding_registers(40075, ModbusDataType.INT_32, wordorder=Endian.Little, unit=1))
     else:
         pv_external = 0
     return pv, pv_external
@@ -45,7 +43,7 @@ class E3dcInverter:
         # nur auslesen wenn als relevant parametrisiert
         # (read_external = 1) , sonst doppelte Auslesung
         # pv -> pv Leistung die direkt an e3dc angeschlossen ist
-        log.debug("read_ext %d", self.component_config.configuration.read_ext)
+        log.debug("read_ext %s", self.component_config.configuration.read_ext)
         log.debug("pv %d pv_external %d", pv, pv_external)
         # pv_other sagt aus, ob WR definiert ist,
         # und dessen PV Leistung auch gilt


### PR DESCRIPTION
Dieser Branch löst folgende Probleme:

E3DC Farm (mit Meter 5 statt Meter 1) wird unterstützt. 
Yanniks Review implementiert (Meters Zuweisung und cast gelöscht)
Lutz Review (E3DC im Namen Gross geschrieben, read_ext als Bool definiert)
ersetzt Branch vollständig #2485 und #2510