### PR TITLE
idm ....

### DIFF
--- a/packages/modules/smarthome/idm/watt.py
+++ b/packages/modules/smarthome/idm/watt.py
@@ -116,7 +116,7 @@ if count5 == 0:
     client.write_registers(78, pvwnew, unit=1)
 else:
     if pvmodus == 99:
-        pvmodus = 0    
+        pvmodus = 0
 answer = '{"power":' + str(aktpower) + ',"powerc":0'
 answer += ',"send":' + str(modbuswrite) + ',"sendpower":' + str(neupower)
 answer += ',"on":' + str(pvmodus) + '}'

--- a/packages/modules/smarthome/idm/watt.py
+++ b/packages/modules/smarthome/idm/watt.py
@@ -37,12 +37,28 @@ if count5 > 6:
     count5 = 0
 with open(file_stringcount5, 'w') as f:
     f.write(str(count5))
+# aktuelle Leistung lesen
+client = ModbusTcpClient(ipadr, port=502)
+#  test
+#  start = 3501
+#  navvers = "2"
+#  prod
+start = 4122
+if navvers == "2":
+    rr = client.read_input_registers(start, 2, unit=1)
+else:
+    rr = client.read_holding_registers(start, 2, unit=1)
+raw = struct.pack('>HH', rr.getRegister(1), rr.getRegister(0))
+lkw = float(struct.unpack('>f', raw)[0])
+aktpower = int(lkw*1000)
+modbuswrite = 0
+neupower = 0
+# pv modus
+pvmodus = 0
+if os.path.isfile(file_stringpv):
+    with open(file_stringpv, 'r') as f:
+        pvmodus = int(f.read())
 if count5 == 0:
-    # pv modus
-    pvmodus = 0
-    if os.path.isfile(file_stringpv):
-        with open(file_stringpv, 'r') as f:
-            pvmodus = int(f.read())
     # log counter
     count1 = 999
     if os.path.isfile(file_stringcount):
@@ -53,22 +69,7 @@ if count5 == 0:
         count1 = 0
     with open(file_stringcount, 'w') as f:
         f.write(str(count1))
-    # aktuelle Leistung lesen
-    client = ModbusTcpClient(ipadr, port=502)
-    #  test
-    #  start = 3501
-    #  navvers = "2"
-    #  prod
-    start = 4122
-    if navvers == "2":
-        rr = client.read_input_registers(start, 2, unit=1)
-    else:
-        rr = client.read_holding_registers(start, 2, unit=1)
-    raw = struct.pack('>HH', rr.getRegister(1), rr.getRegister(0))
-    lkw = float(struct.unpack('>f', raw)[0])
-    aktpower = int(lkw*1000)
     # logik nur schicken bei pvmodus
-    modbuswrite = 0
     if pvmodus == 1:
         modbuswrite = 1
     # Nur positiven Uberschuss schicken, nicht aktuelle Leistung
@@ -101,10 +102,6 @@ if count5 == 0:
     pvwnew = builder.to_registers()
     # json return power = aktuelle Leistungsaufnahme in Watt,
     # on = 1 pvmodus, powerc = counter in kwh
-    answer = '{"power":' + str(aktpower) + ',"powerc":0'
-    answer += ',"send":' + str(modbuswrite) + ',"sendpower":' + str(neupower)
-    answer += ',"on":' + str(pvmodus) + '}'
-    writeret(answer, devicenumber)
     if count1 < 3:
         log.info(" %d ipadr %s ueberschuss %6d Akt Leistung %6d Pv %6d"
                  % (devicenumber, ipadr, uberschuss, aktpower, pvwatt))
@@ -113,7 +110,14 @@ if count5 == 0:
     # modbus write
     if modbuswrite == 1:
         client.write_registers(74, regnew, unit=1)
-        client.write_registers(78, pvwnew, unit=1)
         if count1 < 3:
             log.info("devicenr %d ipadr %s device written by modbus " %
                      (devicenumber, ipadr))
+    client.write_registers(78, pvwnew, unit=1)
+else:
+    if pvmodus == 99:
+        pvmodus = 0    
+answer = '{"power":' + str(aktpower) + ',"powerc":0'
+answer += ',"send":' + str(modbuswrite) + ',"sendpower":' + str(neupower)
+answer += ',"on":' + str(pvmodus) + '}'
+writeret(answer, devicenumber)


### PR DESCRIPTION
Aktuelle Leistung wird nun bei jedem Durchlauf gelesen und an openwb übergeben. Pv Leistung wird nun immer geschrieben (egal ob Gerät on oder off ist). Variablen zentral initialisiert