### PR TITLE
Problem 1+3 Sungrow SG (Siehe ISSU Beschreibung)

### DIFF
--- a/packages/modules/devices/sungrow/counter.py
+++ b/packages/modules/devices/sungrow/counter.py
@@ -38,10 +38,8 @@ class SungrowCounter:
             # powers = [power / 10 for power in powers]
             # log.info("power: " + str(power) + " powers?: " + str(powers))
         else:
-            power = self.__tcp_client.read_input_registers(5082, ModbusDataType.INT_32,
+            power = self.__tcp_client.read_input_registers(5090, ModbusDataType.INT_32,
                                                            wordorder=Endian.Little, unit=unit)
-            if self.component_config.configuration.version == Version.SG_winet_dongle:
-                power = power * -1
             # no valid data for powers per phase
             # powers = self.__tcp_client.read_input_registers(5084, [ModbusDataType.UINT_16] * 3,
             #                                                 wordorder=Endian.Little, unit=unit)


### PR DESCRIPTION
Entfernen SG Auslesung WII NET. 

Die Auswahl muss bei EVU och entfernt werden. 

Neues Modbus Register für SG zum testen, ob dieser auch Tagsüber kontinuierlich richtige Werte zurückgibt. 

Siehe 

https://github.com/snaptec/openWB/issues/2637


