### PR TITLE
smarthome 2.0 openWB 1.9 Zerlegung

### DIFF
--- a/packages/modules/smarthome/acthor/smartacthor.py
+++ b/packages/modules/smarthome/acthor/smartacthor.py
@@ -1,7 +1,6 @@
 #!/usr/bin/python3
 from smarthome.smartbase import Sbase
 from typing import Dict
-import subprocess
 import logging
 log = logging.getLogger(__name__)
 
@@ -47,8 +46,7 @@ class Sacthor(Sbase):
                         str(self.devuberschuss), self._device_acthortype,
                         self._device_acthorpower, str(forcesend)]
         try:
-            self.proc = subprocess.Popen(argumentList)
-            self.proc.communicate()
+            self.callpro(argumentList)
             self.answer = self.readret()
             self.newwatt = int(self.answer['power'])
             self.newwattk = int(self.answer['powerc'])
@@ -83,8 +81,7 @@ class Sacthor(Sbase):
                         str(self.device_nummer), str(self._device_ip),
                         str(self.devuberschuss)]
         try:
-            self.proc = subprocess.Popen(argumentList)
-            self.proc.communicate()
+            self.callpro(argumentList)
         except Exception as e1:
             log.warning("(" + str(self.device_nummer) +
                         ") on / off  %s %d %s Fehlermeldung: %s "

--- a/packages/modules/smarthome/avmhomeautomation/smartavm.py
+++ b/packages/modules/smarthome/avmhomeautomation/smartavm.py
@@ -1,21 +1,20 @@
 #!/usr/bin/python3
 from smarthome.smartbase import Sbase, Slavm
-import subprocess
+from typing import Dict
 import logging
 log = logging.getLogger(__name__)
 
 
 class Savm(Sbase):
-    def __init__(self):
+    def __init__(self) -> None:
         # setting
         super().__init__()
         self._old_measuretype0 = 'none'
-        self._smart_paramadd = {}
         self._device_actor = 'none'
         self._device_username = 'none'
         self._device_password = 'none'
 
-    def getwatt(self, uberschuss, uberschussoffset):
+    def getwatt(self, uberschuss: int, uberschussoffset: int) -> None:
         self.prewatt(uberschuss, uberschussoffset)
         self._mydevicemeasure0.devuberschuss = self.devuberschuss
         self._mydevicemeasure0.getwattread()
@@ -25,7 +24,7 @@ class Savm(Sbase):
 
         self.postwatt()
 
-    def updatepar(self, input_param):
+    def updatepar(self,  input_param: Dict[str, str]) -> None:
         super().updatepar(input_param)
         self._smart_paramadd = input_param.copy()
         self.device_nummer = int(self._smart_paramadd.get('device_nummer',
@@ -39,7 +38,7 @@ class Savm(Sbase):
                 self._device_password = value
             else:
                 log.info("(" + str(self.device_nummer) + ") " +
-                         __class__.__name__ + " überlesen " + key +
+                         " AVM überlesen " + key +
                          " " + value)
 
         if (self._old_measuretype0 == 'none'):
@@ -54,7 +53,7 @@ class Savm(Sbase):
                      " update " + self.device_type)
         self._mydevicemeasure0.updatepar(input_param)
 
-    def turndevicerelais(self, zustand, ueberschussberechnung, updatecnt):
+    def turndevicerelais(self, zustand: int, ueberschussberechnung: int, updatecnt: int) -> None:
         self.preturn(zustand, ueberschussberechnung, updatecnt)
         if (zustand == 1):
             pname = "/on.py"
@@ -69,8 +68,7 @@ class Savm(Sbase):
                         self._device_username,
                         self._device_password]
         try:
-            self.proc = subprocess.Popen(argumentList)
-            self.proc.communicate()
+            self.callpro(argumentList)
         except Exception as e1:
             log.warning("(" + str(self.device_nummer) +
                         ") on / off %s %d %s Fehlermeldung: %s "

--- a/packages/modules/smarthome/elwa/smartelwa.py
+++ b/packages/modules/smarthome/elwa/smartelwa.py
@@ -1,7 +1,6 @@
 #!/usr/bin/python3
 from smarthome.smartbase import Sbase
 from typing import Dict
-import subprocess
 import logging
 log = logging.getLogger(__name__)
 
@@ -24,8 +23,7 @@ class Selwa(Sbase):
                         str(self.device_nummer), str(self._device_ip),
                         str(self.devuberschuss), str(forcesend)]
         try:
-            self.proc = subprocess.Popen(argumentList)
-            self.proc.communicate()
+            self.callpro(argumentList)
             self.answer = self.readret()
             self.newwatt = int(self.answer['power'])
             self.newwattk = int(self.answer['powerc'])
@@ -52,8 +50,7 @@ class Selwa(Sbase):
                         str(self.device_nummer), str(self._device_ip),
                         str(self.devuberschuss)]
         try:
-            self.proc = subprocess.Popen(argumentList)
-            self.proc.communicate()
+            self.callpro(argumentList)
         except Exception as e1:
             log.warning("(" + str(self.device_nummer) +
                         ") on / off  %s %d %s Fehlermeldung: %s "

--- a/packages/modules/smarthome/http/smarthttp.py
+++ b/packages/modules/smarthome/http/smarthttp.py
@@ -1,19 +1,19 @@
 #!/usr/bin/python3
 from smarthome.smartbase import Sbase, Slhttp
-import subprocess
+from typing import Dict
 import logging
 log = logging.getLogger(__name__)
 
 
 class Shttp(Sbase):
-    def __init__(self):
+    def __init__(self) -> None:
         # setting
         super().__init__()
         self._old_measuretype0 = 'none'
         self._device_einschalturl = 'none'
         self._device_ausschalturl = 'none'
 
-    def getwatt(self, uberschuss, uberschussoffset):
+    def getwatt(self, uberschuss: int, uberschussoffset: int) -> None:
         self.prewatt(uberschuss, uberschussoffset)
         self._mydevicemeasure0.devuberschuss = self.devuberschuss
         self._mydevicemeasure0.getwattread()
@@ -25,7 +25,7 @@ class Shttp(Sbase):
         self.temp2 = self._mydevicemeasure0.temp2
         self.postwatt()
 
-    def updatepar(self, input_param):
+    def updatepar(self, input_param: Dict[str, str]) -> None:
         super().updatepar(input_param)
         self._smart_paramadd = input_param.copy()
         self.device_nummer = int(self._smart_paramadd.get('device_nummer',
@@ -43,7 +43,7 @@ class Shttp(Sbase):
                 self._device_ausschalturl = value
             else:
                 log.info("(" + str(self.device_nummer) + ") " +
-                         __class__.__name__ + " überlesen " + key +
+                         " http überlesen " + key +
                          " " + value)
         if (self._old_measuretype0 == 'none'):
             self._mydevicemeasure0 = Slhttp()
@@ -57,7 +57,7 @@ class Shttp(Sbase):
                      " update " + self.device_type)
         self._mydevicemeasure0.updatepar(input_param)
 
-    def turndevicerelais(self, zustand, ueberschussberechnung, updatecnt):
+    def turndevicerelais(self, zustand: int, ueberschussberechnung: int, updatecnt: int) -> None:
         self.preturn(zustand, ueberschussberechnung, updatecnt)
         if (zustand == 1):
             pname = "/on.py"
@@ -70,8 +70,7 @@ class Shttp(Sbase):
                         str(self.device_nummer), '0',
                         str(self.devuberschuss), url]
         try:
-            self.proc = subprocess.Popen(argumentList)
-            self.proc.communicate()
+            self.callpro(argumentList)
         except Exception as e1:
             log.warning("(" + str(self.device_nummer) +
                         ") on / off %s %d %s Fehlermeldung: %s "

--- a/packages/modules/smarthome/idm/smartidm.py
+++ b/packages/modules/smarthome/idm/smartidm.py
@@ -1,19 +1,18 @@
 #!/usr/bin/python3
 from smarthome.smartbase import Sbase
-import subprocess
+from typing import Dict
 import logging
 log = logging.getLogger(__name__)
 
 
 class Sidm(Sbase):
-    def __init__(self):
+    def __init__(self) -> None:
         # setting
         super().__init__()
-        self._smart_paramadd = {}
         self._device_idmnav = '2'
         self.device_nummer = 0
 
-    def updatepar(self, input_param):
+    def updatepar(self, input_param: Dict[str, str]) -> None:
         super().updatepar(input_param)
         self._smart_paramadd = input_param.copy()
         self.device_nummer = int(self._smart_paramadd.get('device_nummer',
@@ -25,17 +24,16 @@ class Sidm(Sbase):
                 self._device_idmnav = value
             else:
                 log.info("(" + str(self.device_nummer) + ") " +
-                         __class__.__name__ + " überlesen " + key +
+                         " IDM überlesen " + key +
                          " " + value)
 
-    def getwatt(self, uberschuss, uberschussoffset):
+    def getwatt(self, uberschuss: int, uberschussoffset: int) -> None:
         self.prewatt(uberschuss, uberschussoffset)
         argumentList = ['python3', self._prefixpy + 'idm/watt.py',
                         str(self.device_nummer), str(self._device_ip),
                         str(self.devuberschuss), str(self._device_idmnav)]
         try:
-            self.proc = subprocess.Popen(argumentList)
-            self.proc.communicate()
+            self.callpro(argumentList)
             self.answer = self.readret()
             self.newwatt = int(self.answer['power'])
             self.newwattk = int(self.answer['powerc'])
@@ -47,7 +45,7 @@ class Sidm(Sbase):
                            str(self._device_ip), str(e1)))
         self.postwatt()
 
-    def turndevicerelais(self, zustand, ueberschussberechnung, updatecnt):
+    def turndevicerelais(self, zustand: int, ueberschussberechnung: int, updatecnt: int) -> None:
         self.preturn(zustand, ueberschussberechnung, updatecnt)
         if (zustand == 1):
             pname = "/on.py"
@@ -57,8 +55,7 @@ class Sidm(Sbase):
                         str(self.device_nummer), str(self._device_ip),
                         str(self.devuberschuss), str(self._device_idmnav)]
         try:
-            self.proc = subprocess.Popen(argumentList)
-            self.proc.communicate()
+            self.callpro(argumentList)
         except Exception as e1:
             log.warning("(" + str(self.device_nummer) +
                         ") on / off  %s %d %s Fehlermeldung: %s "

--- a/packages/modules/smarthome/lambda_/smartlambda.py
+++ b/packages/modules/smarthome/lambda_/smartlambda.py
@@ -1,16 +1,15 @@
 #!/usr/bin/python3
 from smarthome.smartbase import Sbase
-import subprocess
 import logging
 log = logging.getLogger(__name__)
 
 
 class Slambda(Sbase):
-    def __init__(self):
+    def __init__(self) -> None:
         # setting
         super().__init__()
 
-    def getwatt(self, uberschuss, uberschussoffset):
+    def getwatt(self, uberschuss: int, uberschussoffset: int) -> None:
         self.prewatt(uberschuss, uberschussoffset)
         forcesend = self.checkbefsend()
         argumentList = ['python3', self._prefixpy + 'lambda_/watt.py',
@@ -18,8 +17,7 @@ class Slambda(Sbase):
                         str(self.devuberschuss), str(self.device_lambdaueb),
                         str(forcesend)]
         try:
-            self.proc = subprocess.Popen(argumentList)
-            self.proc.communicate()
+            self.callpro(argumentList)
             self.answer = self.readret()
             self.newwatt = int(self.answer['power'])
             self.newwattk = int(self.answer['powerc'])
@@ -32,7 +30,7 @@ class Slambda(Sbase):
                            str(self._device_ip), str(e1)))
         self.postwatt()
 
-    def turndevicerelais(self, zustand, ueberschussberechnung, updatecnt):
+    def turndevicerelais(self, zustand: int, ueberschussberechnung: int, updatecnt: int) -> None:
         self.preturn(zustand, ueberschussberechnung, updatecnt)
         if (zustand == 1):
             pname = "/on.py"
@@ -42,8 +40,7 @@ class Slambda(Sbase):
                         str(self.device_nummer), str(self._device_ip),
                         str(self.devuberschuss), str(self.device_lambdaueb)]
         try:
-            self.proc = subprocess.Popen(argumentList)
-            self.proc.communicate()
+            self.callpro(argumentList)
         except Exception as e1:
             log.warning("(" + str(self.device_nummer) +
                         ") on / off  %s %d %s Fehlermeldung: %s "

--- a/packages/modules/smarthome/mqtt/smartmqtt.py
+++ b/packages/modules/smarthome/mqtt/smartmqtt.py
@@ -1,17 +1,17 @@
 #!/usr/bin/python3
 from smarthome.smartbase import Sbase, Slmqtt
-import subprocess
+from typing import Dict
 import logging
 log = logging.getLogger(__name__)
 
 
 class Smqtt(Sbase):
-    def __init__(self):
+    def __init__(self) -> None:
         # setting
         super().__init__()
         self._old_measuretype0 = 'none'
 
-    def getwatt(self, uberschuss, uberschussoffset):
+    def getwatt(self, uberschuss: int, uberschussoffset: int) -> None:
         self.prewatt(uberschuss, uberschussoffset)
         self._mydevicemeasure0.devuberschuss = self.devuberschuss
         self._mydevicemeasure0.getwattread()
@@ -23,7 +23,7 @@ class Smqtt(Sbase):
         self.temp2 = self._mydevicemeasure0.temp2
         self.postwatt()
 
-    def updatepar(self, input_param):
+    def updatepar(self, input_param: Dict[str, str]) -> None:
         super().updatepar(input_param)
         if (self._old_measuretype0 == 'none'):
             self._mydevicemeasure0 = Slmqtt()
@@ -37,7 +37,7 @@ class Smqtt(Sbase):
                      " update " + self.device_type)
         self._mydevicemeasure0.updatepar(input_param)
 
-    def turndevicerelais(self, zustand, ueberschussberechnung, updatecnt):
+    def turndevicerelais(self, zustand: int, ueberschussberechnung: int, updatecnt: int) -> None:
         self.preturn(zustand, ueberschussberechnung, updatecnt)
         if (zustand == 1):
             pname = "/on.py"
@@ -47,8 +47,7 @@ class Smqtt(Sbase):
                         str(self.device_nummer), str(self._device_ip),
                         str(self.devuberschuss)]
         try:
-            self.proc = subprocess.Popen(argumentList)
-            self.proc.communicate()
+            self.callpro(argumentList)
         except Exception as e1:
             log.warning("(" + str(self.device_nummer) +
                         ") on / off  %s %d %s Fehlermeldung: %s "

--- a/packages/modules/smarthome/mystrom/smartmystrom.py
+++ b/packages/modules/smarthome/mystrom/smartmystrom.py
@@ -1,17 +1,17 @@
 #!/usr/bin/python3
-import subprocess
-from smarthome.smartbase import Sbase, Slmystrom
 import logging
+from typing import Dict
+from smarthome.smartbase import Sbase, Slmystrom
 log = logging.getLogger(__name__)
 
 
 class Smystrom(Sbase):
-    def __init__(self):
+    def __init__(self) -> None:
         # setting
         super().__init__()
         self._old_measuretype0 = 'none'
 
-    def getwatt(self, uberschuss, uberschussoffset):
+    def getwatt(self, uberschuss: int, uberschussoffset: int) -> None:
         self.prewatt(uberschuss, uberschussoffset)
         self._mydevicemeasure0.devuberschuss = self.devuberschuss
         self._mydevicemeasure0.getwattread()
@@ -23,7 +23,7 @@ class Smystrom(Sbase):
         self.temp2 = self._mydevicemeasure0.temp2
         self.postwatt()
 
-    def updatepar(self, input_param):
+    def updatepar(self, input_param: Dict[str, str]) -> None:
         super().updatepar(input_param)
         if (self._old_measuretype0 == 'none'):
             self._mydevicemeasure0 = Slmystrom()
@@ -37,7 +37,7 @@ class Smystrom(Sbase):
                      " update " + self.device_type)
         self._mydevicemeasure0.updatepar(input_param)
 
-    def turndevicerelais(self, zustand, ueberschussberechnung, updatecnt):
+    def turndevicerelais(self, zustand: int, ueberschussberechnung: int, updatecnt: int) -> None:
         self.preturn(zustand, ueberschussberechnung, updatecnt)
         if (zustand == 1):
             pname = "/on.py"
@@ -47,8 +47,7 @@ class Smystrom(Sbase):
         argumentList = ['python3', self._prefixpy + 'mystrom' + pname,
                         str(self.device_nummer), str(self._device_ip), '0']
         try:
-            self.proc = subprocess.Popen(argumentList)
-            self.proc.communicate()
+            self.callpro(argumentList)
         except Exception as e1:
             log.warning("(" + str(self.device_nummer) +
                         ") on / off %s %d %s Fehlermeldung: %s "

--- a/packages/modules/smarthome/nxdacxx/smartnxdacxx.py
+++ b/packages/modules/smarthome/nxdacxx/smartnxdacxx.py
@@ -1,7 +1,6 @@
 #!/usr/bin/python3
 from smarthome.smartbase import Sbase
 from typing import Dict
-import subprocess
 import logging
 log = logging.getLogger(__name__)
 
@@ -47,8 +46,7 @@ class Snxdacxx(Sbase):
                         str(self._device_dacport),
                         str(self._device_nxdacxxtype)]
         try:
-            self.proc = subprocess.Popen(argumentList)
-            self.proc.communicate()
+            self.callpro(argumentList)
             self.answer = self.readret()
             self.newwatt = int(self.answer['power'])
             self.newwattk = int(self.answer['powerc'])
@@ -73,8 +71,7 @@ class Snxdacxx(Sbase):
                         str(self._device_dacport),
                         str(self._device_nxdacxxtype)]
         try:
-            self.proc = subprocess.Popen(argumentList)
-            self.proc.communicate()
+            self.callpro(argumentList)
         except Exception as e1:
             log.warning("(" + str(self.device_nummer) +
                         ") on / off  %s %d %s Fehlermeldung: %s "

--- a/packages/modules/smarthome/ratiotherm/smartratiotherm.py
+++ b/packages/modules/smarthome/ratiotherm/smartratiotherm.py
@@ -1,6 +1,5 @@
 #!/usr/bin/python3
 from smarthome.smartbase import Sbase
-import subprocess
 import logging
 log = logging.getLogger(__name__)
 
@@ -19,8 +18,7 @@ class Sratiotherm(Sbase):
                         str(self.devuberschuss),
                         str(forcesend)]
         try:
-            self.proc = subprocess.Popen(argumentList)
-            self.proc.communicate()
+            self.callpro(argumentList)
             self.answer = self.readret()
             self.newwatt = int(self.answer['power'])
             self.newwattk = int(self.answer['powerc'])
@@ -43,8 +41,7 @@ class Sratiotherm(Sbase):
                         str(self.device_nummer), str(self._device_ip),
                         str(self.devuberschuss)]
         try:
-            self.proc = subprocess.Popen(argumentList)
-            self.proc.communicate()
+            self.callpro(argumentList)
         except Exception as e1:
             log.warning("(" + str(self.device_nummer) +
                         ") on / off  %s %d %s Fehlermeldung: %s "

--- a/packages/modules/smarthome/shelly/smartshelly.py
+++ b/packages/modules/smarthome/shelly/smartshelly.py
@@ -1,7 +1,6 @@
 #!/usr/bin/python3
 from smarthome.smartbase import Sbase, Slshelly
 from typing import Dict
-import subprocess
 import logging
 log = logging.getLogger(__name__)
 
@@ -72,8 +71,7 @@ class Sshelly(Sbase):
                         self._device_shusername,
                         self._device_shpassword]
         try:
-            self.proc = subprocess.Popen(argumentList)
-            self.proc.communicate()
+            self.callpro(argumentList)
         except Exception as e1:
             log.warning("(" + str(self.device_nummer) +
                         ") on / off %s %d %s Fehlermeldung: %s "

--- a/packages/modules/smarthome/stiebel/smartstiebel.py
+++ b/packages/modules/smarthome/stiebel/smartstiebel.py
@@ -1,23 +1,21 @@
 #!/usr/bin/python3
 from smarthome.smartbase import Sbase
-import subprocess
 import logging
 log = logging.getLogger(__name__)
 
 
 class Sstiebel(Sbase):
-    def __init__(self):
+    def __init__(self) -> None:
         # setting
         super().__init__()
 
-    def getwatt(self, uberschuss, uberschussoffset):
+    def getwatt(self, uberschuss: int, uberschussoffset: int) -> None:
         self.prewatt(uberschuss, uberschussoffset)
         argumentList = ['python3', self._prefixpy + 'stiebel/watt.py',
                         str(self.device_nummer), str(self._device_ip),
                         str(self.devuberschuss)]
         try:
-            self.proc = subprocess.Popen(argumentList)
-            self.proc.communicate()
+            self.callpro(argumentList)
             self.answer = self.readret()
             self.newwatt = int(self.answer['power'])
             self.newwattk = int(self.answer['powerc'])
@@ -29,7 +27,7 @@ class Sstiebel(Sbase):
                            str(self._device_ip), str(e1)))
         self.postwatt()
 
-    def turndevicerelais(self, zustand, ueberschussberechnung, updatecnt):
+    def turndevicerelais(self, zustand: int, ueberschussberechnung: int, updatecnt: int) -> None:
         self.preturn(zustand, ueberschussberechnung, updatecnt)
         if (zustand == 1):
             pname = "/on.py"
@@ -39,8 +37,7 @@ class Sstiebel(Sbase):
                         str(self.device_nummer), str(self._device_ip),
                         str(self.devuberschuss)]
         try:
-            self.proc = subprocess.Popen(argumentList)
-            self.proc.communicate()
+            self.callpro(argumentList)
         except Exception as e1:
             log.warning("(" + str(self.device_nummer) +
                         ") on / off  %s %d %s Fehlermeldung: %s "

--- a/packages/modules/smarthome/tasmota/smarttasmota.py
+++ b/packages/modules/smarthome/tasmota/smarttasmota.py
@@ -1,17 +1,17 @@
 #!/usr/bin/python3
 from smarthome.smartbase import Sbase, Sltasmota
-import subprocess
 import logging
+from typing import Dict
 log = logging.getLogger(__name__)
 
 
 class Stasmota(Sbase):
-    def __init__(self):
+    def __init__(self) -> None:
         # setting
         super().__init__()
         self._old_measuretype0 = 'none'
 
-    def getwatt(self, uberschuss, uberschussoffset):
+    def getwatt(self, uberschuss: int, uberschussoffset: int) -> None:
         self.prewatt(uberschuss, uberschussoffset)
         self._mydevicemeasure0.devuberschuss = self.devuberschuss
         self._mydevicemeasure0.getwattread()
@@ -20,7 +20,7 @@ class Stasmota(Sbase):
         self.relais = self._mydevicemeasure0.relais
         self.postwatt()
 
-    def updatepar(self, input_param):
+    def updatepar(self, input_param: Dict[str, str]) -> None:
         super().updatepar(input_param)
         if (self._old_measuretype0 == 'none'):
             self._mydevicemeasure0 = Sltasmota()
@@ -34,7 +34,7 @@ class Stasmota(Sbase):
                      " update  " + self.device_type)
         self._mydevicemeasure0.updatepar(input_param)
 
-    def turndevicerelais(self, zustand, ueberschussberechnung, updatecnt):
+    def turndevicerelais(self, zustand: int, ueberschussberechnung: int, updatecnt: int) -> None:
         self.preturn(zustand, ueberschussberechnung, updatecnt)
         if (zustand == 1):
             pname = "/on.py"
@@ -44,8 +44,7 @@ class Stasmota(Sbase):
         argumentList = ['python3', self._prefixpy + 'tasmota' + pname,
                         str(self.device_nummer), str(self._device_ip), '0']
         try:
-            self.proc = subprocess.Popen(argumentList)
-            self.proc.communicate()
+            self.callpro(argumentList)
         except Exception as e1:
             log.warning("(" + str(self.device_nummer) +
                         ") on / off %s %d %s Fehlermeldung: %s "

--- a/packages/modules/smarthome/vampair/smartvampair.py
+++ b/packages/modules/smarthome/vampair/smartvampair.py
@@ -1,23 +1,21 @@
 #!/usr/bin/python3
 from smarthome.smartbase import Sbase
-import subprocess
 import logging
 log = logging.getLogger(__name__)
 
 
 class Svampair(Sbase):
-    def __init__(self):
+    def __init__(self) -> None:
         # setting
         super().__init__()
 
-    def getwatt(self, uberschuss, uberschussoffset):
+    def getwatt(self, uberschuss: int, uberschussoffset: int) -> None:
         self.prewatt(uberschuss, uberschussoffset)
         argumentList = ['python3', self._prefixpy + 'vampair/watt.py',
                         str(self.device_nummer), str(self._device_ip),
                         str(self.devuberschuss)]
         try:
-            self.proc = subprocess.Popen(argumentList)
-            self.proc.communicate()
+            self.callpro(argumentList)
             self.answer = self.readret()
             self.newwatt = int(self.answer['power'])
             self.newwattk = int(self.answer['powerc'])
@@ -29,7 +27,7 @@ class Svampair(Sbase):
                            str(self._device_ip), str(e1)))
         self.postwatt()
 
-    def turndevicerelais(self, zustand, ueberschussberechnung, updatecnt):
+    def turndevicerelais(self, zustand: int, ueberschussberechnung: int, updatecnt: int) -> None:
         self.preturn(zustand, ueberschussberechnung, updatecnt)
         if (zustand == 1):
             pname = "/on.py"
@@ -39,8 +37,7 @@ class Svampair(Sbase):
                         str(self.device_nummer), str(self._device_ip),
                         str(self.devuberschuss)]
         try:
-            self.proc = subprocess.Popen(argumentList)
-            self.proc.communicate()
+            self.callpro(argumentList)
         except Exception as e1:
             log.warning("(" + str(self.device_nummer) +
                         ") on / off  %s %d %s Fehlermeldung: %s "

--- a/packages/modules/smarthome/viessmann/smartviessmann.py
+++ b/packages/modules/smarthome/viessmann/smartviessmann.py
@@ -1,30 +1,23 @@
 #!/usr/bin/python3
 from smarthome.smartbase import Sbase
-import subprocess
-import json
 import logging
 log = logging.getLogger(__name__)
 
 
 class Sviessmann(Sbase):
-    def __init__(self):
+    def __init__(self) -> None:
         # setting
         super().__init__()
         print('__init__ Sviessmann executed')
 
-    def getwatt(self, uberschuss, uberschussoffset):
+    def getwatt(self, uberschuss: int, uberschussoffset: int) -> None:
         self.prewatt(uberschuss, uberschussoffset)
         argumentList = ['python3', self._prefixpy + 'viessmann/watt.py',
                         str(self.device_nummer), str(self._device_ip),
                         str(self.devuberschuss)]
         try:
-            self.proc = subprocess.Popen(argumentList)
-            self.proc.communicate()
-            self.f1 = open(self._basePath+'/ramdisk/smarthome_device_ret' +
-                           str(self.device_nummer), 'r')
-            self.answerj = json.load(self.f1)
-            self.f1.close()
-            self.answer = json.loads(self.answerj)
+            self.callpro(argumentList)
+            self.answer = self.readret()
             self.newwatt = int(self.answer['power'])
             self.newwattk = int(self.answer['powerc'])
             self.relais = int(self.answer['on'])
@@ -35,7 +28,7 @@ class Sviessmann(Sbase):
                            str(self._device_ip), str(e1)))
         self.postwatt()
 
-    def turndevicerelais(self, zustand, ueberschussberechnung, updatecnt):
+    def turndevicerelais(self, zustand: int, ueberschussberechnung: int, updatecnt: int) -> None:
         self.preturn(zustand, ueberschussberechnung, updatecnt)
         if (zustand == 1):
             pname = "/on.py"
@@ -45,8 +38,7 @@ class Sviessmann(Sbase):
                         str(self.device_nummer), str(self._device_ip),
                         str(self.devuberschuss)]
         try:
-            self.proc = subprocess.Popen(argumentList)
-            self.proc.communicate()
+            self.callpro(argumentList)
         except Exception as e1:
             log.warning("(" + str(self.device_nummer) +
                         ") on / off  %s %d %s Fehlermeldung: %s "

--- a/packages/smarthome/smartbase.py
+++ b/packages/smarthome/smartbase.py
@@ -166,7 +166,8 @@ class Sbase(Sbase0):
         else:
             self.relais = 0
         self.mqtt_param = {}
-        pref = 'openWB/SmartHome/Devices/' + str(self.device_nummer) + '/'
+        #  pref = 'openWB/SmartHome/Devices/' + str(self.device_nummer) + '/'
+        pref = '/' + str(self.device_nummer) + '/'
         self.mqtt_param[pref + 'RelayStatus'] = str(self.relais)
         if (self.c_mantime_f == 'Y') and (self.device_manual != 1):
             # nach Ausschalten manueller Modus mindestens 30 Sek +
@@ -276,7 +277,7 @@ class Sbase(Sbase0):
             elif (key == 'device_mineinschaltdauer'):
                 self._device_mineinschaltdauer = valueint * 60
             elif (key == 'device_mindayeinschaltdauer'):
-                self._device_mineinschaltdauer = valueint * 60
+                self._device_mindayeinschaltdauer = valueint * 60
             elif (key == 'device_maxeinschaltdauer'):
                 self._device_maxeinschaltdauer = valueint * 60
             elif (key == 'device_homeConsumtion'):
@@ -394,7 +395,8 @@ class Sbase(Sbase0):
                          + "Sbase überlesen " + key +
                          " " + value)
         self._first_run = 0
-        pref = 'openWB/SmartHome/Devices/' + str(self.device_nummer) + '/'
+        #  pref = 'openWB/SmartHome/Devices/' + str(self.device_nummer) + '/'
+        pref = '/' + str(self.device_nummer) + '/'
         self.mqtt_param_del[pref + 'RelayStatus'] = '0'
         self.mqtt_param_del[pref + 'Watt'] = '0'
         self.mqtt_param_del[pref + 'oncountnor'] = '0'

--- a/packages/smarthome/smartbase0.py
+++ b/packages/smarthome/smartbase0.py
@@ -59,4 +59,4 @@ class Sbase0:
             if errs:
                 log.error("%s" % (errs))
         except Exception as e1:
-            log.warning("Subprocess Fehlermeldung: %s in %s " % (str(e1)), argumentList[1])
+            log.exception("Subprocess Fehlermeldung: argumentList %s " % argumentList[1])

--- a/packages/smarthome/smartbase0.py
+++ b/packages/smarthome/smartbase0.py
@@ -1,6 +1,9 @@
 import json
 import time
+import os
+import subprocess
 import logging
+from typing import List
 log = logging.getLogger(__name__)
 
 
@@ -45,3 +48,15 @@ class Sbase0:
             log.warning("(" + str(self.device_nummer) +
                         ") checksend Fehlermeldung: %s "
                         % (str(e1)))
+
+    def callpro(self, argumentList: List[str]) -> None:
+        try:
+            my_env = os.environ.copy()
+            my_env["PYTHONPATH"] = "/var/www/html/openWB/packages"
+            proc = subprocess.Popen(argumentList, stderr=subprocess.PIPE,
+                                    universal_newlines=True, env=my_env)
+            _, errs = proc.communicate()
+            if errs:
+                log.error("%s" % (errs))
+        except Exception as e1:
+            log.warning("Subprocess Fehlermeldung: %s in %s " % (str(e1)), argumentList[1])

--- a/packages/smarthome/smartbase0.py
+++ b/packages/smarthome/smartbase0.py
@@ -58,5 +58,5 @@ class Sbase0:
             _, errs = proc.communicate()
             if errs:
                 log.error("%s" % (errs))
-        except Exception as e1:
+        except Exception:
             log.exception("Subprocess Fehlermeldung: argumentList %s " % argumentList[1])

--- a/packages/smarthome/smartcommon.py
+++ b/packages/smarthome/smartcommon.py
@@ -1,0 +1,486 @@
+#!/usr/bin/python3
+from modules.smarthome.ratiotherm.smartratiotherm import Sratiotherm
+from modules.smarthome.viessmann.smartviessmann import Sviessmann
+from modules.smarthome.tasmota.smarttasmota import Stasmota
+from modules.smarthome.lambda_.smartlambda import Slambda
+from modules.smarthome.vampair.smartvampair import Svampair
+from modules.smarthome.stiebel.smartstiebel import Sstiebel
+from modules.smarthome.shelly.smartshelly import Sshelly
+from modules.smarthome.mystrom.smartmystrom import Smystrom
+from modules.smarthome.mqtt.smartmqtt import Smqtt
+from modules.smarthome.http.smarthttp import Shttp
+from modules.smarthome.idm.smartidm import Sidm
+from modules.smarthome.elwa.smartelwa import Selwa
+from modules.smarthome.nxdacxx.smartnxdacxx import Snxdacxx
+from modules.smarthome.acthor.smartacthor import Sacthor
+from modules.smarthome.avmhomeautomation.smartavm import Savm
+from smarthome.smartbase import Sbase
+from typing import Dict, List, Any, Tuple
+import paho.mqtt.client as mqtt
+import re
+import time
+import os
+import math
+import logging
+log = logging.getLogger(__name__)
+mydevices = []  # type: List[Any]
+mqtt_cache = {}  # type: Dict[str, str]
+parammqtt = []  # type: List[Any]
+# will be populated with open 1.9 / openwb 2.0 specifc param
+mqttcg = 'none'
+mqttcs = 'none'
+mqttsdevstat = 'none'
+mqttsglobstat = 'none'
+mqtttopicdisengageable = 'none'
+ramdiskwrite = True
+mqttport = 0
+bp = '/var/www/html/openWB'
+numberOfSupportedDevices = 9  # limit number of smarthome devices
+resetmaxeinschaltdauer = 0
+maxspeicher = 0
+firststart = True
+
+
+def on_connect(client, userdata, flags, rc) -> None:
+    global mqttcg
+    global mqttsdevstat
+    #  mqttcg = 'openWB/config/get/SmartHome/'
+    #  client.subscribe("openWB/config/get/SmartHome/#", 2)
+    client.subscribe(mqttcg + '#', 2)
+    #  mqttsdevstat = 'openWB/SmartHome/Devices'
+    #  client.subscribe("openWB/SmartHome/Devices/#", 2)
+    client.subscribe(mqttsdevstat + '/#', 2)
+
+
+def logmq(topic: str, devicenumb: int, keyword: str, value: str) -> None:
+    global parammqtt
+    global ramdiskwrite
+    #  richtig  topic single
+    if (devicenumb < 1) or (devicenumb > numberOfSupportedDevices):
+        pass
+    else:
+        log.info("(" + str(devicenumb) + ") Key " + str(keyword) + " Value " + str(value))
+        parammqtt.append([devicenumb, keyword, value])
+        if ramdiskwrite:
+            with open(bp+'/ramdisk/smartparam.sh', 'a') as f:
+                print('%s' % ('mosquitto_pub -p 1886 -t ' +
+                              '"' + topic + '/' + str(devicenumb) + '/' + keyword +
+                              '" -r -m "' + str(value) + '"'), file=f)
+
+
+def logmqgl(keyword: str, value: str) -> None:
+    #  richtig  topic global
+    log.info("( global ) Key " + str(keyword) + " Value " + str(value))
+    if ramdiskwrite:
+        with open(bp+'/ramdisk/smartparam.sh', 'a') as f:
+            print('%s' % ('mosquitto_pub -p 1886 -t ' +
+                          '"openWB/LegacySmartHome/config/get/' + keyword +
+                          '" -r -m "' + str(value) + '"'), file=f)
+
+
+def on_message(client, userdata, msg) -> None:
+    # wenn exception hier wird mit nächster msg weitergemacht
+    # macht paho unter phyton 3 immer so
+    # für neuer python 3.7 version gibt es absturz
+    global maxspeicher
+    try:
+        devicenumb = int(re.sub(r'\D', '', msg.topic))
+    except Exception:
+        devicenumb = 0
+    value = msg.payload.decode("utf-8")
+    try:
+        valueint = int(value)
+    except Exception:
+        valueint = 0
+    # mqttcg = 'openWB/config/get/SmartHome/'
+    if (mqttcg + 'Devices' in msg.topic):
+        keyword = re.sub(mqttcg + 'Devices/' + str(devicenumb) + '/', '', msg.topic)
+        logmq("openWB/LegacySmartHome/config/get/Devices", devicenumb, keyword, value)
+    # mqttsdevstat = 'openWB/SmartHome/Devices'
+    elif (mqttsdevstat in msg.topic):
+        keyword = re.sub(mqttsdevstat + "/" + str(devicenumb) + '/', '', msg.topic)
+        logmq("openWB/LegacySmartHome/Devices", devicenumb, keyword, value)
+    # mqttcg = 'openWB/config/get/SmartHome/'
+    elif (mqttcg + "maxBatteryPower" in msg.topic):
+        keyword = re.sub(mqttcg, '', msg.topic)
+        logmqgl(keyword, value)
+        maxspeicher = int(valueint)
+    else:
+        log.warning(" Skipped msg " + msg.topic + " Value " + value)
+
+
+def getdevicevalues(uberschuss: int, uberschussoffset: int) -> None:
+    global mydevices
+    totalwatt = 0
+    totalwattot = 0
+    totalminhaus = 0
+    # dyn daten einschaltgruppe
+    Sbase.ausschaltwatt = 0
+    Sbase.einrelais = 0
+    Sbase.eindevstatus = 0
+    mqtt_all = {}
+    for mydevice in mydevices:
+        mydevice.getwatt(uberschuss, uberschussoffset)
+        watt = mydevice.newwatt
+        wattk = mydevice.newwattk
+        relais = mydevice.relais
+        # temp0 = mydevice.temp0
+        # temp1 = mydevice.temp1
+        # temp2 = mydevice.temp2
+        if ((mydevice.abschalt == 1) and (relais == 1)
+           and (mydevice.device_manual != 1)):
+            totalwatt = totalwatt + watt
+        else:
+            totalwattot = totalwattot + watt
+        if (mydevice.device_homeconsumtion == 0):
+            totalminhaus = totalminhaus + watt
+        log.info("(" + str(mydevice.device_nummer) + ") " +
+                 str(mydevice.device_name) + " rel: " + str(relais) +
+                 " oncnt/onstandby/time: " + str(mydevice.oncountnor) + "/"
+                 + str(mydevice.oncntstandby) + "/" +
+                 str(mydevice.runningtime) + " Status/Üeb: " +
+                 str(mydevice.devstatus) + "/" +
+                 str(mydevice.ueberschussberechnung) + " akt: " + str(watt) +
+                 " Z: " + str(wattk))
+        #  mqtt_all.update(mydevice.mqtt_param)
+        for keyread, value in mydevice.mqtt_param.items():
+            key = mqttsdevstat + keyread
+            mqtt_all[key] = value
+    # device_total_watt is needed for calculation the proper überschuss
+    # (including switchable smarthomedevices)
+    if ramdiskwrite:
+        with open(bp+'/ramdisk/devicetotal_watt', 'w') as f:
+            f.write(str(totalwatt))
+        with open(bp+'/ramdisk/devicetotal_watt_other', 'w') as f:
+            f.write(str(totalwattot))
+        with open(bp+'/ramdisk/devicetotal_watt_hausmin', 'w') as f:
+            f.write(str(totalminhaus))
+    log.info("Total Watt abschaltbarer smarthomedevices: " +
+             str(totalwatt))
+    log.info("Total Watt nichtabschaltbarer smarthomedevices: "
+             + str(totalwattot))
+    log.info("Total Watt nicht im Hausverbrauch: " +
+             str(totalminhaus))
+    log.info("Anzahl devices in Auschaltgruppe: " +
+             str(Sbase.ausdevices) + " akt: " + str(Sbase.ausschaltwatt) +
+             " Anzahl devices in Einschaltgruppe: " + str(Sbase.eindevices)
+             )
+    nurhh = math.floor(Sbase.nureinschaltinsec / 3600)
+    nurmm = math.floor((Sbase.nureinschaltinsec - (nurhh * 3600)) / 60)
+    nurss = (Sbase.nureinschaltinsec - (nurhh * 3600) - (nurmm * 60))
+    log.info("Einschaltgruppe rel: " + str(Sbase.einrelais) +
+             " Summe Einschaltschwelle: " +
+             str(Sbase.einschwelle) + " max Einschaltverzögerung " +
+             str(Sbase.einverz) + " nur Einschaltgruppe prüfen bis: " +
+             str('%.2d' % nurhh) + ":" + str('%.2d' % nurmm) + ":" +
+             str('%.2d' % nurss) +
+             " in Total sec " + str(Sbase.nureinschaltinsec)
+             )
+    # mqttsglobstat = 'openWB/SmartHome/Status/'
+    mqtt_all[mqttsglobstat + 'maxspeicherladung'] = maxspeicher
+    # mqtttopicdisengageable = 'openWB/SmartHome/Status/wattschalt'
+    mqtt_all[mqtttopicdisengageable] = totalwatt
+    mqtt_all[mqttsglobstat + 'wattnichtschalt'] = totalwattot
+    mqtt_all[mqttsglobstat + 'wattnichtHaus'] = totalminhaus
+    mqtt_all[mqttsglobstat + 'uberschuss'] = uberschuss
+    mqtt_all[mqttsglobstat + 'uberschussoffset'] = uberschussoffset
+    sendmq(mqtt_all)
+
+
+def sendmq(mqtt_input: Dict[str, str]) -> None:
+    global mqtt_cache
+    client = mqtt.Client("openWB-SmartHome-bulkpublisher-" + str(os.getpid()))
+    client.connect("localhost", mqttport)
+    for key, value in mqtt_input.items():
+        valueold = mqtt_cache.get(key, 'not in cache')
+        if (valueold == value):
+            pass
+        else:
+            log.info("Mq pub " + str(key) + "=" +
+                     str(value) + " old " + str(valueold))
+            mqtt_cache[key] = value
+            client.publish(key, payload=value, qos=0, retain=True)
+            client.loop(timeout=2.0)
+    client.disconnect()
+
+
+def conditions(speichersoc: int) -> None:
+    global mydevices
+    for mydevice in mydevices:
+        mydevice.conditions(speichersoc)
+
+
+def update_devices() -> None:
+    global parammqtt
+    global mydevices
+    global mqtt_cache
+    client = mqtt.Client("openWB-SmartHome-bulkpublisher-" + str(os.getpid()))
+    client.connect("localhost", mqttport)
+    # statische daten einschaltgruppe
+    Sbase.ausdevices = 0
+    Sbase.eindevices = 0
+    Sbase.einverz = 0
+    Sbase.einschwelle = 0
+    # Nur einschaltgruppe in Sekunden
+    Sbase.nureinschaltinsec = 0
+    for i in range(1, numberOfSupportedDevices+1):
+        device_configured = 0
+        device_type = 'none'
+        input_param = {}
+        input_param['device_nummer'] = str(i)
+        for devicenumb, keyword, value in parammqtt:
+            if (str(i) == str(devicenumb)):
+                if (keyword == 'device_configured'):
+                    device_configured = value
+                if (keyword == 'device_type'):
+                    device_type = value
+                input_param[keyword] = value
+        if (device_configured == "1"):
+            createnew = 1
+            for mydevice in mydevices:
+                if (str(i) == str(mydevice.device_nummer)):
+                    log.info("(" + str(i) + ") " +
+                             "Device bereits erzeugt")
+                    if (device_type == mydevice.device_type):
+                        log.info("(" + str(i) + ") " +
+                                 "Typ gleich, nur Parameter update")
+                        createnew = 0
+                        mydevice.updatepar(input_param)
+                    else:
+                        log.info("(" + str(i) + ") " +
+                                 "Typ ungleich " + mydevice.device_type)
+                        mydevice.device_nummer = 0
+                        mydevice._device_configured = '9'
+                        # del mydevice
+                        mydevices.remove(mydevice)
+                        log.info("(" + str(i) + ") " +
+                                 "Device gelöscht")
+                    break
+            if (createnew == 1):
+                log.info("(" + str(i) +
+                         ") Neues Devices oder Typänderung: " +
+                         str(device_type))
+                if (device_type == 'shelly'):
+                    mydevice = Sshelly()
+                elif (device_type == 'stiebel'):
+                    mydevice = Sstiebel()
+                elif (device_type == 'vampair'):
+                    mydevice = Svampair()
+                elif (device_type == 'lambda'):
+                    mydevice = Slambda()
+                elif (device_type == 'ratiotherm'):
+                    mydevice = Sratiotherm()
+                elif (device_type == 'tasmota'):
+                    mydevice = Stasmota()
+                elif (device_type == 'avm'):
+                    mydevice = Savm()
+                elif (device_type == 'viessmann'):
+                    mydevice = Sviessmann()
+                elif (device_type == 'acthor'):
+                    mydevice = Sacthor()
+                elif (device_type == 'NXDACXX'):
+                    mydevice = Snxdacxx()
+                elif (device_type == 'elwa'):
+                    mydevice = Selwa()
+                elif (device_type == 'idm'):
+                    mydevice = Sidm()
+                elif (device_type == 'mqtt'):
+                    mydevice = Smqtt()
+                elif (device_type == 'http'):
+                    mydevice = Shttp()
+                elif (device_type == 'mystrom'):
+                    mydevice = Smystrom()
+                else:
+                    mydevice = Sbase()
+                mydevice.updatepar(input_param)
+                mydevices.append(mydevice)
+        else:
+            log.info("(" + str(i) + ") " +
+                     "Device nicht (länger) definiert")
+            for mydevice in mydevices:
+                if (str(i) == str(mydevice.device_nummer)):
+                    # cleant up mqtt
+                    for keyread, value in mydevice.mqtt_param_del.items():
+                        key = mqttsdevstat + keyread
+                        valueold = mqtt_cache.pop(key, 'not in cache')
+                        log.info("Mq pub " + str(key) + "=" +
+                                 str(value) + " old " + str(valueold))
+                        client.publish(key, payload=value, qos=0, retain=True)
+                        client.loop(timeout=2.0)
+                    mydevice.device_nummer = 0
+                    mydevice._device_configured = '9'
+                    # del mydevice
+                    mydevices.remove(mydevice)
+                    log.info("(" + str(i) + ") " +
+                             "Device gelöscht")
+    client.disconnect()
+
+
+def readmq() -> None:
+    global parammqtt
+    global mydevices
+    log.info("Config reRead start / Parameter check")
+    if ramdiskwrite:
+        with open(bp+'/ramdisk/smartparam.sh', 'w') as f:
+            print('%s' % ('#!/bin/bash'), file=f)
+    parammqtt = []
+    client = mqtt.Client("openWB-mqttsmarthome")
+    client.on_connect = on_connect
+    client.on_message = on_message
+    startTime = time.time()
+    waitTime = 5
+    client.connect("localhost", mqttport)
+    while True:
+        client.loop()
+        elapsedTime = time.time() - startTime
+        if elapsedTime > waitTime:
+            client.disconnect()
+            break
+    log.info("Config reRead / Parameter check done")
+    update_devices()
+    log.info("Config reRead done")
+    if ramdiskwrite:
+        with open(bp+'/ramdisk/smartparam.sh', 'a') as f:
+            print('%s' % ('echo 1 > /var/www/html/openWB/ramdisk/rereadsmarthomedevices'), file=f)
+
+
+def resetmaxeinschaltdauerfunc() -> None:
+    global resetmaxeinschaltdauer
+    global mydevices
+    mqtt_reset = {}
+    hour = time.strftime("%H")
+    if (int(hour) == 0):
+        if (int(resetmaxeinschaltdauer) == 0):
+            for i in range(1, (numberOfSupportedDevices+1)):
+                for mydevice in mydevices:
+                    if (str(i) == str(mydevice.device_nummer)):
+                        # mqttsdevstat = 'openWB/SmartHome/Devices'
+                        pref = mqttsdevstat + '/' + str(i) + '/'
+                        mydevice.runningtime = 0
+                        mqtt_reset[pref + 'RunningTimeToday'] = '0'
+                        log.info("(" + str(i) +
+                                 ") RunningTime auf 0 gesetzt")
+                        mydevice.oncountnor = '0'
+                        mqtt_reset[pref + 'oncountnor'] = '0'
+                # Sofern Anlauferkennung laueft counter nicht zuruecksetzen
+                        if (mydevice.devstatus != 20):
+                            mydevice.oncntstandby = '0'
+                            mqtt_reset[pref + 'OnCntStandby'] = '0'
+                        mydevice.c_oldstampeinschaltdauer = 0
+                        mydevice.c_oldstampeinschaltdauer_f = 'N'
+                        # mqttcs = 'openWB/config/set/SmartHome/'
+                        pref = mqttcs + 'Devices/' + str(i) + '/'
+                        if ((mydevice.device_setauto == 1) and
+                           (mydevice.device_manual == 1)):
+                            log.info("(" + str(i) +
+                                     ") Umschaltung auf automatisch Modus ")
+                            mqtt_reset[pref + 'mode'] = '0'
+            resetmaxeinschaltdauer = 1
+            # Nur einschaltgruppe in Sekunden für neuen Tag zurücksetzten
+            Sbase.nureinschaltinsec = 0
+            sendmq(mqtt_reset)
+    if (int(hour) == 1):
+        resetmaxeinschaltdauer = 0
+
+
+def loadregelvars(wattbezug: int, speicherleistung: int, speichersoc: int) -> Tuple[int, int]:
+    global maxspeicher
+    global mydevices
+    uberschuss = wattbezug + speicherleistung
+    uberschussoffset = wattbezug + speicherleistung - maxspeicher
+    log.info("EVU Bezug(-)/Einspeisung(+): " + str(wattbezug) +
+             " max Speicherladung: " + str(maxspeicher))
+    log.info("Uberschuss: " + str(uberschuss) +
+             " Uberschuss mit Offset: " + str(uberschussoffset))
+    log.info("Speicher Entladung(-)/Ladung(+): " +
+             str(speicherleistung) + " SpeicherSoC: " + str(speichersoc))
+    reread = 0
+    try:
+        with open(bp+'/ramdisk/rereadsmarthomedevices', 'r') as value:
+            reread = int(value.read())
+    except Exception:
+        reread = 1
+    if (reread == 1):
+        with open(bp+'/ramdisk/rereadsmarthomedevices', 'w') as f:
+            f.write(str(0))
+        readmq()
+    for i in range(1, (numberOfSupportedDevices+1)):
+        try:
+            with open(bp+'/ramdisk/smarthome_device_manual_'
+                      + str(i), 'r') as value:
+                for mydevice in mydevices:
+                    if (str(i) == str(mydevice.device_nummer)):
+                        mydevice.device_manual = int(value.read())
+        except Exception:
+            pass
+        try:
+            with open(bp+'/ramdisk/smarthome_device_manual_control_'
+                      + str(i), 'r') as value:
+                for mydevice in mydevices:
+                    if (str(i) == str(mydevice.device_nummer)):
+                        mydevice.device_manual_control = int(value.read())
+        except Exception:
+            pass
+    return uberschuss, uberschussoffset
+
+
+def initparam(inpcg: str, inpcs: str, inpsdevstat: str, inpsglobstat: str, inptopicdisengageable: str,
+              inpramdiskwrite: bool, inpport: int) -> None:
+    global mqttcg
+    global mqttcs
+    global mqttsdevstat
+    global mqttsglobstat
+    global mqtttopicdisengageable
+    global ramdiskwrite
+    global mqttport
+    mqttcg = inpcg
+    mqttcs = inpcs
+    mqttsdevstat = inpsdevstat
+    mqttsglobstat = inpsglobstat
+    mqtttopicdisengageable = inptopicdisengageable
+    ramdiskwrite = inpramdiskwrite
+    mqttport = inpport
+
+
+def mainloop(wattbezug: int, speicherleistung: int, speichersoc: int) -> None:
+    global firststart
+    if firststart:
+        readmq()
+        firststart = False
+    mqtt_man = {}
+    sendmess = 0
+    uberschuss, uberschussoffset = loadregelvars(wattbezug, speicherleistung, speichersoc)
+    resetmaxeinschaltdauerfunc()
+    getdevicevalues(uberschuss, uberschussoffset)
+    conditions(speichersoc)
+    # do the manual stuff
+    for i in range(1, (numberOfSupportedDevices+1)):
+        for mydevice in mydevices:
+            if (str(i) == str(mydevice.device_nummer)):
+                if (mydevice.device_manual == 1):
+                    if (mydevice.device_manual_control == 0):
+                        if (mydevice.relais == 1):
+                            mydevice.turndevicerelais(0, 0, 1)
+                    if (mydevice.device_manual_control == 1):
+                        if (mydevice.relais == 0):
+                            mydevice.turndevicerelais(1, 0, 1)
+                    mydevice.c_mantime_f = 'Y'
+                    mydevice.c_mantime = time.time()
+                    log.info("(" + str(i) + ") " +
+                             mydevice.device_name + " manueller Modus aktiviert, keine Regelung")
+    for i in range(1, (numberOfSupportedDevices+1)):
+        # mqttcs = 'openWB/config/set/SmartHome/'
+        pref = mqttcs + 'Devices/' + str(i) + '/'
+        for mydevice in mydevices:
+            if (str(i) == str(mydevice.device_nummer)):
+                mydevice.updatebutton()
+                if (mydevice.btchange == 1):
+                    sendmess = 1
+                    mqtt_man[pref + 'mode'] = mydevice.newdevice_manual
+                if (mydevice.btchange == 2):
+                    sendmess = 1
+                    workman = mydevice.newdevice_manual_control
+                    mqtt_man[pref + 'device_manual_control'] = workman
+    if (sendmess == 1):
+        sendmq(mqtt_man)
+    time.sleep(5)

--- a/packages/smarthome/smartmeas.py
+++ b/packages/smarthome/smartmeas.py
@@ -3,8 +3,6 @@ from typing import Dict, Tuple
 from modules.common import modbus
 from modules.common import sdm
 from modules.common import lovato
-
-import subprocess
 import logging
 log = logging.getLogger(__name__)
 
@@ -174,8 +172,7 @@ class Slmqtt(Slbase):
                         str(self.device_nummer), str(ip),
                         str(self.devuberschuss)]
         try:
-            proc = subprocess.Popen(argumentList)
-            proc.communicate()
+            self.callpro(argumentList)
             answer = self.readret()
             self.newwatt = int(answer['power'])
             self.newwattk = int(answer['powerc'])
@@ -204,8 +201,7 @@ class Slshelly(Slbase):
                         str(self.device_nummer), str(ip), '0',
                         str(chan), str(shaut), shuser, shpw]
         try:
-            proc = subprocess.Popen(argumentList)
-            proc.communicate()
+            self.callpro(argumentList)
             answer = self.readret()
             self.newwatt = int(answer['power'])
             self.newwattk = int(answer['powerc'])
@@ -260,8 +256,7 @@ class Slavm(Slbase):
                         '0', '0',
                         act, user, pw]
         try:
-            proc = subprocess.Popen(argumentList)
-            proc.communicate()
+            self.callpro(argumentList)
             answer = self.readret()
             self.newwatt = int(answer['power'])
             self.newwattk = int(answer['powerc'])
@@ -287,8 +282,7 @@ class Sltasmota(Slbase):
         argumentList = ['python3', self._prefixpy + 'tasmota/watt.py',
                         str(self.device_nummer), str(ip), '0']
         try:
-            proc = subprocess.Popen(argumentList)
-            proc.communicate()
+            self.callpro(argumentList)
             answer = self.readret()
             self.newwatt = int(answer['power'])
             self.newwattk = int(answer['powerc'])
@@ -317,11 +311,8 @@ class Slhttp(Slbase):
                         str(self.device_nummer), '0',
                         str(self.devuberschuss), url, urlc,
                         '0', '0', urls]
-        proc = subprocess.Popen(argumentList)
-        proc.communicate()
         try:
-            proc = subprocess.Popen(argumentList)
-            proc.communicate()
+            self.callpro(argumentList)
             answer = self.readret()
             self.newwatt = int(answer['power'])
             self.newwattk = int(answer['powerc'])
@@ -347,8 +338,7 @@ class Slmystrom(Slbase):
         argumentList = ['python3', self._prefixpy + 'mystrom/watt.py',
                         str(self.device_nummer), str(ip), '0']
         try:
-            proc = subprocess.Popen(argumentList)
-            proc.communicate()
+            self.callpro(argumentList)
             answer = self.readret()
             self.newwatt = int(answer['power'])
             self.newwattk = int(answer['powerc'])
@@ -376,8 +366,7 @@ class Slsmaem(Slbase):
                         str(self._device_measuresmaser),
                         str(self._device_measuresmaage)]
         try:
-            proc = subprocess.Popen(argumentList)
-            proc.communicate()
+            self.callpro(argumentList)     
             answer = self.readret()
             self.newwatt = int(answer['power'])
             self.newwattk = int(answer['powerc'])
@@ -398,8 +387,7 @@ class Slwe514(Slbase):
                         str(self.device_nummer), str(self._device_measureip),
                         str(self._device_measureid)]
         try:
-            proc = subprocess.Popen(argumentList)
-            proc.communicate()
+            self.callpro(argumentList)
             answer = self.readret()
             self.newwatt = int(answer['power'])
             self.newwattk = int(answer['powerc'])
@@ -422,8 +410,7 @@ class Sljson(Slbase):
                         self._device_measurejsonpower,
                         self._device_measurejsoncounter]
         try:
-            proc = subprocess.Popen(argumentList)
-            proc.communicate()
+            self.callpro(argumentList)
             answer = self.readret()
             self.newwatt = int(answer['power'])
             self.newwattk = int(answer['powerc'])
@@ -443,8 +430,7 @@ class Slfronius(Slbase):
                         str(self.device_nummer), str(self._device_measureip),
                         str(self._device_measureid)]
         try:
-            proc = subprocess.Popen(argumentList)
-            proc.communicate()
+            self.callpro(argumentList)
             answer = self.readret()
             self.newwatt = int(answer['power'])
             self.newwattk = int(answer['powerc'])

--- a/packages/smarthome/smartmeas.py
+++ b/packages/smarthome/smartmeas.py
@@ -366,7 +366,7 @@ class Slsmaem(Slbase):
                         str(self._device_measuresmaser),
                         str(self._device_measuresmaage)]
         try:
-            self.callpro(argumentList)     
+            self.callpro(argumentList)
             answer = self.readret()
             self.newwatt = int(answer['power'])
             self.newwattk = int(answer['powerc'])

--- a/runs/smarthomemq.py
+++ b/runs/smarthomemq.py
@@ -100,4 +100,4 @@ if __name__ == "__main__":
                         + str(e))
             wattbezug = 0
         mainloop(wattbezug, speicherleistung, speichersoc)
-        time.sleep(5)
+

--- a/runs/smarthomemq.py
+++ b/runs/smarthomemq.py
@@ -1,34 +1,28 @@
-#!/usr/bin/env python3
-import paho.mqtt.client as mqtt
+#!/usr/bin/python3
+from smarthome.smartcommon import mainloop, initparam
 import time
-import re
-import os
 import logging
-import math
-from typing import Dict, Any, List
-from smarthome.global0 import log
-from smarthome.smartbase import Sbase
-from modules.smarthome.avmhomeautomation.smartavm import Savm
-from modules.smarthome.acthor.smartacthor import Sacthor
-from modules.smarthome.nxdacxx.smartnxdacxx import Snxdacxx
-from modules.smarthome.elwa.smartelwa import Selwa
-from modules.smarthome.idm.smartidm import Sidm
-from modules.smarthome.http.smarthttp import Shttp
-from modules.smarthome.mqtt.smartmqtt import Smqtt
-from modules.smarthome.mystrom.smartmystrom import Smystrom
-from modules.smarthome.shelly.smartshelly import Sshelly
-from modules.smarthome.stiebel.smartstiebel import Sstiebel
-from modules.smarthome.vampair.smartvampair import Svampair
-from modules.smarthome.lambda_.smartlambda import Slambda
-from modules.smarthome.tasmota.smarttasmota import Stasmota
-from modules.smarthome.viessmann.smartviessmann import Sviessmann
-from modules.smarthome.ratiotherm.smartratiotherm import Sratiotherm
+log = logging.getLogger("smarthome")
+# openwb 1.9 spec
+mqttcg = 'openWB/config/get/SmartHome/'
+mqttcs = 'openWB/config/set/SmartHome/'
+mqttsdevstat = 'openWB/SmartHome/Devices'
+mqttsglobstat = 'openWB/SmartHome/Status/'
+mqtttopicdisengageable = 'openWB/SmartHome/Status/wattschalt'
+ramdiskwrite = True
+mqttport = 1883
+#
+#  openwb 2.0 spec
+#  mqttcg = 'openWB/LegacySmartHome/config/get/'
+#  mqttcs = 'openWB/LegacySmartHome/config/set/'
+#  mqttsdevstat = 'openWB/LegacySmartHome/Devices'
+#  mqttsglobstat = 'openWB/LegacySmartHome/Status/'
+#  mqtttopicdisengageable = 'openWB/set/counter/set/disengageable_smarthome_power'
+#  ramdiskwrite = False
+#  mqttport = 1886
+#
 
-mqtt_cache = {}  # type: Dict[str, str]
-parammqtt = []  # type: List[Any]
-mydevices = []  # type: List[Any]
 bp = '/var/www/html/openWB'
-numberOfSupportedDevices = 9  # limit number of smarthome devices
 
 
 def initlog() -> None:
@@ -38,64 +32,6 @@ def initlog() -> None:
     fh.setLevel(logging.DEBUG)
     fh.setFormatter(formatter)
     log.addHandler(fh)
-
-
-def on_connect(client, userdata, flags, rc) -> None:
-    # client.subscribe("openWB/config/get/SmartHome/Devices/#", 2)
-    client.subscribe("openWB/config/get/SmartHome/#", 2)
-    client.subscribe("openWB/SmartHome/Devices/#", 2)
-
-
-def logmq(topic: str, devicenumb: int, keyword: str, value: str) -> None:
-    global parammqtt
-    #  richtig  topic single
-    if (devicenumb < 1) or (devicenumb > numberOfSupportedDevices):
-        pass
-    else:
-        log.info("(" + str(devicenumb) + ") Key " + str(keyword) + " Value " + str(value))
-        parammqtt.append([devicenumb, keyword, value])
-        with open(bp+'/ramdisk/smartparam.sh', 'a') as f:
-            print('%s' %
-                 ('mosquitto_pub -p 1886 -t ' +
-                  '"' + topic + '/' + str(devicenumb) + '/' + keyword +
-                  '" -r -m "' + str(value) + '"'),file=f)
-def logmqgl(keyword: str, value: str) -> None:
-    #  richtig  topic global
-    log.info("( global ) Key " + str(keyword) + " Value " + str(value))
-    with open(bp+'/ramdisk/smartparam.sh', 'a') as f:
-        print('%s' % 
-             ('mosquitto_pub -p 1886 -t ' +
-                '"openWB/config/get/SmartHome/' + keyword + 
-                '" -r -m "' + str(value) +  '"'),file=f)
-
-def on_message(client, userdata, msg) -> None:
-    # wenn exception hier wird mit nächster msg weitergemacht
-    # macht paho unter phyton 3 immer so
-    # für neuer python 3.7 version gibt es absturz
-    global maxspeicher
-    try:
-        devicenumb = int(re.sub(r'\D', '', msg.topic))
-    except Exception:
-        devicenumb = 0
-    value = msg.payload.decode("utf-8")
-    try:
-        valueint = int(value)
-    except Exception:
-        valueint = 0
-    if ("openWB/config/get/SmartHome/Devices" in msg.topic):
-        keyword = re.sub('openWB/config/get/SmartHome/Devices/'
-                         + str(devicenumb) + '/', '', msg.topic)
-        logmq("openWB/config/get/SmartHome/Devices",devicenumb, keyword, value)
-    elif ("openWB/SmartHome/Devices" in msg.topic):
-        keyword = re.sub('openWB/SmartHome/Devices/'
-                         + str(devicenumb) + '/', '', msg.topic)
-        logmq("openWB/SmartHome/Devices",devicenumb, keyword, value)
-    elif ("openWB/config/get/SmartHome/maxBatteryPower" in msg.topic):
-        keyword = re.sub('openWB/config/get/SmartHome/', '', msg.topic)
-        logmqgl(keyword, value)
-        maxspeicher = valueint
-    else:
-        log.warning(" Skipped msg " + msg.topic + " Value " + value)
 
 
 def checkbootdone() -> int:
@@ -126,401 +62,42 @@ def checkbootdone() -> int:
         time.sleep(30)
         return 0
     return 1
+
+
 # Lese aus der Ramdisk Regelrelevante Werte ein
-
-
-def loadregelvars() -> None:
-    global uberschuss
-    global uberschussoffset
-    global speicherleistung
-    global speichersoc
-    global speichervorhanden
-    global wattbezug
-    global numberOfSupportedDevices
-    global maxspeicher
-    global mydevices
-    try:
-        with open(bp+'/ramdisk/speichervorhanden', 'r') as value:
-            speichervorhanden = int(value.read())
-        if (speichervorhanden == 1):
-            with open(bp+'/ramdisk/speicherleistung', 'r') as value:
-                speicherleistung = int(float(value.read()))
-            with open(bp+'/ramdisk/speichersoc', 'r') as value:
-                speichersoc = int(float(value.read()))
-        else:
-            speicherleistung = 0
-            speichersoc = 100
-    except Exception as e:
-        log.warning("Fehler beim Auslesen der Ramdisk " +
-                    "(speichervorhanden,speicherleistung,speichersoc): " +
-                    str(e))
-        speichervorhanden = 0
-        speicherleistung = 0
-        speichersoc = 100
-    try:
-        with open(bp+'/ramdisk/wattbezug', 'r') as value:
-            wattbezug = int(float(value.read())) * -1
-    except Exception as e:
-        log.warning("Fehler beim Auslesen der Ramdisk (wattbezug):"
-                    + str(e))
-        wattbezug = 0
-    uberschuss = wattbezug + speicherleistung
-    uberschussoffset = wattbezug + speicherleistung - maxspeicher
-    log.info("EVU Bezug(-)/Einspeisung(+): " + str(wattbezug) +
-             " max Speicherladung: " + str(maxspeicher))
-    log.info("Uberschuss: " + str(uberschuss) +
-             " Uberschuss mit Offset: " + str(uberschussoffset))
-    log.info("Speicher Entladung(-)/Ladung(+): " +
-             str(speicherleistung) + " SpeicherSoC: " + str(speichersoc))
-    reread = 0
-    try:
-        with open(bp+'/ramdisk/rereadsmarthomedevices', 'r') as value:
-            reread = int(value.read())
-    except Exception:
-        reread = 1
-    if (reread == 1):
-        with open(bp+'/ramdisk/rereadsmarthomedevices', 'w') as f:
-            f.write(str(0))
-        readmq()
-
-    for i in range(1, (numberOfSupportedDevices+1)):
-        try:
-            with open(bp+'/ramdisk/smarthome_device_manual_'
-                      + str(i), 'r') as value:
-                for mydevice in mydevices:
-                    if (str(i) == str(mydevice.device_nummer)):
-                        mydevice.device_manual = int(value.read())
-        except Exception:
-            pass
-        try:
-            with open(bp+'/ramdisk/smarthome_device_manual_control_'
-                      + str(i), 'r') as value:
-                for mydevice in mydevices:
-                    if (str(i) == str(mydevice.device_nummer)):
-                        mydevice.device_manual_control = int(value.read())
-        except Exception:
-            pass
-
-
-def getdevicevalues() -> None:
-    global mydevices
-    global uberschuss
-    global uberschussoffset
-    totalwatt = 0
-    totalwattot = 0
-    totalminhaus = 0
-    # dyn daten einschaltgruppe
-    Sbase.ausschaltwatt = 0
-    Sbase.einrelais = 0
-    Sbase.eindevstatus = 0
-    mqtt_all = {}
-    for mydevice in mydevices:
-        mydevice.getwatt(uberschuss, uberschussoffset)
-        watt = mydevice.newwatt
-        wattk = mydevice.newwattk
-        relais = mydevice.relais
-        # temp0 = mydevice.temp0
-        # temp1 = mydevice.temp1
-        # temp2 = mydevice.temp2
-        if ((mydevice.abschalt == 1) and (relais == 1)
-           and (mydevice.device_manual != 1)):
-            totalwatt = totalwatt + watt
-        else:
-            totalwattot = totalwattot + watt
-        if (mydevice.device_homeconsumtion == 0):
-            totalminhaus = totalminhaus + watt
-        log.info("(" + str(mydevice.device_nummer) + ") " +
-                 str(mydevice.device_name) + " rel: " + str(relais) +
-                 " oncnt/onstandby/time: " + str(mydevice.oncountnor) + "/"
-                 + str(mydevice.oncntstandby) + "/" +
-                 str(mydevice.runningtime) + " Status/Üeb: " +
-                 str(mydevice.devstatus) + "/" +
-                 str(mydevice.ueberschussberechnung) + " akt: " + str(watt) +
-                 " Z: " + str(wattk))
-        mqtt_all.update(mydevice.mqtt_param)
-    # device_total_watt is needed for calculation the proper überschuss
-    # (including switchable smarthomedevices)
-
-    with open(bp+'/ramdisk/devicetotal_watt', 'w') as f:
-        f.write(str(totalwatt))
-    with open(bp+'/ramdisk/devicetotal_watt_other', 'w') as f:
-        f.write(str(totalwattot))
-    with open(bp+'/ramdisk/devicetotal_watt_hausmin', 'w') as f:
-        f.write(str(totalminhaus))
-    log.info("Total Watt abschaltbarer smarthomedevices: " +
-             str(totalwatt))
-    log.info("Total Watt nichtabschaltbarer smarthomedevices: "
-             + str(totalwattot))
-    log.info("Total Watt nicht im Hausverbrauch: " +
-             str(totalminhaus))
-    log.info("Anzahl devices in Auschaltgruppe: " +
-             str(Sbase.ausdevices) + " akt: " + str(Sbase.ausschaltwatt) +
-             " Anzahl devices in Einschaltgruppe: " + str(Sbase.eindevices)
-             )
-    nurhh = math.floor(Sbase.nureinschaltinsec / 3600)
-    nurmm = math.floor((Sbase.nureinschaltinsec - (nurhh * 3600)) / 60)
-    nurss = (Sbase.nureinschaltinsec - (nurhh * 3600) - (nurmm * 60))
-    log.info("Einschaltgruppe rel: " + str(Sbase.einrelais) +
-             " Summe Einschaltschwelle: " +
-             str(Sbase.einschwelle) + " max Einschaltverzögerung " +
-             str(Sbase.einverz) + " nur Einschaltgruppe prüfen bis: " +
-             str('%.2d' % nurhh) + ":" + str('%.2d' % nurmm) + ":" +
-             str('%.2d' % nurss) +
-             " in Total sec " + str(Sbase.nureinschaltinsec)
-             )
-    mqtt_all['openWB/SmartHome/Status/maxspeicherladung'] = maxspeicher
-    mqtt_all['openWB/SmartHome/Status/wattschalt'] = totalwatt
-    mqtt_all['openWB/SmartHome/Status/wattnichtschalt'] = totalwattot
-    mqtt_all['openWB/SmartHome/Status/wattnichtHaus'] = totalminhaus
-    mqtt_all['openWB/SmartHome/Status/uberschuss'] = uberschuss
-    mqtt_all['openWB/SmartHome/Status/uberschussoffset'] = uberschussoffset
-    sendmq(mqtt_all)
-
-
-def sendmq(mqtt_input: Dict[str, str]) -> None:
-    global mqtt_cache
-    client = mqtt.Client("openWB-SmartHome-bulkpublisher-" + str(os.getpid()))
-    client.connect("localhost")
-    for key, value in mqtt_input.items():
-        valueold = mqtt_cache.get(key, 'not in cache')
-        if (valueold == value):
-            pass
-        else:
-            log.info("Mq pub " + str(key) + "=" +
-                     str(value) + " old " + str(valueold))
-            mqtt_cache[key] = value
-            client.publish(key, payload=value, qos=0, retain=True)
-            client.loop(timeout=2.0)
-    client.disconnect()
-
-
-def conditions() -> None:
-    global mydevices
-    global speichersoc
-    for mydevice in mydevices:
-        mydevice.conditions(speichersoc)
-
-
-def update_devices() -> None:
-    global parammqtt
-    global mydevices
-    global mqtt_cache
-    client = mqtt.Client("openWB-SmartHome-bulkpublisher-" + str(os.getpid()))
-    client.connect("localhost")
-    # statische daten einschaltgruppe
-    Sbase.ausdevices = 0
-    Sbase.eindevices = 0
-    Sbase.einverz = 0
-    Sbase.einschwelle = 0
-    # Nur einschaltgruppe in Sekunden
-    Sbase.nureinschaltinsec = 0
-    for i in range(1, numberOfSupportedDevices+1):
-        device_configured = 0
-        device_type = 'none'
-        input_param = {}
-        input_param['device_nummer'] = str(i)
-        for devicenumb, keyword, value in parammqtt:
-            if (str(i) == str(devicenumb)):
-                if (keyword == 'device_configured'):
-                    device_configured = value
-                if (keyword == 'device_type'):
-                    device_type = value
-                input_param[keyword] = value
-        if (device_configured == "1"):
-            createnew = 1
-            for mydevice in mydevices:
-                if (str(i) == str(mydevice.device_nummer)):
-                    log.info("(" + str(i) + ") " +
-                             "Device bereits erzeugt")
-                    if (device_type == mydevice.device_type):
-                        log.info("(" + str(i) + ") " +
-                                 "Typ gleich, nur Parameter update")
-                        createnew = 0
-                        mydevice.updatepar(input_param)
-                    else:
-                        log.info("(" + str(i) + ") " +
-                                 "Typ ungleich " + mydevice.device_type)
-                        mydevice.device_nummer = 0
-                        mydevice._device_configured = '9'
-                        # del mydevice
-                        mydevices.remove(mydevice)
-                        log.info("(" + str(i) + ") " +
-                                 "Device gelöscht")
-                    break
-            if (createnew == 1):
-                log.info("(" + str(i) +
-                         ") Neues Devices oder Typänderung: " +
-                         str(device_type))
-                if (device_type == 'shelly'):
-                    mydevice = Sshelly()
-                elif (device_type == 'stiebel'):
-                    mydevice = Sstiebel()
-                elif (device_type == 'vampair'):
-                    mydevice = Svampair()
-                elif (device_type == 'lambda'):
-                    mydevice = Slambda()
-                elif (device_type == 'ratiotherm'):
-                    mydevice = Sratiotherm()
-                elif (device_type == 'tasmota'):
-                    mydevice = Stasmota()
-                elif (device_type == 'avm'):
-                    mydevice = Savm()
-                elif (device_type == 'viessmann'):
-                    mydevice = Sviessmann()
-                elif (device_type == 'acthor'):
-                    mydevice = Sacthor()
-                elif (device_type == 'NXDACXX'):
-                    mydevice = Snxdacxx()
-                elif (device_type == 'elwa'):
-                    mydevice = Selwa()
-                elif (device_type == 'idm'):
-                    mydevice = Sidm()
-                elif (device_type == 'mqtt'):
-                    mydevice = Smqtt()
-                elif (device_type == 'http'):
-                    mydevice = Shttp()
-                elif (device_type == 'mystrom'):
-                    mydevice = Smystrom()
-                else:
-                    mydevice = Sbase()
-                mydevice.updatepar(input_param)
-                mydevices.append(mydevice)
-        else:
-            log.info("(" + str(i) + ") " +
-                     "Device nicht (länger) definiert")
-            for mydevice in mydevices:
-                if (str(i) == str(mydevice.device_nummer)):
-                    # cleant up mqtt
-                    for key, value in mydevice.mqtt_param_del.items():
-                        valueold = mqtt_cache.pop(key, 'not in cache')
-                        log.info("Mq pub " + str(key) + "=" +
-                                 str(value) + " old " + str(valueold))
-                        client.publish(key, payload=value, qos=0, retain=True)
-                        client.loop(timeout=2.0)
-                    mydevice.device_nummer = 0
-                    mydevice._device_configured = '9'
-                    # del mydevice
-                    mydevices.remove(mydevice)
-                    log.info("(" + str(i) + ") " +
-                             "Device gelöscht")
-    client.disconnect()
-
-
-def readmq() -> None:
-    global parammqtt
-    global mydevices
-    log.info("Config reRead start / Parameter check") 
-    with open(bp+'/ramdisk/smartparam.sh', 'w') as f:
-        print('%s' % ('#!/bin/bash'),file=f)   
-    parammqtt = []
-    client = mqtt.Client("openWB-mqttsmarthome")
-    client.on_connect = on_connect
-    client.on_message = on_message
-    startTime = time.time()
-    waitTime = 5
-    client.connect("localhost")
-    while True:
-        client.loop()
-        elapsedTime = time.time() - startTime
-        if elapsedTime > waitTime:
-            client.disconnect()
-            break
-    log.info("Config reRead / Parameter check done")
-    update_devices()
-    log.info("Config reRead done")
-
-
-def resetmaxeinschaltdauerfunc() -> None:
-    global resetmaxeinschaltdauer
-    global numberOfSupportedDevices
-    global mydevices
-    mqtt_reset = {}
-    hour = time.strftime("%H")
-    if (int(hour) == 0):
-        if (int(resetmaxeinschaltdauer) == 0):
-            for i in range(1, (numberOfSupportedDevices+1)):
-                for mydevice in mydevices:
-                    if (str(i) == str(mydevice.device_nummer)):
-                        pref = 'openWB/SmartHome/Devices/' + str(i) + '/'
-                        mydevice.runningtime = 0
-                        mqtt_reset[pref + 'RunningTimeToday'] = '0'
-                        log.info("(" + str(i) +
-                                 ") RunningTime auf 0 gesetzt")
-                        mydevice.oncountnor = '0'
-                        mqtt_reset[pref + 'oncountnor'] = '0'
-                # Sofern Anlauferkennung laueft counter nicht zuruecksetzen
-                        if (mydevice.devstatus != 20):
-                            mydevice.oncntstandby = '0'
-                            mqtt_reset[pref + 'OnCntStandby'] = '0'
-                        mydevice.c_oldstampeinschaltdauer = 0
-                        mydevice.c_oldstampeinschaltdauer_f = 'N'
-                        pref = 'openWB/config/set/SmartHome/Devices/' + str(i) + '/'
-                        if ((mydevice.device_setauto == 1) and
-                           (mydevice.device_manual == 1)):
-                            log.info("(" + str(i) +
-                                     ") Umschaltung auf automatisch Modus ")
-                            mqtt_reset[pref + 'mode'] = '0'
-            resetmaxeinschaltdauer = 1
-            # Nur einschaltgruppe in Sekunden für neuen Tag zurücksetzten
-            Sbase.nureinschaltinsec = 0
-            sendmq(mqtt_reset)
-    if (int(hour) == 1):
-        resetmaxeinschaltdauer = 0
-
-
 if __name__ == "__main__":
-    resetmaxeinschaltdauer = 0
-    maxspeicher = 0
-    speicherleistung = 0
-    speichersoc = 100
-    speichervorhanden = 0
-    wattbezug = 0
-    uberschuss = 0
-    uberschussoffset = 0
     initlog()
-    log.info("*** Smarthome mq Start ***")
+    log.info("*** Smarthome mq openWB 1.9 Start ***")
+    initparam(mqttcg, mqttcs, mqttsdevstat, mqttsglobstat, mqtttopicdisengageable, ramdiskwrite, mqttport)
     while True:
         if (checkbootdone() == 1):
             break
         time.sleep(5)
-    readmq()
-    time.sleep(5)
     while True:
-        #        update_devices()
-        mqtt_man = {}
-        sendmess = 0
-        loadregelvars()
-        resetmaxeinschaltdauerfunc()
-        getdevicevalues()
-        conditions()
-        # do the manual stuff
-        for i in range(1, (numberOfSupportedDevices+1)):
-            for mydevice in mydevices:
-                if (str(i) == str(mydevice.device_nummer)):
-                    if (mydevice.device_manual == 1):
-                        if (mydevice.device_manual_control == 0):
-                            if (mydevice.relais == 1):
-                                mydevice.turndevicerelais(0, 0, 1)
-                        if (mydevice.device_manual_control == 1):
-                            if (mydevice.relais == 0):
-                                mydevice.turndevicerelais(1, 0, 1)
-                        mydevice.c_mantime_f = 'Y'
-                        mydevice.c_mantime = time.time()
-                        log.info("(" + str(i) + ") " +
-                                 mydevice.device_name +
-                                 " manueller Modus aktiviert, keine Regelung")
-        for i in range(1, (numberOfSupportedDevices+1)):
-            pref = 'openWB/config/set/SmartHome/Devices/' + str(i) + '/'
-            for mydevice in mydevices:
-                if (str(i) == str(mydevice.device_nummer)):
-                    mydevice.updatebutton()
-                    if (mydevice.btchange == 1):
-                        sendmess = 1
-                        mqtt_man[pref + 'mode'] = mydevice.newdevice_manual
-                    if (mydevice.btchange == 2):
-                        sendmess = 1
-                        workman = mydevice.newdevice_manual_control
-                        mqtt_man[pref + 'device_manual_control'] = workman
-        if (sendmess == 1):
-            sendmq(mqtt_man)
+        try:
+            with open(bp+'/ramdisk/speichervorhanden', 'r') as value:
+                speichervorhanden = int(value.read())
+            if (speichervorhanden == 1):
+                with open(bp+'/ramdisk/speicherleistung', 'r') as value:
+                    speicherleistung = int(float(value.read()))
+                with open(bp+'/ramdisk/speichersoc', 'r') as value:
+                    speichersoc = int(float(value.read()))
+            else:
+                speicherleistung = 0
+                speichersoc = 100
+        except Exception as e:
+            log.warning("Fehler beim Auslesen der Ramdisk " +
+                        "(speichervorhanden,speicherleistung,speichersoc): " +
+                        str(e))
+            speichervorhanden = 0
+            speicherleistung = 0
+            speichersoc = 100
+        try:
+            with open(bp+'/ramdisk/wattbezug', 'r') as value:
+                wattbezug = int(float(value.read())) * -1
+        except Exception as e:
+            log.warning("Fehler beim Auslesen der Ramdisk (wattbezug):"
+                        + str(e))
+            wattbezug = 0
+        mainloop(wattbezug, speicherleistung, speichersoc)
         time.sleep(5)


### PR DESCRIPTION
Der Smarthomemq.py wurde zerlegt in einen openWB 1.9 Teil und einen zwischen openWB 1.9 und openWB 2.0 gemeinsamen Teil. Die gleiche Einlieferung findet auch für openWB 2.0 statt. Somit soll dieser PR nur für openWB 1.9 verwendet werden Es wurde ein Fehler bei der mindestlaufzeit pro Tag behoben