### PR TITLE
use new version of libvwid.py; new script to download libvwid.py from…

### DIFF
--- a/modules/soc_vwid/libvwid.py
+++ b/modules/soc_vwid/libvwid.py
@@ -38,15 +38,13 @@ class vwid:
 			if (a.text) and (a.text.find('window._IDK') != -1):
 				text = a.text.strip()
 				text = text[text.find('\n'):text.rfind('\n')].strip()
-
 				for line in text.split('\n'):
 					try:
 						(name, val) = line.strip().split(':', 1)
-					except Exception:
-						self.log.error("password_form: ignore line: " + line)
-					else:
-						val = val.strip('\', ')
-						objects[name] = val
+					except ValueError:
+						continue
+					val = val.strip('\', ')
+					objects[name] = val
 
 		json_model = json.loads(objects['templateModel'])
 

--- a/modules/soc_vwid/main.sh
+++ b/modules/soc_vwid/main.sh
@@ -76,7 +76,7 @@ getAndWriteSoc(){
 			ln -s $MODULEDIR/_secrets.py $MODULEDIR/secrets.py
 		fi
 	fi
-	answer=$($MODULEDIR/soc_vwid.py --user "$username" --password "$password" --vin "$vin" --chargepoint "$CHARGEPOINT" 2>&1)
+	answer=$($MODULEDIR/soc_vwid.py --user "$username" --password "$password" --vin "$vin" --chargepoint "$CHARGEPOINT" 2>>$RAMDISKDIR/soc.log)
 	if [ $? -eq 0 ]; then
 		# we got a valid answer
 		echo $answer > $socfile

--- a/modules/soc_vwid/prepare_libvwid.sh
+++ b/modules/soc_vwid/prepare_libvwid.sh
@@ -1,0 +1,14 @@
+echo "downloading libvwid.py  from github to libvwid.org"
+curl -sS -o libvwid.org https://raw.githubusercontent.com/skagmo/ha_vwid/main/custom_components/vwid/libvwid.py
+diff libvwid.py libvwid.org
+echo "replace libvwid.py by libvwid.mod?(Y)"
+read a
+if [ "$a" == "Y" ]
+then
+   mv libvwid.org libvwid.py
+   echo "libvwid.py is replaced by version from github/skagmo"
+   chmod +x libvwid.py
+else
+   echo "libvwid.py is not replaced"
+fi
+

--- a/modules/soc_vwid/prepare_libvwid.sh
+++ b/modules/soc_vwid/prepare_libvwid.sh
@@ -5,10 +5,10 @@ echo "replace libvwid.py by libvwid.mod?(Y)"
 read a
 if [ "$a" == "Y" ]
 then
-   mv libvwid.org libvwid.py
-   echo "libvwid.py is replaced by version from github/skagmo"
-   chmod +x libvwid.py
+	mv libvwid.org libvwid.py
+	echo "libvwid.py is replaced by version from github/skagmo"
+	chmod +x libvwid.py
 else
-   echo "libvwid.py is not replaced"
+	echo "libvwid.py is not replaced"
 fi
 


### PR DESCRIPTION
… github.
Last weeks problem has been fixed by author of original script. Uing that now.
New shell script prepare_libvwid.sh  to download and compare libvwid.py.