### PR TITLE
soc_evcc: add pin for fiat

### DIFF
--- a/modules/soc_evcc/main.sh
+++ b/modules/soc_evcc/main.sh
@@ -78,7 +78,7 @@ getAndWriteSoc(){
 	if [ "${fztype}" == "fiat" ]; then
 		options="${options} --pin ${pin}"
 	fi
-	answer=$($MODULEDIR/../soc_evcc/soc $options 2>&1)
+	answer=$($MODULEDIR/soc $options 2>&1)
 	if [ $? -eq 0 ]; then
 		# we got a valid answer
 		# catch float
@@ -96,7 +96,7 @@ wakeupCar(){
 	if [ "${fztype}" == "fiat" ]; then
 		options="${options} --pin ${pin}"
 	fi
-	answer=$($MODULEDIR/../soc_evcc/soc $options --action wakeup 2>&1)
+	answer=$($MODULEDIR/soc $options --action wakeup 2>&1)
 	if [ $? -eq 0 ]; then
 		# we got a valid answer
 		openwbDebugLog ${DMOD} 0 "Lp$CHARGEPOINT: Wakeup Message from EVCC: $answer"

--- a/modules/soc_evcc/main.sh
+++ b/modules/soc_evcc/main.sh
@@ -25,6 +25,7 @@ case $CHARGEPOINT in
 		username=$soc_evcc_username_lp2
 		password=$soc_evcc_password_lp2
 		vin=$soc_evcc_vin_lp2
+		pin=$soc_evcc_pin_lp2
 		token=$soc_evcc_token_lp2
 		intervall=$(( soc2intervall * 6 ))
 		intervallladen=$(( soc2intervallladen * 6 ))
@@ -40,6 +41,7 @@ case $CHARGEPOINT in
 		username=$soc_evcc_username_lp1
 		password=$soc_evcc_password_lp1
 		vin=$soc_evcc_vin_lp1
+		pin=$soc_evcc_pin_lp1
 		token=$soc_evcc_token_lp1
 		intervall=$(( soc_evcc_intervall * 6 ))
 		intervallladen=$(( soc_evcc_intervallladen * 6 ))
@@ -72,7 +74,11 @@ incrementTimer(){
 getAndWriteSoc(){
 	openwbDebugLog ${DMOD} 0 "Lp$CHARGEPOINT: Requesting SoC"
 	echo 0 > $soctimerfile
-	answer=$($MODULEDIR/../soc_evcc/soc $fztype --user "$username" --password "$password" --vin "$vin" --token "$token" 2>&1)
+	options="${fztype} --user ${username} --password ${password} --vin ${vin} --token ${token}"
+	if [ "${fztype}" == "fiat" ]; then
+		options="${options} --pin ${pin}"
+	fi
+	answer=$($MODULEDIR/../soc_evcc/soc $options 2>&1)
 	if [ $? -eq 0 ]; then
 		# we got a valid answer
 		# catch float
@@ -86,7 +92,11 @@ getAndWriteSoc(){
 }
 wakeupCar(){
 	openwbDebugLog ${DMOD} 0 "Lp$CHARGEPOINT: Wakeup car"
-	answer=$($MODULEDIR/../soc_evcc/soc $fztype --user "$username" --password "$password" --vin "$vin" --token "$token" --action wakeup 2>&1)
+	options="${fztype} --user ${username} --password ${password} --vin ${vin} --token ${token}"
+	if [ "${fztype}" == "fiat" ]; then
+		options="${options} --pin ${pin}"
+	fi
+	answer=$($MODULEDIR/../soc_evcc/soc $options --action wakeup 2>&1)
 	if [ $? -eq 0 ]; then
 		# we got a valid answer
 		openwbDebugLog ${DMOD} 0 "Lp$CHARGEPOINT: Wakeup Message from EVCC: $answer"

--- a/runs/updateConfig.sh
+++ b/runs/updateConfig.sh
@@ -2226,6 +2226,7 @@ updateConfig(){
 			echo "soc_evcc_username_lp1=''"
 			echo "soc_evcc_password_lp1=''"
 			echo "soc_evcc_vin_lp1=''"
+			echo "soc_evcc_pin_lp1=''"
 			echo "soc_evcc_token_lp1=''"
 			echo "soc_evcc_intervall=720"
 			echo "soc_evcc_intervallladen=15"
@@ -2233,8 +2234,15 @@ updateConfig(){
 			echo "soc_evcc_username_lp2=''"
 			echo "soc_evcc_password_lp2=''"
 			echo "soc_evcc_vin_lp2=''"
+			echo "soc_evcc_pin_lp2=''"
 			echo "soc_evcc_token_lp2=''"
 		} >> $ConfigFile
+	fi
+	if ! grep -Fq "soc_evcc_pin_lp1=" $ConfigFile; then
+			echo "soc_evcc_pin_lp1=''" >> $ConfigFile
+	fi
+	if ! grep -Fq "soc_evcc_pin_lp2=" $ConfigFile; then
+			echo "soc_evcc_pin_lp2=''" >> $ConfigFile
 	fi
 	if ! grep -Fq "cpunterbrechungmindestlaufzeitaktiv=" $ConfigFile; then
 		{

--- a/web/settings/modulconfiglp.php
+++ b/web/settings/modulconfiglp.php
@@ -1452,6 +1452,17 @@
 											</span>
 										</div>
 									</div>
+									<div id="socevccpinlp1" class="hide">
+										<div class="form-row mb-1">
+											<label for="soc_evcc_pin_lp1" class="col-md-4 col-form-label">PIN</label>
+											<div class="col">
+												<input class="form-control" type="text" name="soc_evcc_pin_lp1" id="soc_evcc_pin_lp1" value="<?php echo $soc_evcc_pin_lp1old ?>">
+												<span class="form-text small">
+													Sicherheits-PIN der App des Fahrzeugs
+												</span>
+											</div>
+										</div>
+									</div>
 									<div class="form-row mb-1">
 										<label for="soc_evcc_token_lp1" class="col-md-4 col-form-label">Token</label>
 										<div class="col">
@@ -1481,8 +1492,21 @@
 									</div>
 								</div>
 								<script>
+									function visibility_socevccpinlp1() {
+										if($('#soc_evcc_type_lp1').val() == 'fiat') {
+											showSection('#socevccpinlp1');
+										} else {
+											hideSection('#socevccpinlp1');
+										}
+									}
+
+									$(function() {
+										visibility_socevccpinlp1();
+									});
+
 									$('#soc_evcc_select_vehicle_lp1').change(function(){
 										$('#soc_evcc_type_lp1').val($(this).val());
+										visibility_socevccpinlp1();
 									});
 
 									$('#soc_evcc_load_vehicles_lp1').click(function(){
@@ -4068,6 +4092,17 @@
 											</span>
 										</div>
 									</div>
+									<div id="socevccpinlp2" class="hide">
+										<div class="form-row mb-1">
+											<label for="soc_evcc_pin_lp2" class="col-md-4 col-form-label">PIN</label>
+											<div class="col">
+												<input class="form-control" type="text" name="soc_evcc_pin_lp2" id="soc_evcc_pin_lp2" value="<?php echo $soc_evcc_pin_lp2old ?>">
+												<span class="form-text small">
+													Sicherheits-PIN der App des Fahrzeugs
+												</span>
+											</div>
+										</div>
+									</div>
 									<div class="form-row mb-1">
 										<label for="soc_evcc_token_lp2" class="col-md-4 col-form-label">Token</label>
 										<div class="col">
@@ -4079,8 +4114,20 @@
 									</div>
 								</div>
 								<script>
+									function visibility_socevccpinlp2() {
+										if($('#soc_evcc_type_lp2').val() == 'fiat') {
+											showSection('#socevccpinlp2');
+										} else {
+											hideSection('#socevccpinlp2');
+										}
+									}
+
+									$(function() {
+										visibility_socevccpinlp2();
+									});
 									$('#soc_evcc_select_vehicle_lp2').change(function(){
 										$('#soc_evcc_type_lp2').val($(this).val());
+										visibility_socevccpinlp2();
 									});
 
 									$('#soc_evcc_load_vehicles_lp2').click(function(){


### PR DESCRIPTION
Fiat requires an app pin for SoC access, so add optional field to enter that pin and only use it if car type is fiat.