### PR TITLE
smarthome fix

### DIFF
--- a/packages/modules/smarthome/lambda_/smartlambda.py
+++ b/packages/modules/smarthome/lambda_/smartlambda.py
@@ -8,12 +8,11 @@ class Slambda(Sbase):
     def __init__(self):
         # setting
         super().__init__()
-        print('__init__ Slambda executed')
 
     def getwatt(self, uberschuss, uberschussoffset):
         self.prewatt(uberschuss, uberschussoffset)
         forcesend = self.checkbefsend()
-        argumentList = ['python3', self._prefixpy + 'lambda/watt.py',
+        argumentList = ['python3', self._prefixpy + 'lambda_/watt.py',
                         str(self.device_nummer), str(self._device_ip),
                         str(self.devuberschuss), str(self.device_lambdaueb),
                         str(forcesend)]
@@ -38,7 +37,7 @@ class Slambda(Sbase):
             pname = "/on.py"
         else:
             pname = "/off.py"
-        argumentList = ['python3', self._prefixpy + 'lambda' + pname,
+        argumentList = ['python3', self._prefixpy + 'lambda_' + pname,
                         str(self.device_nummer), str(self._device_ip),
                         str(self.devuberschuss), str(self.device_lambdaueb)]
         try:

--- a/packages/modules/smarthome/ratiotherm/smartratiotherm.py
+++ b/packages/modules/smarthome/ratiotherm/smartratiotherm.py
@@ -5,12 +5,12 @@ import subprocess
 
 
 class Sratiotherm(Sbase):
-    def __init__(self):
+    def __init__(self) -> None:
         # setting
         super().__init__()
-        print('__init__ Sratiotherm executed')
+        self._dynregel = 1
 
-    def getwatt(self, uberschuss, uberschussoffset):
+    def getwatt(self, uberschuss: int, uberschussoffset: int) -> None:
         self.prewatt(uberschuss, uberschussoffset)
         forcesend = self.checkbefsend()
         argumentList = ['python3', self._prefixpy + 'ratiotherm/watt.py',
@@ -32,7 +32,7 @@ class Sratiotherm(Sbase):
                            str(self._device_ip), str(e1)))
         self.postwatt()
 
-    def turndevicerelais(self, zustand, ueberschussberechnung, updatecnt):
+    def turndevicerelais(self, zustand: int, ueberschussberechnung: int, updatecnt: int) -> None:
         self.preturn(zustand, ueberschussberechnung, updatecnt)
         if (zustand == 1):
             pname = "/on.py"


### PR DESCRIPTION
Ratiotherm alter PR  (Dynregel = 1) angepasst (auf neuen Verzeichnispfad umgestellt)
https://github.com/snaptec/openWB/pull/2588

Verzeichnispfad von Lambda an neuen Verzeichnispfad Lambda_ angepasst.
Lambda und Ratiotherm überflüssiger print im init entfernt