### PR TITLE
fix python2 syntax

### DIFF
--- a/modules/mpm3pmethll/readmpm3pm.py
+++ b/modules/mpm3pmethll/readmpm3pm.py
@@ -6,7 +6,7 @@ host = '192.168.193.16'
 unit_id = 5
 
 
-def write_to_ramdisk(file: str, content) -> None:
+def write_to_ramdisk(file, content):
     with open('/var/www/html/openWB/ramdisk/' + file, 'w') as f:
         f.write(str(content))
 

--- a/modules/mpm3pmethllframer/readmpm3pm.py
+++ b/modules/mpm3pmethllframer/readmpm3pm.py
@@ -7,7 +7,7 @@ host = '192.168.193.18'
 unit_id = 5
 
 
-def write_to_ramdisk(file: str, content) -> None:
+def write_to_ramdisk(file, content):
     with open('/var/www/html/openWB/ramdisk/' + file, 'w') as f:
         f.write(str(content))
 

--- a/modules/mpm3pmethlls2/readmpm3pm.py
+++ b/modules/mpm3pmethlls2/readmpm3pm.py
@@ -6,7 +6,7 @@ host = '192.168.193.26'
 unit_id = 5
 
 
-def write_to_ramdisk(file: str, content) -> None:
+def write_to_ramdisk(file, content):
     with open('/var/www/html/openWB/ramdisk/' + file, 'w') as f:
         f.write(str(content))
 

--- a/modules/mpm3pmll/readall.py
+++ b/modules/mpm3pmll/readall.py
@@ -5,7 +5,7 @@ import struct
 from pymodbus.client.sync import ModbusSerialClient
 
 
-def write_to_ramdisk(file: str, content) -> None:
+def write_to_ramdisk(file, content):
     with open('/var/www/html/openWB/ramdisk/' + file, 'w') as f:
         f.write(str(content))
 

--- a/modules/mpm3pmspeicher/readmpm3pm.py
+++ b/modules/mpm3pmspeicher/readmpm3pm.py
@@ -8,7 +8,7 @@ unit_id = int(sys.argv[2])
 pv_flag = str(sys.argv[3])
 
 
-def write_to_ramdisk(file: str, content) -> None:
+def write_to_ramdisk(file, content):
     with open('/var/www/html/openWB/ramdisk/' + file, 'w') as f:
         f.write(str(content))
 

--- a/modules/sdm120modbusll/readsdm3.py
+++ b/modules/sdm120modbusll/readsdm3.py
@@ -10,7 +10,7 @@ unit_id_2 = int(sys.argv[3])
 unit_id_3 = int(sys.argv[4])
 
 
-def write_to_ramdisk(file: str, content) -> None:
+def write_to_ramdisk(file, content):
     with open('/var/www/html/openWB/ramdisk/' + file, 'w') as f:
         f.write(str(content))
 


### PR DESCRIPTION
remove missed python3 type annotations in modules running on python2