### PR TITLE
at_reboot.sh: install lxml via apt-get instead via pip3

### DIFF
--- a/runs/atreboot.sh
+++ b/runs/atreboot.sh
@@ -303,7 +303,7 @@ at_reboot() {
 	if python3 -c "import lxml" &> /dev/null; then
 		echo 'lxml installed...'
 	else
-		sudo pip3 install lxml
+		sudo apt-get install python3-lxml
 	fi
 	#Prepare for secrets used in soc module libvwid in Python
 	VWIDMODULEDIR="$OPENWBBASEDIR/modules/soc_vwid"


### PR DESCRIPTION
feedback from user recommends to install python3 lxml  module via apt-get to avoid memory problems during compile with pip3