### PR TITLE
fix logging error with unicode characters

### DIFF
--- a/packages/modules/devices/e3dc/counter.py
+++ b/packages/modules/devices/e3dc/counter.py
@@ -22,7 +22,7 @@ def read_counter(client: modbus.ModbusTcpClient_) -> Tuple[int, List[int]]:
     log.debug("Beginning EVU update")
     # 40130,40131, 40132 je Phasenleistung in Watt
     # max 7 Leistungsmesser verbaut ab 40105, typ 1 ist evu
-    # Modbus dokumentation Leistungsmesser von #0 bis #6
+    # Modbus Dokumentation Leistungsmesser von #0 bis #6
     # bei den meisten e3dc auf 40128
     # farm haben typ 5, normale e3dc haben nur typ 1 und keinen typ 5
     # bei farm ist typ 1 vorhanden aber liefert immer 0

--- a/packages/modules/devices/e3dc/external_inverter.py
+++ b/packages/modules/devices/e3dc/external_inverter.py
@@ -14,7 +14,7 @@ from modules.devices.e3dc.config import E3dcExternalInverterSetup
 log = logging.getLogger(__name__)
 
 
-def read_externalinverter(client: modbus.ModbusTcpClient_) -> int:
+def read_external_inverter(client: modbus.ModbusTcpClient_) -> int:
     # 40075 externe PV Leistung
     pv_external = int(client.read_holding_registers(40075, ModbusDataType.INT_32, wordorder=Endian.Little, unit=1))
     return pv_external
@@ -31,11 +31,11 @@ class E3dcExternalInverter:
 
     def update(self, client: modbus.ModbusTcpClient_) -> None:
 
-        pv_external = read_externalinverter(client)
+        pv_external = read_external_inverter(client)
         # pv_external - > pv Leistung
         # die als externe Produktion an e3dc angeschlossen ist
-        # Im gegensatz zu v1.9 implementierung wird nicht mehr die PV
-        # leistung vom WR1 gelesen, da die durch v2.0 separat gehandelt wird
+        # Im gegensatz zur Implementierung in Version 1.9 wird nicht mehr die PV
+        # Leistung vom WR1 gelesen, da die durch v2.0 separat gehandelt wird
         _, pv_exported = self.sim_counter.sim_count(pv_external)
         inverter_state = InverterState(
             power=pv_external,

--- a/packages/modules/devices/e3dc/inverter.py
+++ b/packages/modules/devices/e3dc/inverter.py
@@ -32,8 +32,8 @@ class E3dcInverter:
     def update(self, client: modbus.ModbusTcpClient_) -> None:
 
         pv = read_inverter(client)
-        # Im gegensatz zu v1.9 implementierung wird nicht mehr die PV
-        # leistung vom WR1 gelesen, da die durch v2.0 separat gehandelt wird
+        # Im gegensatz zur Implementierung in Version 1.9 wird nicht mehr die PV
+        # Leistung vom WR1 gelesen, da die durch v2.0 separat gehandelt wird
         _, pv_exported = self.sim_counter.sim_count(pv)
         inverter_state = InverterState(
             power=pv,


### PR DESCRIPTION
- added note to not log complete config objecs as it will contain german umlauts ("Zähler")
- changed logging to only print configuration details
- fixed spelling and python naming