### PR TITLE
tariff based charging: allow enabling by charge point

### DIFF
--- a/loadvars.sh
+++ b/loadvars.sh
@@ -1867,6 +1867,14 @@ loadvars(){
 	mqttconfvar["config/get/sofort/lp/6/chargeLimitation"]=msmoduslp6
 	mqttconfvar["config/get/sofort/lp/7/chargeLimitation"]=msmoduslp7
 	mqttconfvar["config/get/sofort/lp/8/chargeLimitation"]=msmoduslp8
+	mqttconfvar["config/get/sofort/lp/1/etBasedCharging"]=lp1etbasedcharging
+	mqttconfvar["config/get/sofort/lp/2/etBasedCharging"]=lp2etbasedcharging
+	mqttconfvar["config/get/sofort/lp/3/etBasedCharging"]=lp3etbasedcharging
+	mqttconfvar["config/get/sofort/lp/4/etBasedCharging"]=lp4etbasedcharging
+	mqttconfvar["config/get/sofort/lp/5/etBasedCharging"]=lp5etbasedcharging
+	mqttconfvar["config/get/sofort/lp/6/etBasedCharging"]=lp6etbasedcharging
+	mqttconfvar["config/get/sofort/lp/7/etBasedCharging"]=lp7etbasedcharging
+	mqttconfvar["config/get/sofort/lp/8/etBasedCharging"]=lp8etbasedcharging
 	mqttconfvar["config/get/pv/lp/1/socLimitation"]=stopchargepvatpercentlp1
 	mqttconfvar["config/get/pv/lp/2/socLimitation"]=stopchargepvatpercentlp2
 	mqttconfvar["config/get/pv/lp/1/maxSoc"]=stopchargepvpercentagelp1

--- a/runs/initRamdisk.sh
+++ b/runs/initRamdisk.sh
@@ -517,6 +517,14 @@ initRamdisk(){
 		"mqtteinschaltverzoegerung:-1" \
 		"mqttetprovideraktiv:-1" \
 		"mqttetprovider:notset" \
+		"mqttlp1etbasedcharging:-1" \
+		"mqttlp2etbasedcharging:-1" \
+		"mqttlp3etbasedcharging:-1" \
+		"mqttlp4etbasedcharging:-1" \
+		"mqttlp5etbasedcharging:-1" \
+		"mqttlp6etbasedcharging:-1" \
+		"mqttlp7etbasedcharging:-1" \
+		"mqttlp8etbasedcharging:-1" \
 		"mqttevuglaettungakt:-1" \
 		"mqtthausverbrauch:-1" \
 		"mqtthausverbrauchstat:-1" \

--- a/runs/mqttsub.py
+++ b/runs/mqttsub.py
@@ -640,6 +640,12 @@ def on_message(client, userdata, msg):
                     client.publish("openWB/config/get/sofort/lp/"+str(devicenumb)+"/socToChargeTo", msg.payload.decode("utf-8"), qos=0, retain=True)
                     sendcommand = ["/var/www/html/openWB/runs/replaceinconfig.sh", "sofortsoclp"+str(devicenumb)+"=", msg.payload.decode("utf-8")]
                     subprocess.run(sendcommand)
+            if (( "openWB/config/set/sofort/lp" in msg.topic) and ("etBasedCharging" in msg.topic)):
+                devicenumb=re.sub(r'\D', '', msg.topic)
+                if ( 1 <= int(devicenumb) <= 8 and 0 <= int(msg.payload) <= 1):
+                    client.publish("openWB/config/get/sofort/lp/"+str(devicenumb)+"/etBasedCharging", msg.payload.decode("utf-8"), qos=0, retain=True)
+                    sendcommand = ["/var/www/html/openWB/runs/replaceinconfig.sh", "lp"+str(devicenumb)+"etbasedcharging=", msg.payload.decode("utf-8")]
+                    subprocess.run(sendcommand)
             if (( "openWB/config/set/sofort/lp" in msg.topic) and ("chargeLimitation" in msg.topic)):
                 devicenumb=re.sub(r'\D', '', msg.topic)
                 if ( 3 <= int(devicenumb) <= 8 and 0 <= int(msg.payload) <= 1):

--- a/runs/updateConfig.sh
+++ b/runs/updateConfig.sh
@@ -1297,6 +1297,11 @@ updateConfig(){
 	if grep -Fq "awattaraktiv=" $ConfigFile; then
 		sed -i '/^awattaraktiv=/d' $ConfigFile
 	fi
+	for i in $(seq 1 8); do
+		if ! grep -Fq "lp${i}etbasedcharging=" $ConfigFile; then
+			echo "lp${i}etbasedcharging=1" >> $ConfigFile
+		fi
+	done
 	if ! grep -Fq "plz=" $ConfigFile; then
 		echo "plz=36124" >> $ConfigFile
 	fi

--- a/sofortlademodus.sh
+++ b/sofortlademodus.sh
@@ -10,31 +10,27 @@ sofortlademodus(){
 	fi
 	if (( etprovideraktiv == 1 )); then
 		actualprice=$(<ramdisk/etproviderprice)
+		
 		if (( $(echo "$actualprice <= $etprovidermaxprice" |bc -l) )); then
 			#price lower than max price, enable charging
-			openwbDebugLog "MAIN" 1 "Aktiviere Ladung (preisbasiert), Preis $actualprice, Max $etprovidermaxprice"
-			if (( lp1enabled == 0 )); then
-				mosquitto_pub -r -t openWB/set/lp/1/ChargePointEnabled -m "1"
-			fi
-			if (( lp2enabled == 0 )); then
-				mosquitto_pub -r -t openWB/set/lp/2/ChargePointEnabled -m "1"
-			fi
-			if (( lp3enabled == 0 )); then
-				mosquitto_pub -r -t openWB/set/lp/3/ChargePointEnabled -m "1"
-			fi
+			for i in $(seq 1 8); do
+				myenabledvar="lp${i}enabled"
+				myetbasedvar="lp${i}etbasedcharging"
+				if (( ${!myenabledvar} == 0 && ${!myetbasedvar} == 1 )); then
+					openwbDebugLog "MAIN" 1 "Aktiviere Ladung (preisbasiert) für Ladepunkt $i, Preis $actualprice, Max $etprovidermaxprice"
+					mosquitto_pub -r -t openWB/set/lp/${i}/ChargePointEnabled -m "1"
+				fi
+			done
 		else
-			openwbDebugLog "MAIN" 1 "Deaktiviere Ladung (preisbasiert), Preis $actualprice, Max $etprovidermaxprice"
 			#price higher than max price, disable charging
-			if (( lp1enabled == 1 )); then
-				mosquitto_pub -r -t openWB/set/lp/1/ChargePointEnabled -m "0"
-			fi
-			if (( lp2enabled == 1 )); then
-				mosquitto_pub -r -t openWB/set/lp/2/ChargePointEnabled -m "0"
-			fi
-			if (( lp3enabled == 1 )); then
-				mosquitto_pub -r -t openWB/set/lp/3/ChargePointEnabled -m "0"
-			fi
-
+			for i in $(seq 1 8); do
+				myenabledvar="lp${i}enabled"
+				myetbasedvar="lp${i}etbasedcharging"
+				if (( ${!myenabledvar} == 1 && ${!myetbasedvar} == 1 )); then
+					openwbDebugLog "MAIN" 1 "Deaktiviere Ladung (preisbasiert) für Ladepunkt $i, Preis $actualprice, Max $etprovidermaxprice"
+					mosquitto_pub -r -t openWB/set/lp/${i}/ChargePointEnabled -m "0"
+				fi
+			done
 		fi
 	fi
 	if (( lastmmaxw < 10 ));then

--- a/web/settings/sofortconfig.php
+++ b/web/settings/sofortconfig.php
@@ -46,7 +46,7 @@
 
 				<div class="card border-secondary">
 					<div class="card-header bg-secondary">
-						 Allgemeine Einstellungen
+						Allgemeine Einstellungen
 					</div>
 					<div class="card-body">
 						<div class="form-group mb-0">
@@ -154,6 +154,22 @@
 								</div>
 							</div>
 							<?php } ?>
+							<div class="form-row mb-1 lp<?php echo $chargepoint; ?>etBased hide">
+								<label class="col-md-4 col-form-label">Preisbasiert</label>
+								<div class="col">
+									<div class="btn-group btn-block btn-group-toggle" id="etBasedChargingLp<?php echo $chargepoint; ?>" name="etBasedCharging" data-toggle="buttons" data-default="0" data-topicprefix="openWB/config/get/sofort/" data-topicsubgroup="lp/<?php echo $chargepoint; ?>/">
+										<label class="btn btn-outline-info btn-toggle">
+											<input type="radio" name="etBasedChargingLp<?php echo $chargepoint; ?>" data-option="0" value="0"> Aus
+										</label>
+										<label class="btn btn-outline-info btn-toggle">
+											<input type="radio" name="etBasedChargingLp<?php echo $chargepoint; ?>" data-option="1" value="1"> An
+										</label>
+									</div>
+									<span class="form-text small">
+										Aktiviert/Deaktiviert Preisbasiertes Laden
+									</span>
+								</div>
+							</div>
 						</div>  <!-- end card body Einstellungen Ladepunkt <?php echo $chargepoint; ?> -->
 						<script>
 							$(document).ready(function(){
@@ -274,7 +290,7 @@
 		<!-- load mqtt library -->
 		<script src = "js/mqttws31.js" ></script>
 		<!-- load topics -->
-		<script src = "settings/topicsToSubscribe_sofortconfig.js?ver=20200503-a" ></script>
+		<script src = "settings/topicsToSubscribe_sofortconfig.js?ver=20221210-a" ></script>
 		<!-- load service -->
 		<script src = "settings/setupMqttServices.js?ver=20200424-a" ></script>
 		<!-- load mqtt handler-->
@@ -333,6 +349,17 @@
 						hideSection('.lp' + index + 'limitenergy');
 					} else {
 						showSection('.lp' + index + 'limitenergy');
+					}
+				}
+				if ( elementId.match( /^boolAwattarEnabled*$/i ) ) {
+					if ( mqttpayload == 1) {
+						for( $index = 1; $index < 9; $index++ ){
+							showSection('.lp' + $index + 'etBased');
+						}
+					} else {
+						for( $index = 1; $index < 9; $index++ ){
+							hideSection('.lp' + $index + 'etBased');
+						}
 					}
 				}
 			}

--- a/web/settings/topicsToSubscribe_sofortconfig.js
+++ b/web/settings/topicsToSubscribe_sofortconfig.js
@@ -51,5 +51,16 @@ var topicsToSubscribe = [
 	["openWB/config/get/sofort/lp/1/socToChargeTo", 0],
 	["openWB/config/get/sofort/lp/2/socToChargeTo", 0],
 
-	["openWB/config/get/global/minEVSECurrentAllowed", 0]
+	["openWB/config/get/sofort/lp/1/etBasedCharging", 0],
+	["openWB/config/get/sofort/lp/2/etBasedCharging", 0],
+	["openWB/config/get/sofort/lp/3/etBasedCharging", 0],
+	["openWB/config/get/sofort/lp/4/etBasedCharging", 0],
+	["openWB/config/get/sofort/lp/5/etBasedCharging", 0],
+	["openWB/config/get/sofort/lp/6/etBasedCharging", 0],
+	["openWB/config/get/sofort/lp/7/etBasedCharging", 0],
+	["openWB/config/get/sofort/lp/8/etBasedCharging", 0],
+
+	["openWB/config/get/global/minEVSECurrentAllowed", 0],
+
+	["openWB/global/awattar/boolAwattarEnabled", 0]
 ];


### PR DESCRIPTION
If an et provider has been configured, a new option will show up under each charge point in Einstellungen->Ladeeinstellungen->Sofortladen, which allows to enable charging based on tariff individually (enabled by default).

With this enhancement a master can do load management in a house with multiple external openWBs when they have different electricity providers, but share the same house connection.

![2022-12-11_14h12_02](https://user-images.githubusercontent.com/35894129/206905727-95fd5ec0-ee0d-40a8-84a8-8194c8958ee0.png)
