### PR TITLE
soc_smarteq: implement token refresh, improve logging

### DIFF
--- a/modules/soc_smarteq/README.txt
+++ b/modules/soc_smarteq/README.txt
@@ -1,3 +1,12 @@
 Das smart SOC Modul ist vom smartEQ Modul des iobroker inspiriert.
 Der js code wurde in python implementiert und etwas vereinfacht.
 
+Es wird in OAUTh ein Token Refresh durchgeführt.
+Da alle Token nur 2 Stunden gültig sind und der Refresh mit gültigem refresh_token erfolgen muss,
+sollten die Intervalle in der Modulkonfiguration weniger als 2 Stunden betragen.
+90 Minuten im Standby und 10 Minuten während des Ladens haben sich im Test bewährt.
+
+Wenn die Intervalle auf mehr als 2 Stunden konfiguriert sind, wird bei der nächsten Abfrage ein Login durchgeführt.
+Das benötigt deutlich mehr Zeit und es können die Token anderer Sitzungen, z.B. der smart Control App,
+ungültig werden und einen neuen Login benötigen mit Eingabe von User und Passwort.
+

--- a/modules/soc_smarteq/main.sh
+++ b/modules/soc_smarteq/main.sh
@@ -67,7 +67,7 @@ incrementTimer(){
 }
 
 getAndWriteSoc(){
-	openwbDebugLog ${DMOD} 0 "Lp$CHARGEPOINT: Requesting SoC"
+	openwbDebugLog ${DMOD} 2 "Lp$CHARGEPOINT: Requesting SoC"
 	echo 0 > $soctimerfile
 	#Prepare for secrets used in soc module libvwid in Python
 	if ! python3 -c "import secrets" &> /dev/null ; then
@@ -80,7 +80,7 @@ getAndWriteSoc(){
 	if [ $? -eq 0 ]; then
 		# we got a valid answer
 		echo $answer > $socfile
-		openwbDebugLog ${DMOD} 0 "Lp$CHARGEPOINT: SoC: $answer"
+		openwbDebugLog ${DMOD} 2 "Lp$CHARGEPOINT: SoC: $answer"
 	else
 		# we have a problem
 		openwbDebugLog ${DMOD} 0 "Lp$CHARGEPOINT: Error from soc_smart: $answer"

--- a/modules/soc_smarteq/soc_smarteq.py
+++ b/modules/soc_smarteq/soc_smarteq.py
@@ -27,12 +27,12 @@ TOKENS_REFRESH_THRESHOLD = 3600
 
 
 # helper functions
-def keys_exist(element, *keys):
+def nested_keys_exist(element: dict, *keys) -> bool:
     # Check if *keys (nested) exists in `element` (dict).
     if not isinstance(element, dict):
-        raise AttributeError('keys_exist() expects dict as first argument - got type ' + str(type(element)))
+        raise AttributeError('nested_keys_exist() expects dict as first argument - got type ' + str(type(element)))
     if len(keys) == 0:
-        raise AttributeError('keys_exist() expects at least two arguments, one given.')
+        raise AttributeError('nested_keys_exist() expects at least two arguments, one given.')
 
     _element = element
     for key in keys:
@@ -350,7 +350,7 @@ class smarteq:
             response = self.session.get(url, headers=headers)
             res = json.loads(response.text)
             res_json = json.dumps(res, indent=4)
-            if keys_exist(res, 'precond', 'data', 'soc', 'value'):
+            if nested_keys_exist(res, 'precond', 'data', 'soc', 'value'):
                 res_json = json.dumps(res['precond']['data']['soc'], indent=4)
                 try:
                     soc = res['precond']['data']['soc']['value']
@@ -410,7 +410,7 @@ class smarteq:
             if 'access_token' in self.store['Tokens']:
                 soc = self.get_status(self.vin)
         self.log.info("Lp" + self.chargepoint +
-                " SOC: " + str(soc) + '%' +
+                      " SOC: " + str(soc) + '%' +
                       '@' + self.soc_ts +
                       ', Method: ' + self.method)
 

--- a/modules/soc_smarteq/soc_smarteq.py
+++ b/modules/soc_smarteq/soc_smarteq.py
@@ -5,6 +5,8 @@ import requests
 import json
 import bs4
 import os
+import time
+import datetime
 import pkce
 import logging
 import pickle
@@ -21,10 +23,29 @@ CLIENT_ID = "70d89501-938c-4bec-82d0-6abb550b0825"
 GUID = "280C6B55-F179-4428-88B6-E0CCF5C22A7C"
 ACCEPT_LANGUAGE = "de-de"
 
+TOKENS_REFRESH_THRESHOLD = 3600
+
+
+# helper functions
+def keys_exist(element, *keys):
+    # Check if *keys (nested) exists in `element` (dict).
+    if not isinstance(element, dict):
+        raise AttributeError('keys_exist() expects dict as first argument - got type ' + str(type(element)))
+    if len(keys) == 0:
+        raise AttributeError('keys_exist() expects at least two arguments, one given.')
+
+    _element = element
+    for key in keys:
+        try:
+            _element = _element[key]
+        except KeyError:
+            return False
+    return True
+
 
 class smarteq:
-    def __init__(self, tokensFile: str):
-        self.tokensFile = tokensFile
+    def __init__(self, storeFile: str):
+        self.storeFile = storeFile
         self.log = logging.getLogger("soc_smarteq")
         debug = os.environ.get('debug', '0')
         LOGLEVEL = 'WARN'
@@ -34,45 +55,81 @@ class smarteq:
             LOGLEVEL = 'DEBUG'
         RAMDISKDIR = os.environ.get("RAMDISKDIR", "undefined")
         logFile = RAMDISKDIR+'/soc.log'
-        format = '%(asctime)s %(name)s:%(levelname)s: %(message)s'
+        format = '%(asctime)s %(levelname)s:%(name)s:%(message)s'
         datefmt = '%Y-%m-%d %H:%M:%S'
         logging.basicConfig(filename=logFile,
                             filemode='a',
                             format=format,
                             datefmt=datefmt,
                             level=LOGLEVEL)
-        # self.log.error("init logging: debug=" + debug + ", LOGLEVEL=" + LOGLEVEL)
+
+        # self.method keeps a high level trach of actions
+        self.method = ''
+        self.soc_ts = 'n/a'
+        # self.store is read from ramdisk at start and saved at end.
+        # currently is contains:
+        # Tokens: refresh- and access-tokens of OAUTH
+        # refresh_timestamp: epoch of last refresh_tokens.
+        self.store = {}
+        self.store['Tokens'] = {}
+        self.store['refresh_timestamp'] = int(0)
 
         self.session = requests.session()
-        self.Tokens = {}
-        self.code_verifier, self.code_challenge = pkce.generate_pkce_pair()
-        self.code_challenge_method = "S256"
 
+        self.load_store()
+        self.oldTokens = self.store['Tokens']
+        self.init = True
+        self.init = False  # test!!
+
+    def load_store(self):
         try:
-            tf = open(self.tokensFile, "rb")
-            self.Tokens = pickle.load(tf)
+            tf = open(self.storeFile, "rb")
+            self.store = pickle.load(tf)
+            if 'Tokens' not in self.store:
+                self.store['Tokens'] = {}
+                self.store['refresh_timestamp'] = int(0)
             tf.close()
         except Exception as e:
-            self.log.warn("init: loading tokens failed, file: " + self.tokensFile)
-            self.Tokens = {}
+            self.log.debug("init: loading stored data failed, file: " + self.storeFile)
+            self.store['Tokens'] = {}
+            self.store['refresh_timestamp'] = int(0)
 
+    def write_store(self):
+        try:
+            tf = open(self.storeFile, "wb")
+        except Exception as e:
+            self.log.debug("write_store: Exception " + str(e))
+            os.system("sudo rm -f " + self.storeFile)
+            tf = open(self.storeFile, "wb")
+        pickle.dump(self.store, tf)
+        tf.close()
+        try:
+            os.chmod(self.storeFile, 0o777)
+        except Exception as e:
+            os.system("sudo chmod 0777 " + self.storeFile)
+
+    # set username and password
     def set_credentials(self, username: str, password: str):
         self.username = username
         self.password = password
 
+    # set vin
     def set_vin(self, vin: str):
         self.vin = vin
 
+    # set chargepoint number
     def set_chargepoint(self, chargepoint: str):
         self.chargepoint = chargepoint
 
-    # ===== step1 get resume ======
+    # ===== get resume string ======
     def get_resume(self) -> str:
         response_type = "code"
-        url1 = OAUTH_URL + '?client_id=' + CLIENT_ID + '&response_type=' + response_type + '&scope=' + SCOPE
-        url1 = url1 + '&redirect_uri=' + REDIRECT_URI
-        url1 = url1 + '&code_challenge=' + self.code_challenge + '&code_challenge_method=' + self.code_challenge_method
-        headers1 = {
+        self.code_verifier, self.code_challenge = pkce.generate_pkce_pair()
+        self.code_challenge_method = "S256"
+        url = OAUTH_URL + '?client_id=' + CLIENT_ID + '&response_type=' + response_type + '&scope=' + SCOPE
+        url = url + '&redirect_uri=' + REDIRECT_URI
+        url = url + '&code_challenge=' + self.code_challenge + '&code_challenge_method=' + self.code_challenge_method
+        headers = {
             "Accept": "text/html,application/xhtml+xml,application/xml;q=0.9,*/*;q=0.8",
             "Accept-Language": ACCEPT_LANGUAGE,
             "User-Agent": "Mozilla/5.0 (iPhone; CPU iPhone OS 12_5_1 like Mac OS X)\
@@ -80,31 +137,30 @@ class smarteq:
         }
 
         try:
-            response1 = self.session.get(url1, headers=headers1)
-            self.log.debug("response1.status_code = " + str(response1.status_code))
-            soup = bs4.BeautifulSoup(response1.text, 'html.parser')
-        
+            response = self.session.get(url, headers=headers)
+            self.log.debug("get_resume: status_code = " + str(response.status_code))
+            self.log.debug("get_resume: text = " + str(response.text))
+            soup = bs4.BeautifulSoup(response.text, 'html.parser')
+
             for cd in soup.findAll(text=True):
-                self.log.debug("cd= " + str(cd))
-                # if isinstance(cd, bs4.CData):
                 if "CDATA" in cd:
-                    self.log.debug("cd.CData= " + str(cd))
+                    self.log.debug("get_resume: cd.CData= " + str(cd))
                     for w in cd.split(','):
                         if w.find("const initialState = ") != -1:
                             iS = w
             if iS:
                 js = iS.split('{')[1].split('}')[0].replace('\\', '').replace('\\"', '"').replace('""', '"')
                 self.resume = js[1:len(js)-1].split(':')[1][2:]
-            self.log.debug("Step1 get_resume: resume = " + self.resume)
+            self.log.debug("get_resume: resume = " + self.resume)
         except Exception as e:
-            self.log.error('Step1 get_resume Exception: ' + str(e))
+            self.log.error('get_resume: Exception: ' + str(e))
         return self.resume
 
-    # step2: login to website, return token
+    # login to website, return (intermediate) token
     def login(self) -> str:
-
-        url3 = LOGIN_URL + "/pass"
-        headers3 = {
+        self.resume = self.get_resume()
+        url = LOGIN_URL + "/pass"
+        headers = {
             "Content-Type": "application/json",
             "Accept": "application/json, text/plain, */*",
             "User-Agent": "Mozilla/5.0 (iPhone; CPU iPhone OS 12_5_1 like Mac OS X)\
@@ -116,17 +172,20 @@ class smarteq:
         d['username'] = self.username
         d['password'] = self.password
         d['rememberMe'] = 'true'
-        data3 = json.dumps(d)
+        data = json.dumps(d)
+        data = json.dumps({'username': self.username,
+                           'password': self.password,
+                           'rememberMe': 'true'})
 
         try:
-            response3 = self.session.post(url3, headers=headers3, data=data3)
-            self.log.debug("response3.status_code = " + str(response3.status_code))
-            # self.log.debug("response3.text = " + str(response3.text))
-            if response3.status_code > 400:
-                self.log.error("login: failed, status_code = " + str(response3.status_code) + ", check username/password" )
+            response = self.session.post(url, headers=headers, data=data)
+            self.log.debug("login: status_code = " + str(response.status_code))
+            if response.status_code > 400:
+                self.log.error("login: failed, status_code = " + str(response.status_code) +
+                               ", check username/password")
                 token = ""
             else:
-                result_json = json.loads(str(bs4.BeautifulSoup(response3.text, 'html.parser')))
+                result_json = json.loads(str(bs4.BeautifulSoup(response.text, 'html.parser')))
                 self.log.debug("login: result_json:\n" + json.dumps(result_json))
                 token = result_json['token']
                 self.log.debug("login: token = " + token)
@@ -136,9 +195,13 @@ class smarteq:
         return token
 
     # get code
-    def get_code(self, token: str) -> str:
-        url4 = BASE_URL + '/' + self.resume
-        headers4 = {
+    def get_code(self) -> str:
+        token = self.login()
+        if token == "":
+            self.log.error("login: Login failed - check username/password")
+            return ""
+        url = BASE_URL + '/' + self.resume
+        headers = {
             "Content-Type": "application/x-www-form-urlencoded",
             "Accept": "application/json, text/plain, */*",
             "User-Agent": "Mozilla/5.0 (iPhone; CPU iPhone OS 12_5_1 like Mac OS X)\
@@ -146,67 +209,137 @@ class smarteq:
             "Referer": LOGIN_URL,
             "Accept-Language": ACCEPT_LANGUAGE,
         }
-        d = {}
-        d['token'] = token
-        data4 = json.dumps(d)
+        # d = {}
+        # d['token'] = token
+        # data = json.dumps(d)
+        data = json.dumps({'token': token})
 
         try:
-            response4 = self.session.post(url4, headers=headers4, data=data4)
-            code = response4.url.split('?')[1].split('=')[1]
-            self.log.debug("get_ ode, code=" + code)
+            response = self.session.post(url, headers=headers, data=data)
+            code = response.url.split('?')[1].split('=')[1]
+            self.log.debug("get_code: code=" + code)
         except Exception as e:
-            self.log.error("get_code Exception: " + str(e))
+            self.log.error("get_code: Exception: " + str(e))
         return code
 
     # get Tokens
-    def get_Tokens(self, code: str) -> dict:
-        url5 = TOKEN_URL
-        headers5 = {
+    def get_tokens(self) -> dict:
+        self.method += " 3-full (re)connect"
+        code = self.get_code()
+        if code == "":
+            self.log.warn("get_tokens: get_code failed")
+            return {}
+        url = TOKEN_URL
+        headers = {
             "Accept": "*/*",
             "User-Agent": "sOAF/202108260942 CFNetwork/978.0.7 Darwin/18.7.0",
             "Accept-Language": ACCEPT_LANGUAGE,
             "Content-Type": "application/x-www-form-urlencoded",
         }
-        data5 = "grant_type=authorization_code&code=" + code + "&code_verifier=" + self.code_verifier +\
-                "&redirect_uri=" + REDIRECT_URI + "&client_id=" + CLIENT_ID
+        data = "grant_type=authorization_code&code=" + code + "&code_verifier=" + self.code_verifier +\
+               "&redirect_uri=" + REDIRECT_URI + "&client_id=" + CLIENT_ID
 
         try:
-            response5 = self.session.post(url5, headers=headers5, data=data5)
-            self.log.debug("get_Tokens: response5.status_code = " + str(response5.status_code))
-            Tokens = json.loads(response5.text)
+            response = self.session.post(url, headers=headers, data=data)
+            self.log.debug("get_tokens: status_code = " + str(response.status_code))
+            Tokens = json.loads(response.text)
             if not Tokens['access_token']:
-                self.log.warn("get_Tokens: no access_token found")
+                self.log.warn("get_tokens: no access_token found")
                 Tokens = {}
             else:
                 self.log.debug("Tokens=\n" + json.dumps(Tokens, indent=4))
         except Exception as e:
-            self.log.exception("get_Tokens: Exception: " + str(e))
+            self.log.exception("get_tokens: Exception: " + str(e))
         return Tokens
+
+    # refresh tokens
+    def refresh_tokens(self) -> dict:
+        self.method += " 2-refresh_tokens"
+        url = TOKEN_URL
+        headers = {
+            "Accept": "*/*",
+            "User-Agent": "sOAF/202108260942 CFNetwork/978.0.7 Darwin/18.7.0",
+            "Accept-Language": ACCEPT_LANGUAGE,
+            "Content-Type": "application/x-www-form-urlencoded",
+        }
+        # data = {'grant_type': 'refresh_token',
+        #         'client_id': CLIENT_ID,
+        #         'refresh_token': self.store['Tokens']['refresh_token']}
+        data = "grant_type=refresh_token&client_id=" + CLIENT_ID + "&refresh_token=" +\
+               self.store['Tokens']['refresh_token']
+
+        try:
+            response = self.session.post(url,
+                                         headers=headers,
+                                         data=data,
+                                         verify=True,
+                                         allow_redirects=False,
+                                         timeout=(30, 30))
+            self.log.debug("refresh_tokens: status_code = " + str(response.status_code))
+            self.log.debug("refresh_tokens: text = " + str(response.text))
+            newTokens = json.loads(response.text)
+            if 'error' in newTokens and newTokens['error'] == 'unauthorized':
+                self.log.warning("refresh_tokens: error: " + newTokens['error'] + ', ' + newTokens['error_description'])
+            if 'access_token' not in newTokens:
+                self.log.debug("refresh_tokens: new access_token not found")
+                newTokens['access_token'] = ""
+            if 'refresh_token' not in newTokens:
+                self.log.debug("refresh_tokens: new refresh_token not found")
+                newTokens['refresh_token'] = ""
+            self.log.debug("refresh_tokens: newTokens=\n" + json.dumps(newTokens, indent=4))
+        except Exception as e:
+            self.log.error("refresh_tokens: Exception: " + str(e))
+            newTokens['access_token'] = ""
+            newTokens['refresh_token'] = ""
+        return newTokens
 
     # reconnect to Server
     def reconnect(self) -> dict:
-        token = self.login()
-        if token == "":
-            self.log.error("reconnect: Login failed")
-            return {}
-
-        code = self.get_code(token)
-        Tokens = self.get_Tokens(code)
-
-        tf = open(self.tokensFile, "wb")
-        pickle.dump(Tokens, tf)
-        tf.close()
+        # check if we have a refresh token and last refresh was more then 1h ago (3600s)
+        if 'refresh_token' in self.store['Tokens']:
+            now = int(time.time())
+            secs_since_refresh = now - self.store['refresh_timestamp']
+            if secs_since_refresh > TOKENS_REFRESH_THRESHOLD:
+                # try to refresh tokens
+                new_tokens = self.refresh_tokens()
+                self.store['refresh_timestamp'] = int(time.time())
+                _ref = True
+            else:
+                # keep existing tokens
+                return self.store['Tokens']
+        else:
+            self.log.debug("reconnect: refresh_token not found in self.store['Tokens']=" +
+                           json.dumps(self.store['Tokens'], indent=4))
+            new_tokens = {'refresh_token': '', 'access_token': ''}
+            _ref = False
+        self.log.debug("reconnect: new_tokens=" + json.dumps(new_tokens, indent=4))
+        if new_tokens['access_token'] == '':
+            if _ref:
+                self.log.warning("reconnect: refresh access_token failed, try full reconnect")
+            Tokens = self.get_tokens()
+        else:
+            self.log.debug("reconnect: refresh access_token successful")
+            Tokens = self.store['Tokens']   # replace expired access and refresh token by new tokens
+            for key in new_tokens:
+                Tokens[key] = new_tokens[key]
+                self.log.debug("reconnect: replace Tokens[" + key + "], new value: " + str(Tokens[key]))
 
         return Tokens
 
     # get Soc of Vehicle
     def get_status(self, vin: str) -> int:
-        url7 = STATUS_URL + "/seqc/v0/vehicles/" + vin +\
-               "/init-data?requestedData=BOTH&countryCode=DE&locale=de-DE"
-        headers7 = {
+        self.method += " 1-get_status"
+        if self.init:
+            url = STATUS_URL + "/seqc/v0/vehicles/" + vin +\
+                   "/init-data?requestedData=BOTH&countryCode=DE&locale=de-DE"
+        else:
+            url = STATUS_URL + "/seqc/v0/vehicles/" + vin + "/refresh-data"
+            self.init = False
+
+        headers = {
             "accept": "*/*",
             "accept-language": "de-DE;q=1.0",
-            "authorization": "Bearer " + self.Tokens['access_token'],
+            "authorization": "Bearer " + self.store['Tokens']['access_token'],
             "x-applicationname": CLIENT_ID,
             "user-agent": "Device: iPhone 6; OS-version: iOS_12.5.1; App-Name: smart EQ control; App-Version: 3.0;\
             Build: 202108260942; Language: de_DE",
@@ -214,55 +347,77 @@ class smarteq:
         }
 
         try:
-            response7 = self.session.get(url7, headers=headers7)
-            res7 = json.loads(response7.text)
-            res7s = json.dumps(res7, indent=4)
-            res7s = json.dumps(res7['precond']['data']['soc'], indent=4)
-            try:
-                soc = res7['precond']['data']['soc']['value']
-                self.log.info("get_status: result json:\n" + res7s)
-            except:
+            response = self.session.get(url, headers=headers)
+            res = json.loads(response.text)
+            res_json = json.dumps(res, indent=4)
+            if keys_exist(res, 'precond', 'data', 'soc', 'value'):
+                res_json = json.dumps(res['precond']['data']['soc'], indent=4)
+                try:
+                    soc = res['precond']['data']['soc']['value']
+                    _ts = res['precond']['data']['soc']['ts']
+                    self.soc_ts = datetime.datetime.fromtimestamp(_ts).strftime('%Y-%m-%d %H:%M:%S')
+                    self.log.debug("get_status: result json:\n" + res_json)
+                except:
+                    soc = -1
+            elif 'error' in res and res['error'] == 'unauthorized':
+                self.log.warning("get_status: access_token expired - try refresh")
+                self.log.debug("get_status: error - result json:\n" + res_json)
                 soc = -1
-                pass
+
         except Exception as e:
             self.log.error("get_status: Exception: " + str(e))
-            self.log.error("get_status: result json:\n" + res7s)
+            self.log.error("get_status: result:\n" + res_json)
             soc = -1
-        if "Vehicle not found" in res7s:
+        if "Vehicle not found" in res_json:
             soc = -2
         return soc
 
+    # fetch soc in 3 stages:
+    #   1. get_status via stored access_token
+    #   2. if expired: refresh_access_token using id and refresh token, then get_status
+    #   3. if refresh token expired: login, get tokens, then get_status
     def fetch_soc(self) -> int:
         soc = -1
         try:
-            try:
-                if self.Tokens['access_token']:
-                    soc = self.get_status(self.vin)
-                    self.log.info("fetch_soc: 1st attempt successful - skip reconnect")
-            except Exception as e:
-                soc = -1
-                pass
+            if 'refresh_token' in self.store['Tokens']:
+                self.store['Tokens'] = self.reconnect()
+            if 'access_token' in self.store['Tokens']:
+                soc = self.get_status(self.vin)
+                if soc > 0:
+                    self.log.debug("fetch_soc: 1st attempt successful")
+                else:
+                    self.log.debug("fetch_soc: 1st attempt failed - soc=" + str(soc))
 
             if soc == -1:
-                self.log.info("fetch_soc: (re)connecting ...")
-                self.resume = self.get_resume()
-                self.Tokens = self.reconnect()
-                if self.Tokens:
+                self.log.debug("fetch_soc: (re)connecting ...")
+                self.store['Tokens'] = self.reconnect()
+                if 'access_token' in self.store['Tokens']:
                     soc = self.get_status(self.vin)
+                    if soc > 0:
+                        self.log.debug("fetch_soc: 2nd attempt successful")
+                    else:
+                        self.log.warning("fetch_soc: 2nd attempt failed - soc=" + str(soc))
                 else:
                     self.log.error("fetch_soc: (re-)connect failed")
                     soc = 0
             elif soc == -2:
                 self.log.error("fetch_soc: failed, Vehicle not found, check VIN")
                 soc = 0
-                pass
 
         except Exception as e:
             self.log.error("fetch_soc: exception, (re-)connecting ..." + str(e))
-            self.resume = self.get_resume()
-            self.Tokens = self.reconnect()
-            soc = self.get_status(self.vin)
-        self.log.info("fetch_soc: result: soc=" + str(soc) + '%')
+            self.store['Tokens'] = self.reconnect()
+            if 'access_token' in self.store['Tokens']:
+                soc = self.get_status(self.vin)
+        self.log.info("Lp" + self.chargepoint +
+                " SOC: " + str(soc) + '%' +
+                      '@' + self.soc_ts +
+                      ', Method: ' + self.method)
+
+        if self.store['Tokens'] != self.oldTokens:
+            self.log.debug("reconnect: tokens changed, store token file")
+
+        self.write_store()
         return soc
 
 
@@ -283,11 +438,10 @@ def main():
     vin = args['vin']
     chargepoint = args['chargepoint']
 
-    OPENWBBASEDIR = os.environ.get("OPENWBBASEDIR", "undefined")
     RAMDISKDIR = os.environ.get("RAMDISKDIR", "undefined")
-    tokensFile = RAMDISKDIR+'/soc_smarteq_tokens_lp'+chargepoint
+    storeFile = RAMDISKDIR+'/soc_smarteq_store_lp'+chargepoint
 
-    Smart = smarteq(tokensFile)
+    Smart = smarteq(storeFile)
     Smart.set_credentials(user_id, password)
     Smart.set_vin(vin)
     Smart.set_chargepoint(chargepoint)

--- a/modules/soc_smarteq/soc_smarteq.py
+++ b/modules/soc_smarteq/soc_smarteq.py
@@ -27,12 +27,12 @@ TOKENS_REFRESH_THRESHOLD = 3600
 
 
 # helper functions
-def nested_keys_exist(element: dict, *keys) -> bool:
+def nested_key_exists(element: dict, *keys: str) -> bool:
     # Check if *keys (nested) exists in `element` (dict).
     if not isinstance(element, dict):
-        raise AttributeError('nested_keys_exist() expects dict as first argument - got type ' + str(type(element)))
+        raise AttributeError('nested_key_exists() expects dict as first argument - got type ' + str(type(element)))
     if len(keys) == 0:
-        raise AttributeError('nested_keys_exist() expects at least two arguments, one given.')
+        raise AttributeError('nested_key_exists() expects at least two arguments, one given.')
 
     _element = element
     for key in keys:
@@ -350,7 +350,7 @@ class smarteq:
             response = self.session.get(url, headers=headers)
             res = json.loads(response.text)
             res_json = json.dumps(res, indent=4)
-            if nested_keys_exist(res, 'precond', 'data', 'soc', 'value'):
+            if nested_key_exists(res, 'precond', 'data', 'soc', 'value'):
                 res_json = json.dumps(res['precond']['data']['soc'], indent=4)
                 try:
                     soc = res['precond']['data']['soc']['value']


### PR DESCRIPTION
implement token refresh
improve logging.
mode 0: only errors and warnings are logged
mode 1 (info) delivers in soc.log 1 line per run like:
2022-12-17 11:27:45 INFO:soc_smarteq:Lp2 SOC: 82%@2022-12-17 08:38:44, Method:  2-refresh_tokens 1-get_status
- timestamp of soc-update
- INFO: logging level
- soc_smarteq: module name
- SOC xx%: soc-percent
- @: timestamp of car-server update
- Method: steps done 
- 1-get_status: simplest and fastest step with valid access_token
- 2-refresh-tokens: refresh access token with valid refresh token, then 1-get_status, slightly slower the only 1
- 3-full (re)connect: login with username and password, then 1-get_status, takes considerably more ttime than 1 and 2

3-full reconnect can be avoided by setting both intervals to less than 2 hours, e.g. 90/10!

mode 3: full logging of all details