### PR TITLE
Umschalten auf automatisch um 23:59

### DIFF
--- a/packages/smarthome/smartcommon.py
+++ b/packages/smarthome/smartcommon.py
@@ -199,7 +199,10 @@ def sendmq(mqtt_input: Dict[str, str]) -> None:
         else:
             log.info("Mq pub " + str(key) + "=" +
                      str(value) + " old " + str(valueold))
-            mqtt_cache[key] = value
+            if (mqttcs in str(key)):
+                log.info("Mq no caching " + str(key))
+            else:
+                mqtt_cache[key] = value
             client.publish(key, payload=value, qos=0, retain=True)
             client.loop(timeout=2.0)
     client.disconnect()


### PR DESCRIPTION
Für Umschaltung manuell auf automatisch wird das smarthome mqtt cache ausgeschaltet, da auch im Online umgeschaltet werden kann und somit das Cache nicht immer synchron ist.