### PR TITLE
Elwa Warmwassertemperatur...

### DIFF
--- a/modules/smarthome/elwa/watt.py
+++ b/modules/smarthome/elwa/watt.py
@@ -40,7 +40,8 @@ aktpower = int(struct.unpack('>h', codecs.decode(all, 'hex'))[0])
 # Wassertemperatur lesen
 value1 = resp.registers[1]
 all = format(value1, '04x')
-temp0 = int(struct.unpack('>h', codecs.decode(all, 'hex'))[0])
+temp0int = int(struct.unpack('>h', codecs.decode(all, 'hex'))[0])
+temp0 = float(temp0int) / 10
 count5 = 999
 if os.path.isfile(file_stringcount5):
     with open(file_stringcount5, 'r') as f:


### PR DESCRIPTION
Die ausgelesene Temperatur ist in 0.1 Gradeinheiten. Somit braucht es noch einen /10