### PR TITLE
soc_vwid: fix login issue

### DIFF
--- a/modules/soc_vwid/libvwid.py
+++ b/modules/soc_vwid/libvwid.py
@@ -40,9 +40,13 @@ class vwid:
 				text = text[text.find('\n'):text.rfind('\n')].strip()
 
 				for line in text.split('\n'):
-					(name, val) = line.strip().split(':', 1)
-					val = val.strip('\', ')
-					objects[name] = val
+					try:
+						(name, val) = line.strip().split(':', 1)
+					except Exception:
+						self.log.error("password_form: ignore line: " + line)
+					else:
+						val = val.strip('\', ')
+						objects[name] = val
 
 		json_model = json.loads(objects['templateModel'])
 


### PR DESCRIPTION
Please merge asap.

fix for aan issue since 2022-1124: 
A structure in a response of the login request contains a single "}", which can't be split to a name,value pair.
Added a try-except around the split and ignore such lines.
Tested and works.
