### PR TITLE
smarthome temperatur

### DIFF
--- a/packages/smarthome/smartbase.py
+++ b/packages/smarthome/smartbase.py
@@ -272,11 +272,21 @@ class Sbase(Sbase0):
                 self._c_eintime = 0
                 self._c_eintime_f = 'N'
         self._oldrelais = self.relais
-        if (self.device_temperatur_configured > 0):
+        if (self.device_temperatur_configured == 0):
+            self.mqtt_param[pref + 'TemperatureSensor0'] = '300'
+            self.mqtt_param[pref + 'TemperatureSensor1'] = '300'
+            self.mqtt_param[pref + 'TemperatureSensor2'] = '300'
+        elif (self.device_temperatur_configured == 1):
             self.mqtt_param[pref + 'TemperatureSensor0'] = self.temp0
-        if (self.device_temperatur_configured > 1):
+            self.mqtt_param[pref + 'TemperatureSensor1'] = '300'
+            self.mqtt_param[pref + 'TemperatureSensor2'] = '300' 
+        elif (self.device_temperatur_configured == 2):
+            self.mqtt_param[pref + 'TemperatureSensor0'] = self.temp0
             self.mqtt_param[pref + 'TemperatureSensor1'] = self.temp1
-        if (self.device_temperatur_configured > 2):
+            self.mqtt_param[pref + 'TemperatureSensor2'] = '300'
+        else:
+            self.mqtt_param[pref + 'TemperatureSensor0'] = self.temp0
+            self.mqtt_param[pref + 'TemperatureSensor1'] = self.temp1
             self.mqtt_param[pref + 'TemperatureSensor2'] = self.temp2
         self.mqtt_param[pref + 'Watt'] = str(self._oldwatt)
         self.mqtt_param[pref + 'Wh'] = str(self._wh)

--- a/packages/smarthome/smartbase.py
+++ b/packages/smarthome/smartbase.py
@@ -279,7 +279,7 @@ class Sbase(Sbase0):
         elif (self.device_temperatur_configured == 1):
             self.mqtt_param[pref + 'TemperatureSensor0'] = self.temp0
             self.mqtt_param[pref + 'TemperatureSensor1'] = '300'
-            self.mqtt_param[pref + 'TemperatureSensor2'] = '300' 
+            self.mqtt_param[pref + 'TemperatureSensor2'] = '300'
         elif (self.device_temperatur_configured == 2):
             self.mqtt_param[pref + 'TemperatureSensor0'] = self.temp0
             self.mqtt_param[pref + 'TemperatureSensor1'] = self.temp1


### PR DESCRIPTION
Grundsätzlich werden nun beim statusupdate von einem Gerät die nicht definierten temperatur sensoren  (>device_temperatur_configured) initialisiert. Ursprünglich wurde das nur beim deaktivieren und aktivieren von einem Gerät gemacht. Kann für Openwb1.9 und Openwb 2.0 übernommen werden. Damit sollten keine Temperatur anzeigen mehr im Gui hängen bleiben.