### PR TITLE
abb b23

### DIFF
--- a/packages/smarthome/smartbase.py
+++ b/packages/smarthome/smartbase.py
@@ -5,7 +5,7 @@ from typing import Dict, Tuple, Any
 from smarthome.smartbase0 import Sbase0
 from smarthome.smartmeas import Slsdm630, Sllovato, Slsdm120, Slwe514, Slfronius
 from smarthome.smartmeas import Sljson, Slsmaem, Slshelly, Sltasmota, Slmqtt
-from smarthome.smartmeas import Slhttp, Slavm, Slmystrom
+from smarthome.smartmeas import Slhttp, Slavm, Slmystrom, Slb23
 from smarthome.smartbut import Sbshelly
 from datetime import datetime, timezone
 import logging
@@ -458,6 +458,8 @@ class Sbase(Sbase0):
                     self._mydevicemeasure = Slsdm630()
                 elif (self._device_measuretype == 'lovato'):
                     self._mydevicemeasure = Sllovato()
+                elif (self._device_measuretype == 'b23'):
+                    self._mydevicemeasure = Slb23()
                 elif (self._device_measuretype == 'sdm120'):
                     self._mydevicemeasure = Slsdm120()
                 elif (self._device_measuretype == 'we514'):

--- a/packages/smarthome/smartmeas.py
+++ b/packages/smarthome/smartmeas.py
@@ -1,7 +1,7 @@
 from smarthome.smartbase0 import Sbase0
 from typing import Dict, Tuple
 from modules.common import modbus
-from modules.common import sdm
+from modules.common import sdm, b23
 from modules.common import lovato
 import logging
 log = logging.getLogger(__name__)
@@ -457,6 +457,27 @@ class Sllovato(Slbase):
         except Exception as e1:
             log.warning("Leistungsmessung %s %d %s Fehlermeldung: %s "
                         % ('Lovato ', self.device_nummer,
+                           str(self._device_measureip), str(e1)))
+        return self.newwatt, self.newwattk
+
+
+class Slb23(Slbase):
+    def __init__(self) -> None:
+        # setting
+        super().__init__()
+
+    def sepwattread(self) -> Tuple[int, int]:
+        try:
+            # neu aus openwb 2.0
+            with modbus.ModbusTcpClient_(self._device_measureip, self._device_measureportsdm) as tcp_client:
+                b23inst = b23.B23(self._device_measureid, tcp_client)
+                # log.warning(" b23inst id %s " % ( str(id(b23inst))))
+                _, newwatt = b23inst.get_power()
+                self.newwatt = int(newwatt)
+                self.newwattk = int(b23inst.get_imported())
+        except Exception as e1:
+            log.warning("Leistungsmessung %s %d %s Fehlermeldung: %s "
+                        % ('b23 ', self.device_nummer,
                            str(self._device_measureip), str(e1)))
         return self.newwatt, self.newwattk
 

--- a/runs/mqttsub.py
+++ b/runs/mqttsub.py
@@ -156,7 +156,7 @@ def create_smart_home_device_config_handler() -> TopicHandler:
                                     "stiebel", "http", "avm", "mystrom", "viessmann", "mqtt", "NXDACXX", "ratiotherm"
                                     )),
         "device_measureType": create_topic_handler(
-            equals_one_of_validator("shelly", "tasmota", "http", "mystrom", "sdm630", "lovato", "we514", "fronius",
+            equals_one_of_validator("shelly", "tasmota", "http", "mystrom", "sdm630", "lovato", "we514", "fronius", "b23", 
                                     "json", "avm", "mqtt", "sdm120", "smaem")),
         "device_temperatur_configured": create_topic_handler(int_range_validator(0, 3)),
         "device_einschaltschwelle": create_topic_handler(int_range_validator(-100000, 100000)),

--- a/web/settings/smarthomeconfig.php
+++ b/web/settings/smarthomeconfig.php
@@ -850,6 +850,7 @@ $numDevices = 9;
 											<option value="json" data-option="json">Json</option>
 											<option value="mystrom" data-option="mystrom">MyStrom</option>
 											<option value="sdm630" data-option="sdm630">SDM630</option>
+											<option value="b23" data-option="b23">b23</option>											
 											<option value="shelly" data-option="shelly">Shelly oder Shelly plus</option>
 											<option value="tasmota" data-option="tasmota">tasmota</option>
 											<option value="we514" data-option="we514">WE514</option>
@@ -861,7 +862,7 @@ $numDevices = 9;
 										</select>
 									</div>
 								</div>
-								<div class="form-row mb-1 deviceMeasureTypeDevices<?php echo $devicenum; ?>-option deviceMeasureTypeDevices<?php echo $devicenum; ?>-option-shelly deviceMeasureTypeDevices<?php echo $devicenum; ?>-option-tasmota deviceMeasureTypeDevices<?php echo $devicenum; ?>-option-sdm630 deviceMeasureTypeDevices<?php echo $devicenum; ?>-option-lovato deviceMeasureTypeDevices<?php echo $devicenum; ?>-option-sdm120 deviceMeasureTypeDevices<?php echo $devicenum; ?>-option-we514 deviceMeasureTypeDevices<?php echo $devicenum; ?>-option-mystrom deviceMeasureTypeDevices<?php echo $devicenum; ?>-option-fronius deviceMeasureTypeDevices<?php echo $devicenum; ?>-option-avm hide">
+								<div class="form-row mb-1 deviceMeasureTypeDevices<?php echo $devicenum; ?>-option deviceMeasureTypeDevices<?php echo $devicenum; ?>-option-shelly deviceMeasureTypeDevices<?php echo $devicenum; ?>-option-tasmota deviceMeasureTypeDevices<?php echo $devicenum; ?>-option-sdm630 deviceMeasureTypeDevices<?php echo $devicenum; ?>-option-b23 deviceMeasureTypeDevices<?php echo $devicenum; ?>-option-lovato deviceMeasureTypeDevices<?php echo $devicenum; ?>-option-sdm120 deviceMeasureTypeDevices<?php echo $devicenum; ?>-option-we514 deviceMeasureTypeDevices<?php echo $devicenum; ?>-option-mystrom deviceMeasureTypeDevices<?php echo $devicenum; ?>-option-fronius deviceMeasureTypeDevices<?php echo $devicenum; ?>-option-avm hide">
 									<label for="device_measureipDevices<?php echo $devicenum; ?>" class="col-md-4 col-form-label">IP Adresse</label>
 									<div class="col">
 										<input id="device_measureipDevices<?php echo $devicenum; ?>" name="device_measureip" class="form-control" type="text" required="required" pattern="^((\d{1,2}|1\d\d|2[0-4]\d|25[0-5])\.){3}(\d{1,2}|1\d\d|2[0-4]\d|25[0-5])$" data-default="192.168.1.1" value="192.168.1.1" inputmode="text"  data-topicprefix="openWB/config/get/SmartHome/" data-topicsubgroup="Devices/<?php echo $devicenum; ?>/">
@@ -915,13 +916,13 @@ $numDevices = 9;
 										</select>
 									</div>
 								</div>
-								<div class="form-row mb-1 deviceMeasureTypeDevices<?php echo $devicenum; ?>-option deviceMeasureTypeDevices<?php echo $devicenum; ?>-option-sdm630 hide; ?>-option deviceMeasureTypeDevices<?php echo $devicenum; ?>-option-lovato hide; ?>-option deviceMeasureTypeDevices<?php echo $devicenum; ?>-option-sdm120 hide; ?>-option deviceMeasureTypeDevices<?php echo $devicenum; ?>-option-we514 deviceMeasureTypeDevices<?php echo $devicenum; ?>-option-fronius hide">
+								<div class="form-row mb-1 deviceMeasureTypeDevices<?php echo $devicenum; ?>-option deviceMeasureTypeDevices<?php echo $devicenum; ?>-option-sdm630 deviceMeasureTypeDevices<?php echo $devicenum; ?>-option-b23 deviceMeasureTypeDevices<?php echo $devicenum; ?>-option-lovato deviceMeasureTypeDevices<?php echo $devicenum; ?>-option-sdm120 deviceMeasureTypeDevices<?php echo $devicenum; ?>-option-we514 deviceMeasureTypeDevices<?php echo $devicenum; ?>-option-fronius hide">
 									<label for="device_measureidDevices<?php echo $devicenum; ?>" class="col-md-4 col-form-label">ID des Zählers</label>
 									<div class="col">
 										<input id="device_measureidDevices<?php echo $devicenum; ?>" name="device_measureid" class="form-control naturalNumber" type="number" inputmode="decimal" required min="1" max="255" data-default="1" value="1"  data-topicprefix="openWB/config/get/SmartHome/" data-topicsubgroup="Devices/<?php echo $devicenum; ?>/">
 									</div>
 								</div>
-								<div class="form-row mb-1 deviceMeasureTypeDevices<?php echo $devicenum; ?>-option deviceMeasureTypeDevices<?php echo $devicenum; ?>-option-sdm120 deviceMeasureTypeDevices<?php echo $devicenum; ?>-option-lovato deviceMeasureTypeDevices<?php echo $devicenum; ?>-option-sdm630 hide">
+								<div class="form-row mb-1 deviceMeasureTypeDevices<?php echo $devicenum; ?>-option deviceMeasureTypeDevices<?php echo $devicenum; ?>-option-sdm120 deviceMeasureTypeDevices<?php echo $devicenum; ?>-option-lovato deviceMeasureTypeDevices<?php echo $devicenum; ?>-option-b23 deviceMeasureTypeDevices<?php echo $devicenum; ?>-option-sdm630 hide">
 									<label for="device_measurePortSdmDevices<?php echo $devicenum; ?>" class="col-md-4 col-form-label">Modbusport des Zählers</label>
 									<div class="col">
 										<input id="device_measurePortSdmDevices<?php echo $devicenum; ?>" name="device_measurePortSdm" class="form-control naturalNumber" type="number" inputmode="decimal" required min="1" max="9999" data-default="8899" value="8899"  data-topicprefix="openWB/config/get/SmartHome/" data-topicsubgroup="Devices/<?php echo $devicenum; ?>/">
@@ -929,6 +930,7 @@ $numDevices = 9;
 											Standardeinstellungen verschiedener Geräte:<br>
 											SDM630/Lovato: 8899<br>
 											Elgris: 502
+											b23: ???
 										</span>
 									</div>
 								</div>


### PR DESCRIPTION
Der ABB B23 Zähler wird nun auch als separate Leistungsmesser unterstützt. Allerdings nur über Lan. Dieser PR ist für 1.9 und 2.0. Das Gui für 2.0 kommt noch separat.