### PR TITLE
RCT Power - BAT status check removed because their content is unknown

### DIFF
--- a/packages/modules/devices/rct/bat.py
+++ b/packages/modules/devices/rct/bat.py
@@ -2,7 +2,7 @@
 from dataclass_utils import dataclass_from_dict
 from modules.common.component_state import BatState
 from modules.common.component_type import ComponentDescriptor
-from modules.common.fault_state import ComponentInfo, FaultState
+from modules.common.fault_state import ComponentInfo
 from modules.common.store import get_bat_value_store
 from modules.devices.rct.config import RctBatSetup
 from modules.devices.rct.rct_lib import RCT

--- a/packages/modules/devices/rct/bat.py
+++ b/packages/modules/devices/rct/bat.py
@@ -20,15 +20,9 @@ class RctBat:
         watt1 = rct_client.add_by_name(my_tab, 'g_sync.p_acc_lp')
         watt2 = rct_client.add_by_name(my_tab, 'battery.stored_energy')
         watt3 = rct_client.add_by_name(my_tab, 'battery.used_energy')
-        stat1 = rct_client.add_by_name(my_tab, 'battery.bat_status')
-        stat2 = rct_client.add_by_name(my_tab, 'battery.status')
-        stat3 = rct_client.add_by_name(my_tab, 'battery.status2')
 
         # read all parameters
         rct_client.read(my_tab)
-
-        if (stat1.value + stat2.value + stat3.value) > 0:
-            raise FaultState.error("Alarm Status Speicher ist ungleich 0.")
 
         bat_state = BatState(
             power=watt1.value * -1,

--- a/packages/modules/devices/rct/rct_lib.py
+++ b/packages/modules/devices/rct/rct_lib.py
@@ -65,6 +65,31 @@ class rct_data(Enum):
     t_log_ts = 11
     t_dump = 12
 
+# battery status definitions (same for battery.status and status2)
+# battery.status2: comes from BMS
+# battery.status: comes from Inverter
+class battery_status(Enum):
+    t_bat_status_disconnected = (1 << 0)        # Battery disconnected
+    t_bat_status_relay_test = (1 << 1)
+    t_bat_status_ready = (1 << 2)
+    t_bat_status_calibration = (1 << 3)        # Calibration at high voltage
+    t_bat_status_standby = (1 << 4)            # Battery standby (connected) / bootloader
+    t_bat_status_shut_down = (1 << 5)          # Shut Down
+    t_bat_status_precharge = (1 << 6)          # Precharge
+    t_bat_status_startup = (1 << 7)            # Startup
+    t_bat_status_battery_full = (1 << 8)       # Battery is full
+    t_bat_status_battery_empty = (1 << 9)      # Battery is empty
+    t_bat_status_calibration_empty = (1 << 10) # Calibration at low voltage
+    t_bat_status_balance = (1 << 11)           # Balancing active
+    t_bat_status_error = (1 << 12)             # Error
+    t_bat_status_update = (1 << 13)            # Update running
+
+# battery.bat_status definitions
+class battery_bat_status(Enum):
+    t_bc_result_disconnected = 0                #Battery is disconnected
+    t_bc_result_connecting_no_pump = 1          # Battery in connecting state, but DC-Link should not be pumped
+    t_bc_result_connecting = 2                  # Battery in connecting state and DC-Link should be pumped
+    t_bc_result_connected = 3                   # Battery is connected
 
 class rct_id():
     def __init__(self, msgid, idx, name, data_type=rct_data.t_unknown, desc=''):

--- a/packages/modules/devices/rct/rct_lib.py
+++ b/packages/modules/devices/rct/rct_lib.py
@@ -72,21 +72,21 @@ class battery_status(Enum):
     t_bat_status_disconnected = (1 << 0)        # Battery disconnected
     t_bat_status_relay_test = (1 << 1)
     t_bat_status_ready = (1 << 2)
-    t_bat_status_calibration = (1 << 3)        # Calibration at high voltage
-    t_bat_status_standby = (1 << 4)            # Battery standby (connected) / bootloader
-    t_bat_status_shut_down = (1 << 5)          # Shut Down
-    t_bat_status_precharge = (1 << 6)          # Precharge
-    t_bat_status_startup = (1 << 7)            # Startup
-    t_bat_status_battery_full = (1 << 8)       # Battery is full
-    t_bat_status_battery_empty = (1 << 9)      # Battery is empty
-    t_bat_status_calibration_empty = (1 << 10) # Calibration at low voltage
-    t_bat_status_balance = (1 << 11)           # Balancing active
-    t_bat_status_error = (1 << 12)             # Error
-    t_bat_status_update = (1 << 13)            # Update running
+    t_bat_status_calibration = (1 << 3)         # Calibration at high voltage
+    t_bat_status_standby = (1 << 4)             # Battery standby (connected) / bootloader
+    t_bat_status_shut_down = (1 << 5)           # Shut Down
+    t_bat_status_precharge = (1 << 6)           # Precharge
+    t_bat_status_startup = (1 << 7)             # Startup
+    t_bat_status_battery_full = (1 << 8)        # Battery is full
+    t_bat_status_battery_empty = (1 << 9)       # Battery is empty
+    t_bat_status_calibration_empty = (1 << 10)  # Calibration at low voltage
+    t_bat_status_balance = (1 << 11)            # Balancing active
+    t_bat_status_error = (1 << 12)              # Error
+    t_bat_status_update = (1 << 13)             # Update running
 
 # battery.bat_status definitions
 class battery_bat_status(Enum):
-    t_bc_result_disconnected = 0                #Battery is disconnected
+    t_bc_result_disconnected = 0                # Battery is disconnected
     t_bc_result_connecting_no_pump = 1          # Battery in connecting state, but DC-Link should not be pumped
     t_bc_result_connecting = 2                  # Battery in connecting state and DC-Link should be pumped
     t_bc_result_connected = 3                   # Battery is connected

--- a/packages/modules/devices/rct/rct_lib.py
+++ b/packages/modules/devices/rct/rct_lib.py
@@ -65,6 +65,7 @@ class rct_data(Enum):
     t_log_ts = 11
     t_dump = 12
 
+
 # battery status definitions (same for battery.status and status2)
 # battery.status2: comes from BMS
 # battery.status: comes from Inverter
@@ -84,12 +85,14 @@ class battery_status(Enum):
     t_bat_status_error = (1 << 12)              # Error
     t_bat_status_update = (1 << 13)             # Update running
 
+
 # battery.bat_status definitions
 class battery_bat_status(Enum):
     t_bc_result_disconnected = 0                # Battery is disconnected
     t_bc_result_connecting_no_pump = 1          # Battery in connecting state, but DC-Link should not be pumped
     t_bc_result_connecting = 2                  # Battery in connecting state and DC-Link should be pumped
     t_bc_result_connected = 3                   # Battery is connected
+
 
 class rct_id():
     def __init__(self, msgid, idx, name, data_type=rct_data.t_unknown, desc=''):


### PR DESCRIPTION
I see battery.status2 sporadically set to 2048. The raise instruction then stops using the remaining values.
I'm in contact with RCT but still no answer.
