### PR TITLE
soc_vwid: fix python2 syntax problem in libvwid.py

### DIFF
--- a/modules/soc_vwid/libvwid.py
+++ b/modules/soc_vwid/libvwid.py
@@ -189,7 +189,7 @@ class vwid:
 		return True
 
 	async def get_status(self):
-		status_url = f"{API_BASE}/vehicles/{self.vin}/selectivestatus?jobs={self.jobs_string}"
+		status_url = API_BASE + "/vehicles/" + self.vin + "/selectivestatus?jobs=" + self.jobs_string
 		response = await self.session.get(status_url, headers=self.headers)
 
 		# If first attempt fails, try to refresh tokens

--- a/modules/soc_vwid/prepare_libvwid.sh
+++ b/modules/soc_vwid/prepare_libvwid.sh
@@ -1,11 +1,14 @@
 echo "downloading libvwid.py  from github to libvwid.org"
 curl -sS -o libvwid.org https://raw.githubusercontent.com/skagmo/ha_vwid/main/custom_components/vwid/libvwid.py
-diff libvwid.py libvwid.org
+sed '
+/status_url =/s/status_url.*$/status_url = API_BASE + "\/vehicles\/" + self.vin + "\/selectivestatus?jobs=" + self.jobs_string/
+' < libvwid.org > libvwid.mod
+diff libvwid.py libvwid.mod
 echo "replace libvwid.py by libvwid.mod?(Y)"
 read a
 if [ "$a" == "Y" ]
 then
-	mv libvwid.org libvwid.py
+	mv libvwid.mod libvwid.py
 	echo "libvwid.py is replaced by version from github/skagmo"
 	chmod +x libvwid.py
 else


### PR DESCRIPTION
Hallo Lena, Lutz,
bitte bald mergen, in aktueller Nightly läuft das nicht in python2.
Danke