### PR TITLE
E3dc....

### DIFF
--- a/packages/modules/devices/e3dc/config.py
+++ b/packages/modules/devices/e3dc/config.py
@@ -12,7 +12,7 @@ class E3dcConfiguration:
 class E3dc:
     def __init__(self,
                  name: str = "E3DC",
-                 type: str = "E3DC",
+                 type: str = "e3dc",
                  id: int = 0,
                  configuration: E3dcConfiguration = None) -> None:
         self.name = name


### PR DESCRIPTION
Für Openwb 2.0 muss offensichtlich der die type Variable dem Verzeichnissnamen entsprechen , sonst Absturz im Online beim konfigurieren 
` 
Bei der Verarbeitung des Befehls 'addDevice' mit den Parametern '[object Object]' ist ein Fehler aufgetreten: Es ist ein interner Fehler aufgetreten: Traceback (most recent call last):
  File "/var/www/html/openWB/packages/helpermodules/command.py", line 112, in on_message
    func(connection_id, payload)
  File "/var/www/html/openWB/packages/helpermodules/command.py", line 123, in addDevice
    dev = importlib.import_module(".devices."+payload["data"]["type"]+".device", "modules")
  File "/usr/lib/python3.9/importlib/__init__.py", line 127, in import_module
    return _bootstrap._gcd_import(name[level:], package, level)
  File "", line 1030, in _gcd_import
  File "", line 1007, in _find_and_load
  File "", line 972, in _find_and_load_unlocked
  File "", line 228, in _call_with_frames_removed
  File "", line 1030, in _gcd_import
  File "", line 1007, in _find_and_load
  File "", line 984, in _find_and_load_unlocked
ModuleNotFoundError: No module named 'modules.devices.E3DC'
`
Für openwb 1.9 keine Auswirkungen