### PR TITLE
Elwa und ndac type 2

### DIFF
--- a/modules/smarthome/elwa/off.py
+++ b/modules/smarthome/elwa/off.py
@@ -1,48 +1,20 @@
 #!/usr/bin/python3
 import sys
-import os
-import time
-import json
-import getopt
-import socket
-import struct
-import codecs
-from pymodbus.client.sync import ModbusTcpClient
-
-named_tuple = time.localtime() # getstruct_time
-time_string = time.strftime("%m/%d/%Y, %H:%M:%S elwa off.py", named_tuple)
-devicenumber=str(sys.argv[1])
-ipadr=str(sys.argv[2])
-uberschuss=int(sys.argv[3])
+import logging
+from smarthome.smartlog import initlog
+bp = '/var/www/html/openWB/ramdisk/smarthome_device_'
+devicenumber = int(sys.argv[1])
+ipadr = str(sys.argv[2])
+uberschuss = int(sys.argv[3])
 # standard
-file_string= '/var/www/html/openWB/ramdisk/smarthome_device_' + str(devicenumber) + '_elwa.log'
-file_stringpv= '/var/www/html/openWB/ramdisk/smarthome_device_' + str(devicenumber) + '_pv'
-file_stringcount= '/var/www/html/openWB/ramdisk/smarthome_device_' + str(devicenumber) + '_count'
-if os.path.isfile(file_string):
-   f = open( file_string , 'a')
-else:
-   f = open( file_string , 'w')
-print ('%s devicenr %s ipadr %s ueberschuss %6d try to connect (modbus)' % (time_string,devicenumber,ipadr,uberschuss),file=f)
-client = ModbusTcpClient(ipadr, port=502)
-#
-start = 1000
-resp=client.read_holding_registers(start,10,unit=1)
-#
-#start = 3524 
-#resp=client.read_input_registers(start,10,unit=1)
-value1 = resp.registers[0]
-all = format(value1, '04x')
-aktpower= int(struct.unpack('>h',codecs.decode(all, 'hex') )[0])
-value1 = resp.registers[3]
-all = format(value1, '04x')
-status= int(struct.unpack('>h',codecs.decode(all, 'hex') )[0])
-print ('%s devicenr %s ipadr %s Akt Leistung  %6d Status %2d' % (time_string,devicenumber,ipadr,aktpower,status),file=f)
-f.close()
-f = open( file_stringpv , 'w')
-f.write(str(0))
-f.close()
+initlog("elwa", devicenumber)
+log = logging.getLogger("elwa")
+file_stringpv = bp + str(devicenumber) + '_pv'
+file_stringcount = bp + str(devicenumber) + '_count'
+log.info("off devicenr %d ipadr %s ueberschuss %6d" %
+         (devicenumber, ipadr, uberschuss))
+with open(file_stringpv, 'w') as f:
+    f.write(str(0))
 count1 = 999
-f = open( file_stringcount , 'w')
-f.write(str(count1))
-f.close()
- 
+with open(file_stringcount, 'w') as f:
+    f.write(str(count1))

--- a/modules/smarthome/elwa/on.py
+++ b/modules/smarthome/elwa/on.py
@@ -1,48 +1,22 @@
 #!/usr/bin/python3
 import sys
-import os
-import time
-import json
-import getopt
-import socket
-import struct
-import codecs
-from pymodbus.client.sync import ModbusTcpClient
-#from pymodbus.client.sync import ModbusTcpClient
-named_tuple = time.localtime() # getstruct_time
-time_string = time.strftime("%m/%d/%Y, %H:%M:%S elwa on.py", named_tuple)
-devicenumber=str(sys.argv[1])
-ipadr=str(sys.argv[2])
-uberschuss=int(sys.argv[3])
+import logging
+from smarthome.smartlog import initlog
+bp = '/var/www/html/openWB/ramdisk/smarthome_device_'
+devicenumber = int(sys.argv[1])
+ipadr = str(sys.argv[2])
+uberschuss = int(sys.argv[3])
 # standard
 # lesen
 # own log
-file_string= '/var/www/html/openWB/ramdisk/smarthome_device_' + str(devicenumber) + '_elwa.log'
-file_stringpv= '/var/www/html/openWB/ramdisk/smarthome_device_' + str(devicenumber) + '_pv'
-file_stringcount= '/var/www/html/openWB/ramdisk/smarthome_device_' + str(devicenumber) + '_count'
-if os.path.isfile(file_string):
-   f = open( file_string , 'a')
-else:
-   f = open( file_string , 'w')
-print ('%s devicenr %s ipadr %s ueberschuss %6d try to connect (modbus)' % (time_string,devicenumber,ipadr,uberschuss),file=f)
-client = ModbusTcpClient(ipadr, port=502)
-#
-#start = 3524 
-#resp=client.read_input_registers(start,10,unit=1)
-start = 1000
-resp=client.read_holding_registers(start,10,unit=1)
-value1 = resp.registers[0]
-all = format(value1, '04x')
-aktpower= int(struct.unpack('>h',codecs.decode(all, 'hex') )[0])
-value1 = resp.registers[3]
-all = format(value1, '04x')
-status= int(struct.unpack('>h',codecs.decode(all, 'hex') )[0])
-print ('%s devicenr %s ipadr %s Akt Leistung  %6d Status %2d' % (time_string,devicenumber,ipadr,aktpower,status),file=f)
-f.close()
-f = open( file_stringpv , 'w')
-f.write(str(1))
-f.close()
+initlog("elwa", devicenumber)
+log = logging.getLogger("elwa")
+file_stringpv = bp + str(devicenumber) + '_pv'
+file_stringcount = bp + str(devicenumber) + '_count'
+log.info(" on devicenr %d ipadr %s ueberschuss %6d" %
+         (devicenumber, ipadr, uberschuss))
+with open(file_stringpv, 'w') as f:
+    f.write(str(1))
 count1 = 999
-f = open( file_stringcount , 'w')
-f.write(str(count1))
-f.close()
+with open(file_stringcount, 'w') as f:
+    f.write(str(count1))

--- a/modules/smarthome/nxdacxx/off.py
+++ b/modules/smarthome/nxdacxx/off.py
@@ -19,7 +19,7 @@ log.info('off devicenr %d ipadr %s dactyp %d' % (devicenumber, ipadr, dactyp))
 if dactyp == 2:
     client = ModbusTcpClient(ipadr, port=port)
     # DO1 ausschalten um SGready zu sperren
-    rq = client.write_coil(0, False)
+    rq = client.write_coil(0, False, unit=1)
 pvmodus = 0
 if os.path.isfile(file_stringpv):
     with open(file_stringpv, 'r') as f:

--- a/modules/smarthome/nxdacxx/on.py
+++ b/modules/smarthome/nxdacxx/on.py
@@ -18,7 +18,7 @@ log.info('on devicenr %d ipadr %s dactyp %d' % (devicenumber, ipadr, dactyp))
 if dactyp == 2:
     client = ModbusTcpClient(ipadr, port=port)
     # DO1 einschalten um SGready zu aktivieren
-    rq = client.write_coil(0, True)
+    rq = client.write_coil(0, True, unit=1)
 pvmodus = 1
 with open(file_stringpv, 'w') as f:
     f.write(str(pvmodus))

--- a/runs/usmarthome/smartelwa.py
+++ b/runs/usmarthome/smartelwa.py
@@ -1,21 +1,28 @@
 #!/usr/bin/python3
 from usmarthome.smartbase import Sbase
 from usmarthome.global0 import log
+from typing import Dict
 import subprocess
 
 
 class Selwa(Sbase):
-    def __init__(self):
+    def __init__(self) -> None:
         # setting
         super().__init__()
         self._dynregel = 1
         print('__init__ Selwa executed')
 
-    def getwatt(self, uberschuss, uberschussoffset):
+    def updatepar(self, input_param: Dict[str, str]) -> None:
+        super().updatepar(input_param)
+        # fest 1 setzen Warmwasser modbus 1001
+        self.device_temperatur_configured = 1
+
+    def getwatt(self, uberschuss: int, uberschussoffset: int) -> None:
         self.prewatt(uberschuss, uberschussoffset)
+        forcesend = self.checkbefsend()
         argumentList = ['python3', self._prefixpy + 'elwa/watt.py',
                         str(self.device_nummer), str(self._device_ip),
-                        str(self.devuberschuss)]
+                        str(self.devuberschuss), str(forcesend)]
         try:
             self.proc = subprocess.Popen(argumentList)
             self.proc.communicate()
@@ -23,6 +30,11 @@ class Selwa(Sbase):
             self.newwatt = int(self.answer['power'])
             self.newwattk = int(self.answer['powerc'])
             self.relais = int(self.answer['on'])
+            self.temp0 = str(self.answer['temp0'])
+            with open(self._basePath+'/ramdisk/device' +
+                      str(self.device_nummer) + '_temp0', 'w') as f:
+                f.write(str(self.temp0))
+            self.checksend(self.answer)
         except Exception as e1:
             log.warning("(" + str(self.device_nummer) +
                         ") Leistungsmessung %s %d %s Fehlermeldung: %s "
@@ -30,7 +42,7 @@ class Selwa(Sbase):
                            str(self._device_ip), str(e1)))
         self.postwatt()
 
-    def turndevicerelais(self, zustand, ueberschussberechnung, updatecnt):
+    def turndevicerelais(self, zustand: int, ueberschussberechnung: int, updatecnt: int) -> None:
         self.preturn(zustand, ueberschussberechnung, updatecnt)
         if (zustand == 1):
             pname = "/on.py"

--- a/web/settings/smarthomeconfig.php
+++ b/web/settings/smarthomeconfig.php
@@ -148,6 +148,7 @@ $numDevices = 9;
 											Heizstab ELWA-E  der Firma my-PV<br>
 											Im Web Frontend vom Heizstab muss unter Steuerungs-Einstellungen der Parameter "Ansteuerungs-Typ = Modbus TCP" und "Power Timeout = 120 Sek" gesetzt werden.
 											Wenn die Einschaltbedingung erreicht ist wird alle 30 Sekunden der gerechnete Überschuss übertragen.
+											Mit dem Parameter Updategerät kann eine abweichende Sekundenzahl angegeben werden.
 											Wenn die Ausschaltbedingung erreicht ist wird einmalig 0 als Überschuss übertragen.
 											Die Ausschaltschwelle/ Ausschaltverzögerung in OpenWB ist sinnvoll zu wählen (z.B. 500 / 3) um die Regelung von Elwa nicht zu stören.
 											Die Warmwassersicherstellung in Elwa kann genutzt werden. OpenWB erkennt dieses am Status und überträgt dann keinen Überschuss.


### PR DESCRIPTION
Elwa:
Es wurde auf Python Log umgestellt.
Es wurde auf static Types umgestellt.
Sofern Elwa als 1 oder 2 Smarthomegeträt definiert ist, wird die Warmwassertemperatur (Modbusadresse 1001) auf dem Hauptschirm angezeigt. 
Neu kann mit Updategerät ein kürzeres Aktualisierungsintervall festgelegt werden.
Alte fileaufrufe ersetzt.
On / off Trigger vereinfacht
Ndac type 2
Unit=1 wurde im on und off triger hinzugefügt