### PR TITLE
Colors theme: Fix incorrect PV percentage

### DIFF
--- a/web/themes/colors/powergraph.js
+++ b/web/themes/colors/powergraph.js
@@ -275,7 +275,7 @@ class PowerGraph {
 				}
 			});
 			this.updateGraph();
-			this.updateEnergyValues(chargingPv, chargingBat, shPv, shBat, housePv, houseBat, calculatedHouseEnergy);
+			this.updateEnergyValues(chargingPv, chargingBat, shPv, shBat, housePv, houseBat, calculatedHouseEnergy/1000);
 			wbdata.dayGraphUpdated();
 			setTimeout(() => this.activateDay(), 300000)
 		}

--- a/web/themes/colors/powergraph.js
+++ b/web/themes/colors/powergraph.js
@@ -254,6 +254,7 @@ class PowerGraph {
 			let shBat = 0
 			let housePv = 0
 			let houseBat = 0
+			let calculatedHouseEnergy = 0;
 			this.initCounter = 0;
 			this.staging.map(segment =>
 				segment.map(line => this.rawData.push(line))
@@ -268,12 +269,13 @@ class PowerGraph {
 					shBat += (values.shBat / 12)
 					housePv += (values.housePv / 12)
 					houseBat += (values.houseBat / 12)
+					calculatedHouseEnergy += (values.housePower / 12)
 				} else {
 					// const values = this.extractValues(line, []);                
 				}
 			});
 			this.updateGraph();
-			this.updateEnergyValues(chargingPv, chargingBat, shPv, shBat, housePv, houseBat);
+			this.updateEnergyValues(chargingPv, chargingBat, shPv, shBat, housePv, houseBat, calculatedHouseEnergy);
 			wbdata.dayGraphUpdated();
 			setTimeout(() => this.activateDay(), 300000)
 		}
@@ -365,7 +367,7 @@ class PowerGraph {
 		}
 	}
 
-	updateEnergyValues(chargingPv, chargingBat, shPv, shBat, housePv, houseBat) {
+	updateEnergyValues(chargingPv, chargingBat, shPv, shBat, housePv, houseBat, calculatedHouse) {
 		if (this.rawData.length) {
 			const startValues = this.rawData[0].split(',');
 			const endValues = this.rawData[this.rawData.length - 1].split(',');
@@ -401,6 +403,11 @@ class PowerGraph {
 			wbdata.usageSummary.devices.energyBat = shBat / 1000;
 			wbdata.usageSummary.devices.pvPercentage = Math.round((wbdata.usageSummary.devices.energyPv + wbdata.usageSummary.devices.energyBat) / (wbdata.usageSummary.devices.energy) * 100)
 			wbdata.historicSummary.devices.pvPercentage = Math.round((wbdata.historicSummary.devices.energyPv + wbdata.historicSummary.devices.energyBat) / (wbdata.historicSummary.devices.energy) * 100)
+			// correct for incorrect calculations of PV or Bat portion
+			if (calculatedHouse > wbdata.historicSummary.house.energy) {
+				housePv = housePv / calculatedHouse * wbdata.historicSummary.house.energy
+				houseBat = houseBat / calculatedHouse * wbdata.historicSummary.house.energy
+			}	
 			wbdata.historicSummary.house.energyPv = housePv / 1000;
 			wbdata.usageSummary.house.energyPv = housePv / 1000;
 			wbdata.historicSummary.house.energyBat = houseBat / 1000;


### PR DESCRIPTION
Bei Verbrauchern mit unkonventionellen Zähler-Inkrementen (z.B. go-E-Charger) wird der PV-Anteil des Hausverbrauchs nicht korrekt angezeigt. Dieser Fix sollte solche Situationen erkennen und den PV- und Speicher-Anteil korrigieren. 