### PR TITLE
E3DC openWB 2.0

### DIFF
--- a/packages/modules/devices/e3dc/config.py
+++ b/packages/modules/devices/e3dc/config.py
@@ -57,8 +57,8 @@ class E3dcCounterSetup(ComponentSetup[E3dcCounterConfiguration]):
 
 @auto_str
 class E3dcInverterConfiguration:
-    def __init__(self, read_ext: bool = False):
-        self.read_ext = read_ext
+    def __init__(self) -> None:
+        pass
 
 
 @auto_str
@@ -69,3 +69,19 @@ class E3dcInverterSetup(ComponentSetup[E3dcInverterConfiguration]):
                  id: int = 0,
                  configuration: E3dcInverterConfiguration = None) -> None:
         super().__init__(name, type, id, configuration or E3dcInverterConfiguration())
+
+
+@auto_str
+class E3dcExternalInverterConfiguration:
+    def __init__(self) -> None:
+        pass
+
+
+@auto_str
+class E3dcExternalInverterSetup(ComponentSetup[E3dcExternalInverterConfiguration]):
+    def __init__(self,
+                 name: str = "E3DC externer Wechselrichter",
+                 type: str = "external_inverter",
+                 id: int = 0,
+                 configuration: E3dcExternalInverterConfiguration = None) -> None:
+        super().__init__(name, type, id, configuration or E3dcExternalInverterConfiguration())

--- a/packages/modules/devices/e3dc/device.py
+++ b/packages/modules/devices/e3dc/device.py
@@ -8,11 +8,12 @@ from modules.common.configurable_device import ConfigurableDevice, ComponentFact
 from modules.common import modbus
 from modules.devices.e3dc.bat import E3dcBat, read_bat
 from modules.devices.e3dc.inverter import E3dcInverter, read_inverter
+from modules.devices.e3dc.external_inverter import E3dcExternalInverter, read_externalinverter
 from modules.devices.e3dc.counter import E3dcCounter
 from modules.devices.e3dc.config import E3dc, E3dcConfiguration
 from modules.devices.e3dc.config import E3dcBatSetup
 from modules.devices.e3dc.config import E3dcCounterSetup, E3dcCounterConfiguration
-from modules.devices.e3dc.config import E3dcInverterSetup
+from modules.devices.e3dc.config import E3dcInverterSetup, E3dcExternalInverterSetup
 from modules.common.store.ramdisk import files
 from modules.common.simcount import sim_count
 from modules.common.store import get_inverter_value_store, get_bat_value_store
@@ -22,20 +23,25 @@ from modules.common.component_state import InverterState, BatState
 log = logging.getLogger(__name__)
 
 
-def create_device(device_config: E3dc):
-    def create_bat_component(component_config: E3dcBatSetup):
+def create_device(device_config: E3dc) -> ConfigurableDevice:
+    def create_bat_component(component_config: E3dcBatSetup) -> E3dcBat:
         return E3dcBat(device_config.id,
                        component_config)
 
-    def create_counter_component(component_config: E3dcCounterSetup):
+    def create_counter_component(component_config: E3dcCounterSetup) -> E3dcCounter:
         return E3dcCounter(device_config.id,
                            component_config)
 
-    def create_inverter_component(component_config: E3dcInverterSetup):
+    def create_inverter_component(component_config: E3dcInverterSetup) -> E3dcInverter:
         return E3dcInverter(device_config.id,
                             component_config)
 
-    def update_components(components: Iterable[Union[E3dcBat, E3dcCounter, E3dcInverter]]):
+    def create_external_inverter_component(component_config: E3dcExternalInverterSetup) -> E3dcExternalInverter:
+        return E3dcExternalInverter(device_config.id,
+                                    component_config)
+
+    def update_components(components: Iterable[Union[E3dcBat, E3dcCounter, E3dcInverter,
+                                                     E3dcExternalInverter]]) -> None:
         with modbus.ModbusTcpClient_(device_config.configuration.address, 502) as client:
             log.debug('reading: %s', device_config.configuration.address)
             for component in components:
@@ -48,12 +54,14 @@ def create_device(device_config: E3dc):
             bat=create_bat_component,
             counter=create_counter_component,
             inverter=create_inverter_component,
+            external_inverter=create_external_inverter_component
         ),
         component_updater=update_components
     )
 
 
-def run_device_legacy(device_config: E3dc, component_config: Union[E3dcBatSetup, E3dcCounterSetup, E3dcBatSetup]):
+def run_device_legacy(device_config: E3dc,
+                      component_config: Union[E3dcBatSetup, E3dcCounterSetup, E3dcBatSetup]) -> None:
     device = create_device(device_config)
     device.add_component(component_config)
     log.debug("E3dc Configuration: %s, Component Configuration: %s", device_config, component_config)
@@ -68,7 +76,7 @@ def create_legacy_device_config(address: str,
     return device_config
 
 
-def read_legacy_counter(address1: str, num: int):
+def read_legacy_counter(address1: str, num: int) -> None:
     component_config = E3dcCounterSetup(configuration=E3dcCounterConfiguration())
     component_config.id = num
     run_device_legacy(create_legacy_device_config(address1,
@@ -102,7 +110,11 @@ def read_legacy_bat(address1: str,
             soc_tmp, power_tmp = read_bat(client)
             soc += soc_tmp
             power += power_tmp
-            pv_tmp, pv_external_tmp = read_inverter(client,  read_ext)
+            pv_tmp = read_inverter(client)
+            if read_ext:
+                pv_external_tmp = read_externalinverter(client)
+            else:
+                pv_external_tmp = 0
             pv += pv_tmp
             pv_external += pv_external_tmp
     soc /= len(addresses)
@@ -124,7 +136,7 @@ def read_legacy_bat(address1: str,
     get_inverter_value_store(num).set(InverterState(exported=exported_pv, power=pv_total))
 
 
-def main(argv: List[str]):
+def main(argv: List[str]) -> None:
     run_using_positional_cli_args(
         {"bat": read_legacy_bat, "counter": read_legacy_counter}, argv
     )

--- a/packages/modules/devices/e3dc/external_inverter.py
+++ b/packages/modules/devices/e3dc/external_inverter.py
@@ -8,22 +8,22 @@ from modules.common.modbus import ModbusDataType, Endian
 from modules.common.fault_state import ComponentInfo
 from modules.common.store import get_inverter_value_store
 from modules.common.simcount._simcounter import SimCounter
-from modules.devices.e3dc.config import E3dcInverterSetup
+from modules.devices.e3dc.config import E3dcExternalInverterSetup
 
 
 log = logging.getLogger(__name__)
 
 
-def read_inverter(client: modbus.ModbusTcpClient_) -> int:
-    # 40067 PV Leistung
-    pv = int(client.read_holding_registers(40067, ModbusDataType.INT_32, wordorder=Endian.Little, unit=1) * -1)
-    return pv
+def read_externalinverter(client: modbus.ModbusTcpClient_) -> int:
+    # 40075 externe PV Leistung
+    pv_external = int(client.read_holding_registers(40075, ModbusDataType.INT_32, wordorder=Endian.Little, unit=1))
+    return pv_external
 
 
-class E3dcInverter:
+class E3dcExternalInverter:
     def __init__(self,
                  device_id: int,
-                 component_config: E3dcInverterSetup) -> None:
+                 component_config: E3dcExternalInverterSetup) -> None:
         self.component_config = component_config
         self.sim_counter = SimCounter(device_id, self.component_config.id, prefix="pv")
         self.__store = get_inverter_value_store(self.component_config.id)
@@ -31,15 +31,17 @@ class E3dcInverter:
 
     def update(self, client: modbus.ModbusTcpClient_) -> None:
 
-        pv = read_inverter(client)
+        pv_external = read_externalinverter(client)
+        # pv_external - > pv Leistung
+        # die als externe Produktion an e3dc angeschlossen ist
         # Im gegensatz zu v1.9 implementierung wird nicht mehr die PV
         # leistung vom WR1 gelesen, da die durch v2.0 separat gehandelt wird
-        _, pv_exported = self.sim_counter.sim_count(pv)
+        _, pv_exported = self.sim_counter.sim_count(pv_external)
         inverter_state = InverterState(
-            power=pv,
+            power=pv_external,
             exported=pv_exported
         )
         self.__store.set(inverter_state)
 
 
-component_descriptor = ComponentDescriptor(configuration_factory=E3dcInverterSetup)
+component_descriptor = ComponentDescriptor(configuration_factory=E3dcExternalInverterSetup)


### PR DESCRIPTION
Inverter Klasse in Inverter und External_inverter aufgetrennt. Read_ext nur noch für V1.9 verwendet