### PR TITLE
Service cleanup

### DIFF
--- a/runs/atreboot.sh
+++ b/runs/atreboot.sh
@@ -125,7 +125,6 @@ at_reboot() {
 		fi
 	fi
 
-
 	# display setup
 	echo "display..."
 	# remove old display config file
@@ -164,15 +163,6 @@ at_reboot() {
 		echo "executed"
 		sed -i '/atreboot.sh/d' "$OPENWBBASEDIR/ramdisk/tmprootcrontab"
 		cat "$OPENWBBASEDIR/ramdisk/tmprootcrontab" | sudo crontab -
-	fi
-
-	# check for LAN/WLAN connection
-	echo "LAN/WLAN..."
-	ethstate=$(</sys/class/net/eth0/carrier)
-	if (( ethstate == 1 )); then
-		sudo ifconfig eth0:0 "$virtual_ip_eth0" netmask 255.255.255.0 up
-	else
-		sudo ifconfig wlan0:0 "$virtual_ip_wlan0" netmask 255.255.255.0 up
 	fi
 
 	# check for apache configuration
@@ -227,8 +217,6 @@ at_reboot() {
 		sleep 1
 		sudo apt-get -qq install -y libxslt1-dev
 	fi
-	# no need to reload config
-	# . $OPENWBBASEDIR/loadconfig.sh
 
 	# update old ladelog
 	"$OPENWBBASEDIR/runs/transferladelog.sh"

--- a/runs/atreboot.sh
+++ b/runs/atreboot.sh
@@ -16,7 +16,7 @@ at_reboot() {
 		target=$2
 		currentVersion=$(grep -o "openwb-version:[0-9]\+" "$file" | grep -o "[0-9]\+$")
 		installedVersion=$(grep -o "openwb-version:[0-9]\+" "$target" | grep -o "[0-9]\+$")
-		if (( currentVersion == installedVersion )); then
+		if ((currentVersion == installedVersion)); then
 			return 0
 		else
 			return 1
@@ -24,7 +24,13 @@ at_reboot() {
 	}
 
 	echo "atreboot.sh started"
-	(sleep 600; echo "checking for stalled atreboot after 10 minutes"; echo 0 > "$OPENWBBASEDIR/ramdisk/bootinprogress"; echo 0 > "$OPENWBBASEDIR/ramdisk/updateinprogress"; sudo kill "$$") &
+	(
+		sleep 600
+		echo "checking for stalled atreboot after 10 minutes"
+		echo 0 >"$OPENWBBASEDIR/ramdisk/bootinprogress"
+		echo 0 >"$OPENWBBASEDIR/ramdisk/updateinprogress"
+		sudo kill "$$"
+	) &
 
 	# read openwb.conf
 	echo "loading config"
@@ -111,7 +117,7 @@ at_reboot() {
 	fi
 
 	# initialize automatic phase switching
-	if (( u1p3paktiv == 1 )); then
+	if ((u1p3paktiv == 1)); then
 		echo "triginit..."
 		# quick init of phase switching with default pause duration (2s)
 		sudo python "$OPENWBBASEDIR/runs/triginit.py"
@@ -132,7 +138,7 @@ at_reboot() {
 		rm "/home/pi/.config/lxsession/LXDE-pi/lxdeyeah"
 	fi
 	# check if display is configured and setup timeout
-	if (( displayaktiv == 1 )); then
+	if ((displayaktiv == 1)); then
 		if versionMatch "$OPENWBBASEDIR/web/files/lxdeautostart" /home/pi/.config/lxsession/LXDE-pi/autostart; then
 			echo "already up to date"
 		else
@@ -147,19 +153,17 @@ at_reboot() {
 
 	# check crontab for user pi
 	echo "crontab 1..."
-	crontab -l -u pi > "$OPENWBBASEDIR/ramdisk/tmpcrontab"
-	if grep -Fq "lade.log" "$OPENWBBASEDIR/ramdisk/tmpcrontab"
-	then
+	crontab -l -u pi >"$OPENWBBASEDIR/ramdisk/tmpcrontab"
+	if grep -Fq "lade.log" "$OPENWBBASEDIR/ramdisk/tmpcrontab"; then
 		echo "crontab modified"
 		sed -i '/lade.log/d' "$OPENWBBASEDIR/ramdisk/tmpcrontab"
-		echo "* * * * * $OPENWBBASEDIR/regel.sh >> /var/log/openWB.log 2>&1" >> "$OPENWBBASEDIR/ramdisk/tmpcrontab"
+		echo "* * * * * $OPENWBBASEDIR/regel.sh >> /var/log/openWB.log 2>&1" >>"$OPENWBBASEDIR/ramdisk/tmpcrontab"
 		cat "$OPENWBBASEDIR/ramdisk/tmpcrontab" | crontab -u pi -
 	fi
 
 	# check crontab for user root and remove old @reboot entry
-	sudo crontab -l > "$OPENWBBASEDIR/ramdisk/tmprootcrontab"
-	if grep -Fq "atreboot.sh" "$OPENWBBASEDIR/ramdisk/tmprootcrontab"
-	then
+	sudo crontab -l >"$OPENWBBASEDIR/ramdisk/tmprootcrontab"
+	if grep -Fq "atreboot.sh" "$OPENWBBASEDIR/ramdisk/tmprootcrontab"; then
 		echo "executed"
 		sed -i '/atreboot.sh/d' "$OPENWBBASEDIR/ramdisk/tmprootcrontab"
 		cat "$OPENWBBASEDIR/ramdisk/tmprootcrontab" | sudo crontab -
@@ -167,8 +171,7 @@ at_reboot() {
 
 	# check for apache configuration
 	echo "apache..."
-	if grep -Fxq "AllowOverride" /etc/apache2/sites-available/000-default.conf
-	then
+	if grep -Fxq "AllowOverride" /etc/apache2/sites-available/000-default.conf; then
 		echo "...ok"
 	else
 		sudo cp "$OPENWBBASEDIR/web/tools/000-default.conf" /etc/apache2/sites-available/
@@ -177,33 +180,38 @@ at_reboot() {
 
 	# add some crontab entries for user pi
 	echo "crontab 2..."
-	if ! sudo grep -Fq "cronnightly.sh" /var/spool/cron/crontabs/pi
-	then
-		(crontab -l -u pi ; echo "1 0 * * * $OPENWBBASEDIR/runs/cronnightly.sh >> /var/log/openWB.log 2>&1")| crontab -u pi -
+	if ! sudo grep -Fq "cronnightly.sh" /var/spool/cron/crontabs/pi; then
+		(
+			crontab -l -u pi
+			echo "1 0 * * * $OPENWBBASEDIR/runs/cronnightly.sh >> /var/log/openWB.log 2>&1"
+		) | crontab -u pi -
 	fi
-	if ! sudo grep -Fq "cron5min.sh" /var/spool/cron/crontabs/pi
-	then
-		(crontab -l -u pi ; echo "*/5 * * * * $OPENWBBASEDIR/runs/cron5min.sh >> /var/log/openWB.log 2>&1")| crontab -u pi -
+	if ! sudo grep -Fq "cron5min.sh" /var/spool/cron/crontabs/pi; then
+		(
+			crontab -l -u pi
+			echo "*/5 * * * * $OPENWBBASEDIR/runs/cron5min.sh >> /var/log/openWB.log 2>&1"
+		) | crontab -u pi -
 	fi
-	if ! sudo grep -Fq "atreboot.sh" /var/spool/cron/crontabs/pi
-	then
-		(crontab -l -u pi ; echo "@reboot $OPENWBBASEDIR/runs/atreboot.sh >> /var/log/openWB.log 2>&1")| crontab -u pi -
+	if ! sudo grep -Fq "atreboot.sh" /var/spool/cron/crontabs/pi; then
+		(
+			crontab -l -u pi
+			echo "@reboot $OPENWBBASEDIR/runs/atreboot.sh >> /var/log/openWB.log 2>&1"
+		) | crontab -u pi -
 	fi
 
 	# check for needed packages
 	echo "packages 1..."
-	if python -c "import evdev" &> /dev/null; then
+	if python -c "import evdev" &>/dev/null; then
 		echo 'evdev for python2 installed...'
 	else
 		sudo pip install evdev
 	fi
-	if ! [ -x "$(command -v sshpass)" ];then
+	if ! [ -x "$(command -v sshpass)" ]; then
 		sudo apt-get -qq update
 		sleep 1
 		sudo apt-get -qq install sshpass
 	fi
-	if [ "$(dpkg-query -W -f='${Status}' php-gd 2>/dev/null | grep -c "ok installed")" -eq 0 ];
-	then
+	if [ "$(dpkg-query -W -f='${Status}' php-gd 2>/dev/null | grep -c "ok installed")" -eq 0 ]; then
 		sudo apt-get -qq update
 		sleep 1
 		sudo apt-get -qq install -y php-gd
@@ -211,8 +219,7 @@ at_reboot() {
 		sudo apt-get -qq install -y php7.0-xml
 	fi
 	# required package for soc_vwid
-	if [ "$(dpkg-query -W -f='${Status}' libxslt1-dev 2>/dev/null | grep -c "ok installed")" -eq 0 ];
-	then
+	if [ "$(dpkg-query -W -f='${Status}' libxslt1-dev 2>/dev/null | grep -c "ok installed")" -eq 0 ]; then
 		sudo apt-get -qq update
 		sleep 1
 		sudo apt-get -qq install -y libxslt1-dev
@@ -222,7 +229,7 @@ at_reboot() {
 	"$OPENWBBASEDIR/runs/transferladelog.sh"
 
 	# check for led handler
-	if (( ledsakt == 1 )); then
+	if ((ledsakt == 1)); then
 		echo "led..."
 		sudo python "$OPENWBBASEDIR/runs/leds.py" startup
 	fi
@@ -231,13 +238,11 @@ at_reboot() {
 	echo "timezone..."
 	sudo cp /usr/share/zoneinfo/Europe/Berlin /etc/localtime
 
-
 	if [ ! -f /home/pi/ssl_patched ]; then
 		sudo apt-get update
 		sudo apt-get -qq install -y openssl libcurl3 curl libgcrypt20 libgnutls30 libssl1.1 libcurl3-gnutls libssl1.0.2 php7.0-cli php7.0-gd php7.0-opcache php7.0 php7.0-common php7.0-json php7.0-readline php7.0-xml php7.0-curl libapache2-mod-php7.0
 		touch /home/pi/ssl_patched
 	fi
-
 
 	# check for mosquitto packages
 	echo "mosquitto..."
@@ -259,7 +264,7 @@ at_reboot() {
 	python3 -u "$OPENWBBASEDIR/runs/installPythonPackages.py"
 
 	#Prepare for lxml used in soc module libvwid in Python
-	if python3 -c "import lxml" &> /dev/null; then
+	if python3 -c "import lxml" &>/dev/null; then
 		echo 'lxml installed...'
 	else
 		sudo apt-get install python3-lxml
@@ -267,7 +272,7 @@ at_reboot() {
 
 	#Prepare for secrets used in soc module libvwid in Python
 	VWIDMODULEDIR="$OPENWBBASEDIR/modules/soc_vwid"
-	if python3 -c "import secrets" &> /dev/null; then
+	if python3 -c "import secrets" &>/dev/null; then
 		echo 'soc_vwid: python3 secrets installed...'
 		if [ -L "$VWIDMODULEDIR/secrets.py" ]; then
 			echo 'soc_vwid: remove local python3 secrets.py...'
@@ -281,7 +286,7 @@ at_reboot() {
 	fi
 	#Prepare for secrets used in soc module soc_smarteq in Python
 	SMARTEQMODULEDIR="$OPENWBBASEDIR/modules/soc_smarteq"
-	if python3 -c "import secrets" &> /dev/null; then
+	if python3 -c "import secrets" &>/dev/null; then
 		echo 'soc_smarteq: python3 secrets installed...'
 		if [ -L "$SMARTEQMODULEDIR/secrets.py" ]; then
 			echo 'soc_smarteq: remove local python3 secrets.py...'
@@ -304,28 +309,27 @@ at_reboot() {
 
 	# all done, remove warning in display
 	echo "clear warning..."
-	echo "" > "$OPENWBBASEDIR/ramdisk/lastregelungaktiv"
-	echo "" > "$OPENWBBASEDIR/ramdisk/mqttlastregelungaktiv"
+	echo "" >"$OPENWBBASEDIR/ramdisk/lastregelungaktiv"
+	echo "" >"$OPENWBBASEDIR/ramdisk/mqttlastregelungaktiv"
 	chmod 777 "$OPENWBBASEDIR/ramdisk/mqttlastregelungaktiv"
 
 	"$OPENWBBASEDIR/runs/services.sh" restart
 
 	# get local ip
-	ip route get 1 | awk '{print $7;exit}' > "$OPENWBBASEDIR/ramdisk/ipaddress"
+	ip route get 1 | awk '{print $7;exit}' >"$OPENWBBASEDIR/ramdisk/ipaddress"
 
 	# update our local version
-	sudo git -C "$OPENWBBASEDIR" show --pretty='format:%ci [%h]' | head -n1 > "$OPENWBBASEDIR/web/lastcommit"
+	sudo git -C "$OPENWBBASEDIR" show --pretty='format:%ci [%h]' | head -n1 >"$OPENWBBASEDIR/web/lastcommit"
 	# and record the current commit details
 	commitId=$(git -C "$OPENWBBASEDIR" log --format="%h" -n 1)
-	echo "$commitId" > "$OPENWBBASEDIR/ramdisk/currentCommitHash"
-	git -C "$OPENWBBASEDIR" branch -a --contains "$commitId" | perl -nle 'm|.*origin/(.+).*|; print $1' | uniq | xargs > "$OPENWBBASEDIR/ramdisk/currentCommitBranches"
+	echo "$commitId" >"$OPENWBBASEDIR/ramdisk/currentCommitHash"
+	git -C "$OPENWBBASEDIR" branch -a --contains "$commitId" | perl -nle 'm|.*origin/(.+).*|; print $1' | uniq | xargs >"$OPENWBBASEDIR/ramdisk/currentCommitBranches"
 	sudo chmod 777 "$OPENWBBASEDIR/ramdisk/currentCommitHash"
 	sudo chmod 777 "$OPENWBBASEDIR/ramdisk/currentCommitBranches"
 
 	# update broker
 	echo "update broker..."
-	for i in $(seq 1 9);
-	do
+	for i in $(seq 1 9); do
 		configured=$(timeout 1 mosquitto_sub -C 1 -t "openWB/config/get/SmartHome/Devices/$i/device_configured")
 		if ! [[ "$configured" == 0 || "$configured" == 1 ]]; then
 			mosquitto_pub -r -t "openWB/config/get/SmartHome/Devices/$i/device_configured" -m "0"
@@ -344,9 +348,15 @@ at_reboot() {
 	mosquitto_pub -r -t openWB/SmartHome/Devices/2/TemperatureSensor1 -m ""
 	mosquitto_pub -r -t openWB/SmartHome/Devices/2/TemperatureSensor2 -m ""
 	rm -rf "$OPENWBBASEDIR/web/themes/dark19_01"
-	(sleep 10; mosquitto_pub -t openWB/set/ChargeMode -r -m "$bootmodus") &
-	(sleep 10; mosquitto_pub -t openWB/global/ChargeMode -r -m "$bootmodus") &
-	echo " " > "$OPENWBBASEDIR/ramdisk/lastregelungaktiv"
+	(
+		sleep 10
+		mosquitto_pub -t openWB/set/ChargeMode -r -m "$bootmodus"
+	) &
+	(
+		sleep 10
+		mosquitto_pub -t openWB/global/ChargeMode -r -m "$bootmodus"
+	) &
+	echo " " >"$OPENWBBASEDIR/ramdisk/lastregelungaktiv"
 	chmod 777 "$OPENWBBASEDIR/ramdisk/lastregelungaktiv"
 	chmod 777 "$OPENWBBASEDIR/ramdisk/smarthome.log"
 	chmod 777 "$OPENWBBASEDIR/ramdisk/smarthomehandlerloglevel"
@@ -355,7 +365,7 @@ at_reboot() {
 	echo "etprovider..."
 	if [[ "$etprovideraktiv" == "1" ]]; then
 		echo "update electricity pricelist..."
-		echo "" > "$OPENWBBASEDIR/ramdisk/etprovidergraphlist"
+		echo "" >"$OPENWBBASEDIR/ramdisk/etprovidergraphlist"
 		mosquitto_pub -r -t openWB/global/ETProvider/modulePath -m "$etprovider"
 		nohup "$OPENWBBASEDIR/modules/$etprovider/main.sh" >>"$LOGFILE" 2>&1 &
 	else
@@ -379,8 +389,8 @@ at_reboot() {
 
 	# all done, remove boot and update status
 	echo "$(date +"%Y-%m-%d %H:%M:%S:") boot done :-)"
-	echo 0 > "$OPENWBBASEDIR/ramdisk/bootinprogress"
-	echo 0 > "$OPENWBBASEDIR/ramdisk/updateinprogress"
+	echo 0 >"$OPENWBBASEDIR/ramdisk/bootinprogress"
+	echo 0 >"$OPENWBBASEDIR/ramdisk/updateinprogress"
 	mosquitto_pub -t openWB/system/updateInProgress -r -m "0"
 	mosquitto_pub -t openWB/system/reloadDisplay -m "1"
 }

--- a/runs/rse/rseDaemon.py
+++ b/runs/rse/rseDaemon.py
@@ -55,7 +55,8 @@ try:
             if rse_states[rse] != last_rse_states[rse]:
                 write_to_ramdisk(rse_inputs[rse]["file"], str("1" if rse_states[rse] else "0"))
                 log_debug(2, "rse input changed: RSE" + str(rse) + ": " + str(last_rse_states[rse]) + "->" +
-                          str(rse_states[rse]) + " (" + str("1" if rse_states[rse] else "0") + ">" + rse_inputs[rse]["file"] + ")")
+                          str(rse_states[rse]) + " (" + str("1" if rse_states[rse] else "0") + ">" +
+                          rse_inputs[rse]["file"] + ")")
         time.sleep(10.2)
         last_rse_states = rse_states
 except Exception as e:

--- a/runs/services.sh
+++ b/runs/services.sh
@@ -70,7 +70,7 @@ start() {
 	if (( isss == 1 )) || [[ "$evsecon" == "daemon" ]] || [[ "$evsecon" == "buchse" ]]; then
 		if [[ "$evsecon" == "buchse" ]]; then
 			isss_mode="socket"
-		elif [[ $lastmanagement == 1 ]]; then
+		elif [[ $lastmanagement == 1 ]] && { [[ $evsecons1 == "modbusevse" ]] || [[ $evsecons1 == "daemon" ]]; }; then
 			isss_mode="duo"
 		else
 			isss_mode="daemon"

--- a/runs/services.sh
+++ b/runs/services.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 OPENWBBASEDIR=$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)
 
-declare -F "openwbDebugLog" > /dev/null || . "$OPENWBBASEDIR/helperFunctions.sh"
+declare -F "openwbDebugLog" >/dev/null || . "$OPENWBBASEDIR/helperFunctions.sh"
 [[ -z "$debug" ]] && . "$OPENWBBASEDIR/loadconfig.sh"
 
 . "$OPENWBBASEDIR/runs/rfid/rfidHelper.sh"
@@ -17,28 +17,23 @@ stop() {
 	openwbDebugLog "MAIN" 0 "OpenWB services stopped"
 }
 
-
 start() {
 	openwbDebugLog "MAIN" 0 "Starting OpenWB services"
 
-
 	openwbDebugLog "MAIN" 1 "Starting modbus server..."
-	if pgrep -f '^python.*/modbusserver.py' > /dev/null
-	then
+	if pgrep -f '^python.*/modbusserver.py' >/dev/null; then
 		openwbDebugLog "MAIN" 1 "modbus tcp server already running"
 	else
 		openwbDebugLog "MAIN" 0 "modbus tcp server not running! restarting process"
-		sudo nohup python3 "$OPENWBBASEDIR/runs/modbusserver/modbusserver.py" >> "$OPENWBBASEDIR/ramdisk/openWB.log" 2>&1 &
+		sudo nohup python3 "$OPENWBBASEDIR/runs/modbusserver/modbusserver.py" >>"$OPENWBBASEDIR/ramdisk/openWB.log" 2>&1 &
 	fi
 
-
 	openwbDebugLog "MAIN" 1 "Starting MQTT handler..."
-	if pgrep -f '^python.*/mqttsub.py' > /dev/null
-	then
+	if pgrep -f '^python.*/mqttsub.py' >/dev/null; then
 		openwbDebugLog "MAIN" 1 "mqtt handler is already running"
 	else
 		openwbDebugLog "MAIN" 0 "mqtt handler not running! restarting process"
-		nohup python3 "$OPENWBBASEDIR/runs/mqttsub.py" >> "$OPENWBBASEDIR/ramdisk/openWB.log" 2>&1 &
+		nohup python3 "$OPENWBBASEDIR/runs/mqttsub.py" >>"$OPENWBBASEDIR/ramdisk/openWB.log" 2>&1 &
 	fi
 
 	openwbDebugLog "MAIN" 1 "smart home handler..."
@@ -57,9 +52,8 @@ start() {
 	fi
 
 	openwbDebugLog "MAIN" 1 "Starting legacy run server..."
-	pgrep -f "$OPENWBBASEDIR/packages/legacy_run_server.py" > /dev/null
-	if [ $? == 1 ]
-	then
+	pgrep -f "$OPENWBBASEDIR/packages/legacy_run_server.py" >/dev/null
+	if [ $? == 1 ]; then
 		openwbDebugLog "MAIN" 0 "legacy run server is not running. Restarting process"
 		bash "$OPENWBBASEDIR/packages/legacy_run_server.sh"
 	else
@@ -146,17 +140,18 @@ start() {
 }
 
 case "$1" in
-	start)
-		start
-		;;
-	stop)
-		stop
-		;;
-	restart)
-		stop
-		start
-		;;
-	*)
-		echo "Usage: ${BASH_SOURCE[0]} {start|stop|restart}"
-		exit 1
+start)
+	start
+	;;
+stop)
+	stop
+	;;
+restart)
+	stop
+	start
+	;;
+*)
+	echo "Usage: ${BASH_SOURCE[0]} {start|stop|restart}"
+	exit 1
+	;;
 esac

--- a/runs/services.sh
+++ b/runs/services.sh
@@ -66,8 +66,7 @@ start() {
 		openwbDebugLog "MAIN" 1 "legacy run server is already running"
 	fi
 
-
-	if (( isss == 1 )) || [[ "$evsecon" == "daemon" ]] || [[ "$evsecon" == "buchse" ]]; then
+	if ((isss == 1)) || [[ "$evsecon" == "daemon" ]] || [[ "$evsecon" == "buchse" ]]; then
 		if [[ "$evsecon" == "buchse" ]]; then
 			isss_mode="socket"
 		elif [[ $lastmanagement == 1 ]] && { [[ $evsecons1 == "modbusevse" ]] || [[ $evsecons1 == "daemon" ]]; }; then
@@ -75,48 +74,64 @@ start() {
 		else
 			isss_mode="daemon"
 		fi
-		prev_isss_mode=$(< $OPENWBBASEDIR/ramdisk/isss_mode)
+		prev_isss_mode=$(<"$OPENWBBASEDIR/ramdisk/isss_mode")
 
 		openwbDebugLog "MAIN" 1 "external openWB, daemon mode or socket mode configured"
-		if pgrep -f '^python.*/isss.py' > /dev/null && [[ $prev_isss_mode == $isss_mode ]];
-		then
+		if pgrep -f '^python.*/isss.py' >/dev/null && [[ $prev_isss_mode == "$isss_mode" ]]; then
 			openwbDebugLog "MAIN" 1 "isss handler already running"
 		else
 			openwbDebugLog "MAIN" 0 "Start/restart isss handler in mode $isss_mode."
 			if [ -f /home/pi/ppbuchse ]; then
-				ppbuchse=$(< /home/pi/ppbuchse)
+				ppbuchse=$(</home/pi/ppbuchse)
 				re='^[0-9]+$'
-				if ! [[ $ppbuchse =~ $re ]] ; then
+				if ! [[ $ppbuchse =~ $re ]]; then
 					openwbDebugLog "MAIN" 0 "Invalid value in ppbuchse. Set ppbuchse to 32."
 					ppbuchse=32
 				fi
 			else
 				ppbuchse=32
 			fi
-			nohup python3 "$OPENWBBASEDIR/runs/isss.py" "$isss_mode" "$ppbuchse">>"$OPENWBBASEDIR/ramdisk/isss.log" 2>&1 &
+			nohup python3 "$OPENWBBASEDIR/runs/isss.py" "$isss_mode" "$ppbuchse" >>"$OPENWBBASEDIR/ramdisk/isss.log" 2>&1 &
 		fi
-		echo "$isss_mode" > $OPENWBBASEDIR/ramdisk/isss_mode
+		echo "$isss_mode" >"$OPENWBBASEDIR/ramdisk/isss_mode"
 	else
-		openwbDebugLog "MAIN" 1 "external openWB, daemon mode or socket mode not configured; checking network setup"
-		local ethstate=$(</sys/class/net/eth0/carrier)
-		if (( ethstate == 1 )); then
+		openwbDebugLog "MAIN" 1 "external openWB, daemon mode or socket mode not configured"
+
+		# kill obsolete isss handler
+		sudo pkill -f '^python.*/isss.py'
+	fi
+
+	openwbDebugLog "MAIN" 1 "checking network setup"
+	if ((isss == 0)); then
+		# not in isss mode, setup virtual IPs
+		local eth_state
+		eth_state=$(</sys/class/net/eth0/carrier)
+		if ((eth_state == 1)); then
+			# network cable detected, setup eth nethwork
 			sudo ifconfig eth0:0 "$virtual_ip_eth0" netmask 255.255.255.0 up
-			if [ -d /sys/class/net/wlan0 ]; then
+			if [ -d "/sys/class/net/wlan0" ]; then
+				# remove wifi network
 				sudo ifconfig wlan0:0 "$virtual_ip_wlan0" netmask 255.255.255.0 down
-				local wlanstate=$(</sys/class/net/wlan0/carrier)
-				if (( wlanstate == 1 )); then
+				local wlan_state
+				wlan_state=$(</sys/class/net/wlan0/carrier)
+				if ((wlan_state == 1)); then
 					sudo systemctl stop hostapd
 					sudo systemctl stop dnsmasq
 				fi
 			fi
 		else
-			if [ -d /sys/class/net/wlan0 ]; then
+			# no network cable detected, setup wifi network
+			if [ -d "/sys/class/net/wlan0" ]; then
 				sudo ifconfig wlan0:0 "$virtual_ip_wlan0" netmask 255.255.255.0 up
 			fi
 			sudo ifconfig eth0:0 "$virtual_ip_eth0" netmask 255.255.255.0 down
 		fi
-		# kill obsolete isss handler
-		sudo pkill -f '^python.*/isss.py'
+	else
+		# in isss mode, remove virtual IPs
+		sudo ifconfig eth0:0 "$virtual_ip_eth0" netmask 255.255.255.0 down
+		if [ -d /sys/class/net/wlan0 ]; then
+			sudo ifconfig wlan0:0 "$virtual_ip_wlan0" netmask 255.255.255.0 down
+		fi
 	fi
 
 	if ((isss == 0)); then

--- a/runs/services.sh
+++ b/runs/services.sh
@@ -119,9 +119,13 @@ start() {
 		sudo pkill -f '^python.*/isss.py'
 	fi
 
-	rseSetup "$rseenabled" 0
-
-	pushButtonsSetup "$ladetaster" 0
+	if ((isss == 0)); then
+		rseSetup "$rseenabled" 0
+		pushButtonsSetup "$ladetaster" 0
+	else
+		rseStop
+		pushButtonsStop
+	fi
 
 	rfidSetup "$rfidakt" 0 "$rfidlist"
 }

--- a/runs/services.sh
+++ b/runs/services.sh
@@ -41,16 +41,20 @@ start() {
 		nohup python3 "$OPENWBBASEDIR/runs/mqttsub.py" >> "$OPENWBBASEDIR/ramdisk/openWB.log" 2>&1 &
 	fi
 
-
-	openwbDebugLog "MAIN" 1 "Starting smart home handler..."
-	if pgrep -f '^python.*/smarthomemq.py' > /dev/null
-	then
-		openwbDebugLog "MAIN" 1 "smart home handler is already running"
+	openwbDebugLog "MAIN" 1 "smart home handler..."
+	if ((isss == 0)); then
+		if pgrep -f '^python.*/smarthomemq.py' >/dev/null; then
+			openwbDebugLog "MAIN" 1 "smart home handler is already running"
+		else
+			openwbDebugLog "MAIN" 0 "smart home handler not running! restarting process"
+			nohup python3 "$OPENWBBASEDIR/runs/smarthomemq.py" >>"$OPENWBBASEDIR/ramdisk/smarthome.log" 2>&1 &
+		fi
 	else
-		openwbDebugLog "MAIN" 0 "smart home handler not running! restarting process"
-		nohup python3 "$OPENWBBASEDIR/runs/smarthomemq.py" >> "$OPENWBBASEDIR/ramdisk/smarthome.log" 2>&1 &
+		if pgrep -f '^python.*/smarthomemq.py' >/dev/null; then
+			openwbDebugLog "MAIN" 1 "smart home handler running but isss configured! killing process"
+			sudo pkill -f '^python.*/smarthomemq.py'
+		fi
 	fi
-
 
 	openwbDebugLog "MAIN" 1 "Starting legacy run server..."
 	pgrep -f "$OPENWBBASEDIR/packages/legacy_run_server.py" > /dev/null


### PR DESCRIPTION
- following services are only started if not in isss mode:
  - smarthome
  - rse
  - pushbuttons
- isss mode "duo" is only activated if second charge point is configured as modbus or daemon
- configuring virtual IPs is separated from isss mode detection as only setting "isss" has to be considered
- remove virtual IP setup from `atreboot.sh` as `services.sh`is already called and will handle this
- fixes #2608 #2427 
