### PR TITLE
idm....mit PV Leistung

### DIFF
--- a/packages/modules/smarthome/idm/off.py
+++ b/packages/modules/smarthome/idm/off.py
@@ -1,36 +1,21 @@
 #!/usr/bin/python3
 import sys
 import os
-import struct
-from pymodbus.client.sync import ModbusTcpClient
 import logging
 from smarthome.smartlog import initlog
 devicenumber = int(sys.argv[1])
 ipadr = str(sys.argv[2])
 uberschuss = int(sys.argv[3])
-try:
-    navvers = str(sys.argv[4])
-except Exception:
-    navvers = "2"
+navvers = str(sys.argv[4])
 bp = '/var/www/html/openWB/ramdisk/smarthome_device_'
 # standard
 file_stringpv = bp + str(devicenumber) + '_pv'
 file_stringcount = bp + str(devicenumber) + '_count'
+file_stringcount5 = bp + str(devicenumber) + '_count5'
 initlog("idm", devicenumber)
 log = logging.getLogger("idm")
-log.info(" devicenr %d ipadr %s ueberschuss %6d try to connect (modbus)"
+log.info(" off.py devicenr %d ipadr %s ueberschuss %6d "
          % (devicenumber, ipadr, uberschuss))
-client = ModbusTcpClient(ipadr, port=502)
-start = 4122
-if navvers == "2":
-    rr = client.read_input_registers(start, 2, unit=1)
-else:
-    rr = client.read_holding_registers(start, 2, unit=1)
-raw = struct.pack('>HH', rr.getRegister(1), rr.getRegister(0))
-lkw = float(struct.unpack('>f', raw)[0])
-aktpower = int(lkw*1000)
-log.info(" devicenr %d ipadr %s Akt Leistung %6d"
-         % (devicenumber, ipadr, aktpower))
 pvmodus = 0
 if os.path.isfile(file_stringpv):
     with open(file_stringpv, 'r') as f:
@@ -44,3 +29,6 @@ with open(file_stringpv, 'w') as f:
 count1 = 999
 with open(file_stringcount, 'w') as f:
     f.write(str(count1))
+count5 = 999
+with open(file_stringcount5, 'w') as f:
+    f.write(str(count5))

--- a/packages/modules/smarthome/idm/on.py
+++ b/packages/modules/smarthome/idm/on.py
@@ -1,17 +1,12 @@
 #!/usr/bin/python3
 import sys
-import struct
-from pymodbus.client.sync import ModbusTcpClient
 import logging
 from smarthome.smartlog import initlog
 devicenumber = int(sys.argv[1])
 ipadr = str(sys.argv[2])
 uberschuss = int(sys.argv[3])
 bp = '/var/www/html/openWB/ramdisk/smarthome_device_'
-try:
-    navvers = str(sys.argv[4])
-except Exception:
-    navvers = "2"
+navvers = str(sys.argv[4])
 initlog("idm", devicenumber)
 log = logging.getLogger("idm")
 # standard
@@ -19,21 +14,14 @@ log = logging.getLogger("idm")
 # own log
 file_stringpv = bp + str(devicenumber) + '_pv'
 file_stringcount = bp + str(devicenumber) + '_count'
-log.info("devicenr %d ipadr %s ueberschuss %6d try to connect (modbus)"
+file_stringcount5 = bp + str(devicenumber) + '_count5'
+log.info("on.py devicenr %d ipadr %s ueberschuss %6d"
          % (devicenumber, ipadr, uberschuss))
-client = ModbusTcpClient(ipadr, port=502)
-start = 4122
-if navvers == "2":
-    rr = client.read_input_registers(start, 2, unit=1)
-else:
-    rr = client.read_holding_registers(start, 2, unit=1)
-raw = struct.pack('>HH', rr.getRegister(1), rr.getRegister(0))
-lkw = float(struct.unpack('>f', raw)[0])
-aktpower = int(lkw*1000)
-log.info("devicenr %d ipadr %s Akt Leistung  %6d " %
-         (devicenumber, ipadr, aktpower))
 with open(file_stringpv, 'w') as f:
     f.write(str(1))
 count1 = 999
 with open(file_stringcount, 'w') as f:
     f.write(str(count1))
+count5 = 999
+with open(file_stringcount5, 'w') as f:
+    f.write(str(count5))

--- a/packages/modules/smarthome/idm/smartidm.py
+++ b/packages/modules/smarthome/idm/smartidm.py
@@ -29,15 +29,18 @@ class Sidm(Sbase):
 
     def getwatt(self, uberschuss: int, uberschussoffset: int) -> None:
         self.prewatt(uberschuss, uberschussoffset)
+        forcesend = self.checkbefsend()              
         argumentList = ['python3', self._prefixpy + 'idm/watt.py',
                         str(self.device_nummer), str(self._device_ip),
-                        str(self.devuberschuss), str(self._device_idmnav)]
+                        str(self.devuberschuss), str(self._device_idmnav),
+                        str(self.pvwatt), str(forcesend)]
         try:
             self.callpro(argumentList)
             self.answer = self.readret()
             self.newwatt = int(self.answer['power'])
             self.newwattk = int(self.answer['powerc'])
             self.relais = int(self.answer['on'])
+            self.checksend(self.answer)
         except Exception as e1:
             log.warning("(" + str(self.device_nummer) +
                         ") Leistungsmessung %s %d %s Fehlermeldung: %s "

--- a/packages/modules/smarthome/idm/smartidm.py
+++ b/packages/modules/smarthome/idm/smartidm.py
@@ -29,7 +29,7 @@ class Sidm(Sbase):
 
     def getwatt(self, uberschuss: int, uberschussoffset: int) -> None:
         self.prewatt(uberschuss, uberschussoffset)
-        forcesend = self.checkbefsend()              
+        forcesend = self.checkbefsend()
         argumentList = ['python3', self._prefixpy + 'idm/watt.py',
                         str(self.device_nummer), str(self._device_ip),
                         str(self.devuberschuss), str(self._device_idmnav),

--- a/packages/modules/smarthome/idm/watt.py
+++ b/packages/modules/smarthome/idm/watt.py
@@ -84,6 +84,7 @@ if count5 == 0:
         modbuswrite = 1
         neupower = 0
         pvmodus = 0
+        pvwatt = 0
         with open(file_stringpv, 'w') as f:
             f.write(str(pvmodus))
     lkwneu = float(neupower)

--- a/packages/modules/smarthome/idm/watt.py
+++ b/packages/modules/smarthome/idm/watt.py
@@ -1,7 +1,6 @@
 #!/usr/bin/python3
 import sys
 import os
-import time
 import struct
 import logging
 from pymodbus.constants import Endian
@@ -9,14 +8,15 @@ from pymodbus.payload import BinaryPayloadBuilder
 from pymodbus.client.sync import ModbusTcpClient
 from smarthome.smartlog import initlog
 from smarthome.smartret import writeret
-named_tuple = time.localtime()  # getstruct_time
 devicenumber = int(sys.argv[1])
 ipadr = str(sys.argv[2])
 uberschuss = int(sys.argv[3])
-try:
-    navvers = str(sys.argv[4])
-except Exception:
-    navvers = "2"
+navvers = str(sys.argv[4])
+pvwatt = int(sys.argv[5])
+forcesend = int(sys.argv[6])
+# forcesend = 0 default time period applies
+# forcesend = 1 default overwritten send now
+# forcesend = 9 default overwritten no send
 initlog("idm", devicenumber)
 log = logging.getLogger("idm")
 bp = '/var/www/html/openWB/ramdisk/smarthome_device_'
@@ -27,7 +27,12 @@ count5 = 999
 if os.path.isfile(file_stringcount5):
     with open(file_stringcount5, 'r') as f:
         count5 = int(f.read())
-count5 = count5+1
+if (forcesend == 0):
+    count5 = count5 + 1
+elif (forcesend == 1):
+    count5 = 999
+else:
+    count5 = 1
 if count5 > 6:
     count5 = 0
 with open(file_stringcount5, 'w') as f:
@@ -50,6 +55,10 @@ if count5 == 0:
         f.write(str(count1))
     # aktuelle Leistung lesen
     client = ModbusTcpClient(ipadr, port=502)
+    #  test
+    #  start = 3501
+    #  navvers = "2"
+    #  prod
     start = 4122
     if navvers == "2":
         rr = client.read_input_registers(start, 2, unit=1)
@@ -83,18 +92,27 @@ if count5 == 0:
                                    wordorder=Endian.Little)
     builder.add_32bit_float(lkwneu)
     regnew = builder.to_registers()
+    pvw = float(pvwatt)
+    pvw = pvw/1000
+    builder = BinaryPayloadBuilder(byteorder=Endian.Big,
+                                   wordorder=Endian.Little)
+    builder.add_32bit_float(pvw)
+    pvwnew = builder.to_registers()
     # json return power = aktuelle Leistungsaufnahme in Watt,
     # on = 1 pvmodus, powerc = counter in kwh
-    an = '{"power":' + str(aktpower) + ',"powerc":0,"on":' + str(pvmodus) + '}'
-    writeret(an, devicenumber)
+    answer = '{"power":' + str(aktpower) + ',"powerc":0'
+    answer += ',"send":' + str(modbuswrite) + ',"sendpower":' + str(neupower)
+    answer += ',"on":' + str(pvmodus) + '}'
+    writeret(answer, devicenumber)
     if count1 < 3:
-        log.info(" %d ipadr %s ueberschuss %6d Akt Leistung %6d"
-                 % (devicenumber, ipadr, uberschuss, aktpower))
+        log.info(" %d ipadr %s ueberschuss %6d Akt Leistung %6d Pv %6d"
+                 % (devicenumber, ipadr, uberschuss, aktpower, pvwatt))
         log.info(" %d ipadr %s ueberschuss %6d pvmodus %1d modbusw %1d"
                  % (devicenumber, ipadr, neupower, pvmodus, modbuswrite))
     # modbus write
     if modbuswrite == 1:
         client.write_registers(74, regnew, unit=1)
+        client.write_registers(78, pvwnew, unit=1)
         if count1 < 3:
             log.info("devicenr %d ipadr %s device written by modbus " %
                      (devicenumber, ipadr))

--- a/packages/smarthome/smartbase.py
+++ b/packages/smarthome/smartbase.py
@@ -43,6 +43,7 @@ class Sbase(Sbase0):
         self.temp2 = '300'
         self.newwatt = 0
         self.newwattk = 0
+        self.pvwatt = 0
         self.relais = 0
         self.devuberschuss = 0
         self.device_temperatur_configured = 0

--- a/packages/smarthome/smartcommon.py
+++ b/packages/smarthome/smartcommon.py
@@ -110,7 +110,7 @@ def on_message(client, userdata, msg) -> None:
         log.warning(" Skipped msg " + msg.topic + " Value " + value)
 
 
-def getdevicevalues(uberschuss: int, uberschussoffset: int) -> None:
+def getdevicevalues(uberschuss: int, uberschussoffset: int, pvwatt: int) -> None:
     global mydevices
     totalwatt = 0
     totalwattot = 0
@@ -121,6 +121,7 @@ def getdevicevalues(uberschuss: int, uberschussoffset: int) -> None:
     Sbase.eindevstatus = 0
     mqtt_all = {}
     for mydevice in mydevices:
+        mydevice.pvwatt = pvwatt
         mydevice.getwatt(uberschuss, uberschussoffset)
         watt = mydevice.newwatt
         wattk = mydevice.newwattk
@@ -389,7 +390,7 @@ def resetmaxeinschaltdauerfunc() -> None:
         resetmaxeinschaltdauer = 0
 
 
-def loadregelvars(wattbezug: int, speicherleistung: int, speichersoc: int) -> Tuple[int, int]:
+def loadregelvars(wattbezug: int, speicherleistung: int, speichersoc: int,pvwatt: int) -> Tuple[int, int]:
     global maxspeicher
     global mydevices
     uberschuss = wattbezug + speicherleistung
@@ -397,7 +398,7 @@ def loadregelvars(wattbezug: int, speicherleistung: int, speichersoc: int) -> Tu
     log.info("EVU Bezug(-)/Einspeisung(+): " + str(wattbezug) +
              " max Speicherladung: " + str(maxspeicher))
     log.info("Uberschuss: " + str(uberschuss) +
-             " Uberschuss mit Offset: " + str(uberschussoffset))
+             " Uberschuss mit Offset: " + str(uberschussoffset) + " Pv: " + str(pvwatt))
     log.info("Speicher Entladung(-)/Ladung(+): " +
              str(speicherleistung) + " SpeicherSoC: " + str(speichersoc))
     reread = 0
@@ -448,16 +449,16 @@ def initparam(inpcg: str, inpcs: str, inpsdevstat: str, inpsglobstat: str, inpto
     mqttport = inpport
 
 
-def mainloop(wattbezug: int, speicherleistung: int, speichersoc: int) -> None:
+def mainloop(wattbezug: int, speicherleistung: int, speichersoc: int, pvwatt: int = 0) -> None:
     global firststart
     if firststart:
         readmq()
         firststart = False
     mqtt_man = {}
     sendmess = 0
-    uberschuss, uberschussoffset = loadregelvars(wattbezug, speicherleistung, speichersoc)
+    uberschuss, uberschussoffset = loadregelvars(wattbezug, speicherleistung, speichersoc, pvwatt)
     resetmaxeinschaltdauerfunc()
-    getdevicevalues(uberschuss, uberschussoffset)
+    getdevicevalues(uberschuss, uberschussoffset, pvwatt)
     conditions(speichersoc)
     # do the manual stuff
     for i in range(1, (numberOfSupportedDevices+1)):

--- a/packages/smarthome/smartcommon.py
+++ b/packages/smarthome/smartcommon.py
@@ -390,7 +390,7 @@ def resetmaxeinschaltdauerfunc() -> None:
         resetmaxeinschaltdauer = 0
 
 
-def loadregelvars(wattbezug: int, speicherleistung: int, speichersoc: int,pvwatt: int) -> Tuple[int, int]:
+def loadregelvars(wattbezug: int, speicherleistung: int, speichersoc: int, pvwatt: int) -> Tuple[int, int]:
     global maxspeicher
     global mydevices
     uberschuss = wattbezug + speicherleistung


### PR DESCRIPTION
Neu wird IDM die aktuelle PV Leistung (Register 78) zusätzlich übergeben, Die PV Leistung ist für Smarthome nicht steuernd. Der idm treiber wurde vereinfacht. der Branch kann auch für openwb 2.0 übernommen werden, in mainloop wird die PV Leistung mit 0 vorbelegt. Die nötige Änderung in openwb 2.0 kommt dann noch.

https://openwb.de/forum/viewtopic.php?p=88834#p88834