### PR TITLE
Smarthome....

### DIFF
--- a/packages/modules/smarthome/nxdacxx/watt.py
+++ b/packages/modules/smarthome/nxdacxx/watt.py
@@ -93,7 +93,7 @@ if count5 == 0:
             #  ausgabe nicht kleiner 0,9V sonst Leistungsregelung der WP aus
             rq = client.write_register(0, volt, unit=1)
         elif dactyp == 3:
-            ausgabe = int((neupower * 4095) / maxpower)
+            ausgabe = int(((neupower * (4095-820)) / maxpower)+820)
             if ausgabe < 820:
                 ausgabe = 0
             #  ausgabe nicht kleiner 4ma sonst Leistungsregelung der WP aus

--- a/packages/modules/smarthome/nxdacxx/watt.py
+++ b/packages/modules/smarthome/nxdacxx/watt.py
@@ -92,6 +92,12 @@ if count5 == 0:
                 volt = 370
             #  ausgabe nicht kleiner 0,9V sonst Leistungsregelung der WP aus
             rq = client.write_register(0, volt, unit=1)
+        elif dactyp == 3:
+            ausgabe = int((neupower * 4095) / maxpower)
+            if ausgabe < 820:
+                ausgabe = 0
+            #  ausgabe nicht kleiner 4ma sonst Leistungsregelung der WP aus
+            rq = client.write_register(0x01f4, ausgabe, unit=1)
         else:
             pass
         if count1 < 3:

--- a/packages/modules/smarthome/shelly/watt.py
+++ b/packages/modules/smarthome/shelly/watt.py
@@ -120,6 +120,8 @@ try:
                 aktpower = int(answer['em:0']['c_act_power'])
             else:
                 aktpower = int(answer['em:0']['total_act_power'])
+        elif ("SNPM-001PCEU16" in model):
+            aktpower = int(answer['pm1:0']['apower'])
         else:
             aktpower = int(answer[sw]['apower'])
 except Exception:

--- a/packages/smarthome/smartbase.py
+++ b/packages/smarthome/smartbase.py
@@ -209,9 +209,12 @@ class Sbase(Sbase0):
                                                    str(self.device_nummer),
                                                    "device" + str(self.device_nummer) + "_wh",
                                                    "device" + str(self.device_nummer) + "_whe",
-                                                   str(self.device_nummer), 0)
+                                                   str(self.device_nummer), self.newwattk)
+                    #                              str(self.device_nummer), 0)
+                    # um Simulation zweiter Zaehler zu aktivieren
+                    #
                 else:
-                    # uebernehmen grechneten Zaehlerstand für alle anderen devices (z.b. shelly)
+                    # uebernehmen gerechneten Zaehlerstand für alle anderen devices (z.b. shelly)
                     self.newwattk = self.simcount(self._oldwatt, "smarthome_device_" +
                                                   str(self.device_nummer),
                                                   "device" + str(self.device_nummer) + "_wh",

--- a/packages/smarthome/smartbase.py
+++ b/packages/smarthome/smartbase.py
@@ -44,6 +44,7 @@ class Sbase(Sbase0):
         self.temp2 = '300'
         self.newwatt = 0
         self.newwattk = 0
+        self.newwattks = 0
         self.pvwatt = 0
         self.relais = 0
         self.devuberschuss = 0
@@ -202,20 +203,50 @@ class Sbase(Sbase0):
             with open(self._basePath+'/ramdisk/smarthome_device_' +
                       str(self.device_nummer) + 'watt0pos', 'r') as value:
                 importtemp = int(value.read())
-                self.simcount(self._oldwatt, "smarthome_device_" +
-                              str(self.device_nummer),
-                              "device" + str(self.device_nummer) + "_wh",
-                              "device" + str(self.device_nummer) + "_whe",
-                              str(self.device_nummer), self.newwattk)
-        except Exception:
-            importtemp = self._whimported_tmp
+                if (self.newwattk > 0):
+                    # Shadow calculation for devices mit gelierten Zaehler (z.b. sdm630)
+                    self.newwattks = self.simcount(self._oldwatt, "smarthome_device_" +
+                                                   str(self.device_nummer),
+                                                   "device" + str(self.device_nummer) + "_wh",
+                                                   "device" + str(self.device_nummer) + "_whe",
+                                                   str(self.device_nummer), 0)
+                else:
+                    # uebernehmen grechneten Zaehlerstand für alle anderen devices (z.b. shelly)
+                    self.newwattk = self.simcount(self._oldwatt, "smarthome_device_" +
+                                                  str(self.device_nummer),
+                                                  "device" + str(self.device_nummer) + "_wh",
+                                                  "device" + str(self.device_nummer) + "_whe",
+                                                  str(self.device_nummer), 0)
 
+        except Exception:
+            # first run simcount also update
+            # add start point for shadow
+            importtemp = self._whimported_tmp
             with open(self._basePath+'/ramdisk/smarthome_device_' +
                       str(self.device_nummer) + 'watt0pos', 'w') as f:
                 f.write(str(importtemp))
             with open(self._basePath+'/ramdisk/smarthome_device_' +
                       str(self.device_nummer) + 'watt0neg', 'w') as f:
                 f.write(str("0"))
+            if (self.newwattk > 0):
+                log.info("(" + str(self.device_nummer) +
+                         ") Simcount Startwert aus Z1 (HW) übernommen " +
+                         str(self.newwattk) + " kwh " + str(self.newwattk * 3600) + " wh")
+                self.newwattks = self.simcount(self._oldwatt,
+                                               "smarthome_device_" +
+                                               str(self.device_nummer),
+                                               "device" + str(self.device_nummer) + "_wh",
+                                               "device" + str(self.device_nummer) + "_whe",
+                                               str(self.device_nummer), self.newwattk)
+            else:
+                log.info("(" + str(self.device_nummer) +
+                         ") Simcount Startwert aus mqtt übernommen " +
+                         str(self._whimported_tmp) + " wh")
+                self.newwattk = int(self.simcount(self._oldwatt, "smarthome_device_" +
+                                                  str(self.device_nummer),
+                                                  "device" + str(self.device_nummer) + "_wh",
+                                                  "device" + str(self.device_nummer) + "_whe",
+                                                  str(self.device_nummer), 0))
         if (self.relais == 1):
             newtime = int(time.time())
             if (self.c_oldstampeinschaltdauer_f == 'Y'):
@@ -1129,7 +1160,14 @@ class Sbase(Sbase0):
                 self._c_einverz_f = 'N'
                 self._c_ausverz_f = 'N'
 
-    def simcount(self, watt2: int, pref: str, importfn: str, exportfn: str, nummer: str, wattks: int) -> None:
+    def simcount(self, watt2: int, pref: str, importfn: str, exportfn: str, nummer: str, wattks: int) -> int:
+        # if (nummer == "1"):
+        #    debug = True
+        # else:
+        #   debug = False
+        seconds2 = time.time()
+        watt1 = 0
+        seconds1 = 0.0
         # Zaehler mitgeliefert in WH , zurueckrechnen fuer simcount
         if wattks > 0:
             wattposkh = wattks
@@ -1141,16 +1179,19 @@ class Sbase(Sbase0):
             self._wpos = wattposh
             with open(self._basePath+'/ramdisk/'+pref+'watt0neg', 'w') as f:
                 f.write(str(wattnegh))
-            self._wh = round(wattposkh, 2)
             with open(self._basePath+'/ramdisk/' + importfn, 'w') as f:
                 f.write(str(round(wattposkh, 2)))
             with open(self._basePath+'/ramdisk/' + exportfn, 'w') as f:
                 f.write(str(wattnegkh))
-            return
+            # start punkt für simulation schreiben
+            value1 = "%22.6f" % seconds2
+            with open(self._basePath+'/ramdisk/'+pref+'sec0', 'w') as f:
+                f.write(str(value1))
+            with open(self._basePath+'/ramdisk/'+pref+'wh0', 'w') as f:
+                f.write(str(watt2))
+            self._wh = round(wattposkh, 2)
+            return self._wh
         # emulate import  export
-        seconds2 = time.time()
-        watt1 = 0
-        seconds1 = 0.0
         if os.path.isfile(self._basePath+'/ramdisk/'+pref+'sec0'):
             with open(self._basePath+'/ramdisk/'+pref+'sec0', 'r') as f:
                 seconds1 = float(f.read())
@@ -1160,42 +1201,49 @@ class Sbase(Sbase0):
                 wattposh = int(f.read())
             with open(self._basePath+'/ramdisk/'+pref+'watt0neg', 'r') as f:
                 wattnegh = int(f.read())
-            value1 = "%22.6f" % seconds2
-            with open(self._basePath+'/ramdisk/'+pref+'sec0', 'w') as f:
-                f.write(str(value1))
             with open(self._basePath+'/ramdisk/'+pref+'wh0', 'w') as f:
                 f.write(str(watt2))
             seconds1 = seconds1 + 1
             deltasec = seconds2 - seconds1
-            deltasectrun = int(deltasec * 1000) / 1000
-            stepsize = int((watt2-watt1)/deltasec)
-            while seconds1 <= seconds2:
+            stepsize = int((watt2-watt1)/(deltasec + 1))
+            # if debug:
+            #    log.info("(" + str(nummer) +
+            #             ")D star wh " + str(wattposh) +
+            #              " kwh " + str(int(wattposh/3600)) +
+            #              " seconds1 " + str(seconds1) +
+            #              " watt1 " + str(watt1) +
+            #              " seconds2 " + str(seconds2) +
+            #              " deltasec " + str(deltasec) +
+            #              " stepsize " + str(stepsize) +
+            #              " watt2 " + str(watt2))
+            while seconds1 < seconds2:
                 if watt1 < 0:
                     wattnegh = wattnegh + watt1
                 else:
                     wattposh = wattposh + watt1
+                # if debug:
+                #     log.info("(" + str(nummer) +
+                #              ")D calc wh " + str(wattposh) +
+                #              " kwh " + str(int(wattposh/3600)) +
+                #              " seconds1 " + str(seconds1) +
+                #              " watt1 " + str(watt1))
                 watt1 = watt1 + stepsize
-                if stepsize < 0:
+                if stepsize <= 0:
                     watt1 = max(watt1, watt2)
                 else:
                     watt1 = min(watt1, watt2)
                 seconds1 = seconds1 + 1
-            rest = deltasec - deltasectrun
-            seconds1 = seconds1 - 1 + rest
-            if rest > 0:
-                watt1 = int(watt1 * rest)
-                if watt1 < 0:
-                    wattnegh = wattnegh + watt1
-                else:
-                    wattposh = wattposh + watt1
-            wattposkh = int(wattposh/3600)
+            seconds1 = seconds1 - 1
+            value1 = "%22.6f" % seconds1
+            with open(self._basePath+'/ramdisk/'+pref+'sec0', 'w') as f:
+                f.write(str(value1))
             wattnegkh = int((wattnegh*-1)/3600)
             with open(self._basePath+'/ramdisk/'+pref+'watt0pos', 'w') as f:
                 f.write(str(wattposh))
             self._wpos = wattposh
             with open(self._basePath+'/ramdisk/'+pref+'watt0neg', 'w') as f:
                 f.write(str(wattnegh))
-            self._wh = round(wattposkh, 2)
+            wattposkh = int(wattposh/3600)
             with open(self._basePath+'/ramdisk/' + importfn, 'w') as f:
                 f.write(str(round(wattposkh, 2)))
             with open(self._basePath+'/ramdisk/' + exportfn, 'w') as f:
@@ -1206,6 +1254,11 @@ class Sbase(Sbase0):
                 f.write(str(value1))
             with open(self._basePath+'/ramdisk/'+pref+'wh0', 'w') as f:
                 f.write(str(watt2))
+            with open(self._basePath+'/ramdisk/'+pref+'watt0pos', 'r') as f:
+                wattposh = int(f.read())
+            wattposkh = int(wattposh/3600)
+        self._wh = round(wattposkh, 2)
+        return self._wh
 
     def getwatt(self, uberschuss: int, uberschussoffset: int) -> None:
         self.prewatt(uberschuss, uberschussoffset)

--- a/packages/smarthome/smartcommon.py
+++ b/packages/smarthome/smartcommon.py
@@ -126,6 +126,7 @@ def getdevicevalues(uberschuss: int, uberschussoffset: int, pvwatt: int, charges
         mydevice.getwatt(uberschuss, uberschussoffset)
         watt = mydevice.newwatt
         wattk = mydevice.newwattk
+        wattks = mydevice.newwattks
         relais = mydevice.relais
         # temp0 = mydevice.temp0
         # temp1 = mydevice.temp1
@@ -144,7 +145,7 @@ def getdevicevalues(uberschuss: int, uberschussoffset: int, pvwatt: int, charges
                  str(mydevice.runningtime) + " Status/Üeb: " +
                  str(mydevice.devstatus) + "/" +
                  str(mydevice.ueberschussberechnung) + " akt: " + str(watt) +
-                 " Z: " + str(wattk))
+                 " Z1: " + str(wattk) + " Z2: " + str(wattks))
         #  mqtt_all.update(mydevice.mqtt_param)
         for keyread, value in mydevice.mqtt_param.items():
             key = mqttsdevstat + keyread

--- a/runs/mqttsub.py
+++ b/runs/mqttsub.py
@@ -144,7 +144,7 @@ def create_smart_home_device_config_handler() -> TopicHandler:
         "device_shauth": create_topic_handler(int_range_validator(0, 1)),
         "device_measureshauth": create_topic_handler(int_range_validator(0, 1)),
         "device_chan": create_topic_handler(int_range_validator(0, 6)),
-        "device_nxdacxxtype": create_topic_handler(int_range_validator(0, 2)),
+        "device_nxdacxxtype": create_topic_handler(int_range_validator(0, 3)),
         "device_measchan": create_topic_handler(int_range_validator(0, 6)),
         "device_ip": create_topic_handler(ip_address_validator),
         "device_pbip": create_topic_handler(ip_address_validator),

--- a/web/settings/smarthomeconfig.php
+++ b/web/settings/smarthomeconfig.php
@@ -731,8 +731,10 @@ $numDevices = 9;
 															<input type="range" class="form-control-range rangeInput" id="device_speichersocbeforestartDevices<?php echo $devicenum; ?>" name="device_speichersocbeforestart" min="0" max="100" step="5" data-default="0" value="0" data-topicprefix="openWB/config/get/SmartHome/" data-topicsubgroup="Devices/<?php echo $devicenum; ?>/">
 														</div>
 													</div>
-													<span class="form-text small">Parameter in % Ladezustand. 0% deaktiviert die Funktion. Bei deaktivierter Funktion oder wenn der Ladezustand grösser gleich dem Parameter ist, wird die Speicherleistung bei der Berechnung der Ein- und Ausschaltschwelle berücksichtigt.<br>
-													Unterhalb dieses Wertes ist für die Berechnung der Ein und Ausschaltschwelle nur die aktuelle Leistung am EVU Punkt und die maximal mögliche Speicherladung (als Offset) relevant.</span>
+													<span class="form-text small">Parameter in % Ladezustand. 0% deaktiviert die Funktion. Bei deaktivierter Funktion oder wenn der Ladezustand grösser gleich dem Parameter ist, wird die Speicherleistung bei der Berechnung der Ein- und Ausschaltschwelle berücksichtigt<br> Uberschuss = evu + speicherleistung, wobei evu - > Bezug(-)/Einspeisung(+) und speicherleistung Entladung(-)/Ladung(+) ist .<br>
+													Unterhalb dieses Wertes ist für die Berechnung der obige Überschuss und die maximal mögliche Speicherladung (als Offset) relevant <br>Uberschussoffset = Uberschuss - maxspeicher<br>
+													Bei überschussgesteuerten Geräten wird dann der Ueberschuss oder der Ueberschuss mit Offset übertragen.
+																								</span>
 												</div>
 											</div>
 										</div>

--- a/web/settings/smarthomeconfig.php
+++ b/web/settings/smarthomeconfig.php
@@ -282,6 +282,7 @@ $numDevices = 9;
 												<option value="0" data-option="0">N4Dac02</option>
 												<option value="1" data-option="1">DA02</option>
 												<option value="2" data-option="2">M120T von Pigeon</option>
+												<option value="3" data-option="3">AA02B</option>												
 											</select>
 											<span class="form-text small">
 												Hier ist das installierte Modell auszuwählen.


### PR DESCRIPTION
Wenn das Smarthome mehrmals schnell hintereinander gestartet wurde, konnten die simulierten Zählerstände ungültig werden. Das Problem ist nun behoben. Die Genauigkeit der berechneten Zähler wurde erhöht.
Texte bezüglich Speicher beachten beim einschalten überarbeitet.
Bei Geräten die einen berechneten Zählerstand haben, wir neu der berechnete Zählerstand im smarthome.log ausgewiesen.
Shelly Plus pm Mini  wird erstmalig unterstützt
Dac AA02B wird erstmalig unterstützt
Kann für 1.9 und 2.0 übernommen werden, Gui für 2.0 wird separat eingeliefert.