### PR TITLE
Show PIN pad as default; Unlock screen with RFID (only for Cards & Colors themes)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -19,3 +19,4 @@ modules/soc_vwid/secrets.py
 __pycache__
 openwb.conf.*
 web/backup/*.tar.gz
+sed*

--- a/loadvars.sh
+++ b/loadvars.sh
@@ -1073,6 +1073,7 @@ loadvars(){
 	verb3_w=$(printf "%.0f\n" $verb3_w)
 
 	#hausverbrauch=$((wattbezugint - pvwatt - ladeleistung - speicherleistung - shd1_w - shd2_w - shd3_w - shd4_w - shd5_w - shd6_w - shd7_w - shd8_w - shd9_w - verb1_w - verb2_w - verb3_w))
+	openwbDebugLog "Main" 0 "Hausverbrauch: Wattbezug: $wattbezugint ; PVWatt: $pvwatt ;  Ladeleistung: $ladeleistung ; Speicherleistung: $speicherleistung ; SHDall: $shdall_w ; Verb1: $verb1_w ; Verb2: $verb2_w ; Verb3: $verb3_w"
 	hausverbrauch=$((wattbezugint - pvwatt - ladeleistung - speicherleistung - shdall_w - verb1_w - verb2_w - verb3_w))
 	if ((hausverbrauch < 0)); then
 		if [ -f /var/www/html/openWB/ramdisk/hausverbrauch.invalid ]; then

--- a/modules/soc_http/main.sh
+++ b/modules/soc_http/main.sh
@@ -64,7 +64,7 @@ getAndWriteSoc(){
 	re='^-?[0-9]+$'
 	openwbDebugLog ${DMOD} 1 "Lp$CHARGEPOINT: Requesting SoC"
 	echo 0 > "$soctimerfile"
-	soc=$(curl --connect-timeout 15 -s "$ip" | cut -f1 -d".")
+	soc=$(curl --connect-timeout 15 -s -g "$ip" | cut -f1 -d".")
 		
 	if  [[ $soc =~ $re ]] ; then
 		if (( soc != 0 )) ; then

--- a/openwb.conf
+++ b/openwb.conf
@@ -270,3 +270,4 @@ soc_aiwayslp2_user=''
 soc_aiwayslp2_pass=''
 soc_aiwayslp2_vin=''
 soc_aiwayslp2_intervall=''
+unlockscreenrfid=0

--- a/web/display/cards/index.html
+++ b/web/display/cards/index.html
@@ -42,9 +42,14 @@
 		</div>
 
 		<!-- Dashboard -->
+		<input type="hidden" value="" id="rfidwebread" />
 		<div id="dashboard" class="dashboard resume">
 			<div class="row">
 				<!-- EVU data -->
+<!--				<div class=" col-xs-6 card evu">
+					<textarea style="width: 450px; height:150px;color: black" id="rifdarea"></textarea>
+
+				</div>-->
 				<div class=" col-xs-6 card evu">
 					<div class="card-header bg-danger">
 						<div class="row">
@@ -2417,7 +2422,27 @@
 						}
 					}, 2000);
 				});
-
+				//
+				var queryString = window.location.search;
+				var urlParams = new URLSearchParams(queryString);
+				var ids = urlParams.get('rfidlist')
+				rfidArray = ids.split(",").filter(n => parseInt(n) > 0);
+				
+				$(document).keydown(function (e) {
+					if (e.keyCode >= 48 && e.keyCode <= 57 && $('#rfidwebread').val().length < 10) {
+						var old = $('#rfidwebread').val();
+						$('#rfidwebread').val(old+String.fromCharCode(e.keyCode));
+					} else if (event.keyCode == 13 || $('#rfidwebread').val().length == 10) {
+    					var rfid = $('#rfidwebread').val();
+						$('#rfidwebread').val('');
+						if (rfidArray.includes(rfid)) {
+							lockDisplay(false);
+						} 						
+    				}	
+					window.setTimeout(function() {
+						$('#rfidwebread').val('')
+					}, 3000);				
+				});
 			});
 		</script>
 	</body>

--- a/web/display/cards/index.html
+++ b/web/display/cards/index.html
@@ -853,7 +853,7 @@
 				});
 
 				$('#backend .reloadBtn').click(function() {
-					location.reload();
+					window.location = window.location.pathname;
 				});
 			</script>
 		</div>

--- a/web/display/cards/index.html
+++ b/web/display/cards/index.html
@@ -652,7 +652,7 @@
 						$('#ladepunktConfigModal').find('[data-config-lp="'+currentLp+'"]').removeClass('hide');
 						$('#ladepunktConfigModal').modal("show");
 					} else {
-						$("#lockInfoModal").modal("show");
+						triggerUnlockDisplay();
 					}
 				});
 
@@ -660,7 +660,7 @@
 					if( displaylocked == false ){
 						$("#chargeModeModal").modal("show");
 					} else {
-						$("#lockInfoModal").modal("show");
+						triggerUnlockDisplay();
 					}
 				});
 
@@ -677,7 +677,7 @@
 							}
 						}
 					} else {
-						$("#lockInfoModal").modal("show");
+						triggerUnlockDisplay();
 					}
 				});
 
@@ -688,7 +688,7 @@
 							$('#socModal').find('.socLp').text(currentLp);
 							$('#socModal').modal("show");
 						} else {
-							$("#lockInfoModal").modal("show");
+							triggerUnlockDisplay();
 						}
 					}
 				});
@@ -1933,6 +1933,9 @@
 				function addLockNumber(e){
 					var v = $( "#Lockbox" ).val();
 					$( "#Lockbox" ).val( v + e.value );
+					if ($( "#Lockbox" ).val().length  == 4) {
+						submitLockForm(PINbox);
+					}
 				}
 
 				function clearLockForm(e){
@@ -2225,6 +2228,14 @@
 			var lockTimeout = 60000;
 			var displaylocked = true;
 
+			function triggerUnlockDisplay() {
+				if( displaylocked == true ){
+					$("#lockModal").modal("show");
+				} else {
+					lockDisplay(true);
+				}
+			}
+
 			function lockDisplay( lock = true ){
 				if( lock == false ){
 					displaylocked = false;
@@ -2326,7 +2337,7 @@
 
 				$('.sidenav').find('a[href^="#"]').on("click", function(event) {
 					if( $(this).hasClass('displayLock') && displaylocked == true ) {
-						$("#lockInfoModal").modal("show");
+						triggerUnlockDisplay();
 					} else {
 						// hide all panels
 						$('.resume').addClass('hide');
@@ -2362,13 +2373,7 @@
 					}
 				);
 
-				$('#displaylock').on("click", function(){
-					if( displaylocked == true ){
-						$("#lockModal").modal("show");
-					} else {
-						lockDisplay(true);
-					}
-				});
+				$('#displaylock').on("click", triggerUnlockDisplay);
 
 				$('.btn-group-toggle').change(function(event){
 					// only charge limitation has class btn-group-toggle so far

--- a/web/display/cards/index.html
+++ b/web/display/cards/index.html
@@ -19,6 +19,7 @@
 	</head>
 
 	<body>
+		<input type="hidden" value="" id="rfidwebread" />
 		<!-- Side navigation -->
 		<div class="sidenav pt-3">
 			<!-- date and lock status -->
@@ -42,14 +43,9 @@
 		</div>
 
 		<!-- Dashboard -->
-		<input type="hidden" value="" id="rfidwebread" />
 		<div id="dashboard" class="dashboard resume">
 			<div class="row">
 				<!-- EVU data -->
-<!--				<div class=" col-xs-6 card evu">
-					<textarea style="width: 450px; height:150px;color: black" id="rifdarea"></textarea>
-
-				</div>-->
 				<div class=" col-xs-6 card evu">
 					<div class="card-header bg-danger">
 						<div class="row">

--- a/web/display/cards/index.html
+++ b/web/display/cards/index.html
@@ -2229,7 +2229,7 @@
 			var displaylocked = true;
 
 			function triggerUnlockDisplay() {
-				if( displaylocked == true ){
+				if(displaylocked == true){
 					$("#lockModal").modal("show");
 				} else {
 					lockDisplay(true);

--- a/web/display/cards/index.html
+++ b/web/display/cards/index.html
@@ -1955,7 +1955,7 @@
 									$('#Lockcode').find('.enter').prop('disabled', false);
 									$( "#Lockbox" ).val( "" );
 									$("#lockModal").modal("hide");
-								}, 1000);
+								}, 300);
 							} else {
 								$('#lockModal').find('.modal-body').addClass('bg-danger');
 								$('#Lockcode').find('.enter').prop('disabled', true);

--- a/web/display/colors/chargePointList.js
+++ b/web/display/colors/chargePointList.js
@@ -27,18 +27,19 @@ class ChargePointList {
 		const chargePoint = this.cplist
 			.selectAll("rows")
 			.data(this.chargepoints).enter()
-			.append("div").attr("class", "container-fluid mt-3 p-0")
-			;
+			.append("div").attr("class", "container-fluid mt-3 p-0");
 		chargePoint.html((row, index) => `
-			<div class="row m-0 p-0" onclick="modeButtonClicked(${row.isEnabled},${index})">
-		${this.cpNameRow(row, index)}
-		</div>
-		<div class = "row m-0 p-0" onclick="modeButtonClicked(${row.isEnabled},${index})">
-		${this.cpChargeInfoRow(row, index)}
-		</div>
-		<div class = "row m-0 p-0">
-		${this.cpChargeModeRow(row, index)}
-		</div>`
+			
+			<div class="row m-0 p-0" onclick="modeButtonClicked(${index})">
+			${this.cpNameRow(row, index)}
+			</div>
+			<div class = "row m-0 p-0" onclick="modeButtonClicked(${index})">
+			${this.cpChargeInfoRow(row, index)}
+			</div>
+			<div class = "row m-0 p-0">
+			${this.cpChargeModeRow(row, index)}
+			</div>`
+
 		)
 		this.updateValues();
 	}
@@ -212,7 +213,7 @@ function configButtonClicked(index) {
 		// $('#ladepunktConfigModal').find('[data-config-lp="' + (index + 1) + '"]').removeClass('hide');
 		$('#ladepunktConfigModal').modal("show");
 	} else {
-		$("#lockInfoModal").modal("show");
+		triggerUnlockDisplay();
 	}
 }
 
@@ -270,7 +271,7 @@ function modeButtonClicked(index) {
 
 		$("#chargeModeModal").modal("show");
 	} else {
-		$("#lockInfoModal").modal("show");
+		triggerUnlockDisplay();
 	}
 }
 
@@ -278,14 +279,14 @@ function socSetButtonClicked(index) {
 	if (wbdata.displaylocked == false) {
 		$("#socModal").modal("show");
 	} else {
-		$("#lockInfoModal").modal("show");
+		triggerUnlockDisplay();
 	}
 }
 function socLoadButtonClicked(index) {
 	if (wbdata.displaylocked == false) {
 		publish("1", "openWB/set/lp/" + (+index + 1) + "/ForceSoCUpdate");
 	} else {
-		$("#lockInfoModal").modal("show");
+		triggerUnlockDisplay();
 	}
 }
 var chargePointList = new ChargePointList();

--- a/web/display/colors/index.html
+++ b/web/display/colors/index.html
@@ -292,7 +292,7 @@
 			});
 
 			$('#backend .reloadBtn').click(function () {
-				location.reload();
+				window.location = window.location.pathname;
 			});
 		</script>
 	</div>

--- a/web/display/colors/index.html
+++ b/web/display/colors/index.html
@@ -27,7 +27,7 @@
 </head>
 
 <body>
-
+	<input type="hidden" value="" id="rfidwebread" />
 	<div class="container-fluid">
 		<div class="row pt-0">
 
@@ -966,6 +966,27 @@
 				var elementId = $(this).attr('id');
 				var option = $('input[name="' + elementId + '"]:checked').data('option').toString();
 				wbdata.setChargeLimitMode(option)
+			});
+
+			var urlParams = new URLSearchParams(queryString);
+			var ids = urlParams.get('rfidlist')
+			rfidArray = ids.split(",").filter(n => parseInt(n) > 0);
+			
+			$(document).keydown(function (e) {
+				if (e.keyCode >= 48 && e.keyCode <= 57 && $('#rfidwebread').val().length < 10) {
+					var old = $('#rfidwebread').val();
+					$('#rfidwebread').val(old+String.fromCharCode(e.keyCode));
+					console.log($('#rfidwebread').val());
+				} else if (event.keyCode == 13 || $('#rfidwebread').val().length == 10) {
+					var rfid = $('#rfidwebread').val();
+					$('#rfidwebread').val('');
+					if (rfidArray.includes(rfid)) {
+						lockDisplay(false);
+					} 						
+				}	
+				window.setTimeout(function() {
+					$('#rfidwebread').val('')
+				}, 3000);				
 			});
 		});
 	</script>

--- a/web/display/colors/index.html
+++ b/web/display/colors/index.html
@@ -504,6 +504,9 @@
 			function addLockNumber(e) {
 				var v = $("#Lockbox").val();
 				$("#Lockbox").val(v + e.value);
+				if ($("#Lockbox").val().length == 4) {
+					submitLockForm(PINbox);
+				}
 			}
 
 			function clearLockForm(e) {
@@ -523,7 +526,7 @@
 								$('#Lockcode').find('.enter').prop('disabled', false);
 								$("#Lockbox").val("");
 								$("#lockModal").modal("hide");
-							}, 1000);
+							}, 250);
 						} else {
 							$('#lockModal').find('.modal-body').addClass('bg-danger');
 							$('#Lockcode').find('.enter').prop('disabled', true);
@@ -828,6 +831,14 @@
 		var lockTimeoutHandler = null;
 		var lockTimeout = 60000;
 		wbdata.displaylocked = true;
+
+		function triggerUnlockDisplay() {
+			if(wbdata.displaylocked == true){
+				$("#lockModal").modal("show");
+			} else {
+				lockDisplay(true);
+			}
+		}
 
 		function lockDisplay(lock = true) {
 			if (lock == false) {

--- a/web/display/colors/powerdata.js
+++ b/web/display/colors/powerdata.js
@@ -476,7 +476,7 @@ function showStatus() {
 	if (wbdata.displaylocked == false) {
 	$("#statusModal").modal("show");
 	} else {
-		$("#lockInfoModal").modal("show");
+		triggerUnlockDisplay();
 	}
 }
 

--- a/web/settings/misc.php
+++ b/web/settings/misc.php
@@ -348,6 +348,15 @@
 							<div class="form-group mb-1">
 								<div class="form-row">
 									<div class="col">
+										<input type="hidden" name="unlockscreenrfid" value="0" />
+										<input type="checkbox" name="unlockscreenrfid" id="unlockscreenrfid" value="1" <?php if ($unlockscreenrfidold == 1) { echo "checked"; } ?>> Display entsperren wenn Auto zugwiesen. Display sperrt sich automatisch nach der eingestellten Zeit.
+									</div>
+								</div>
+							</div>
+							<hr class="border-secondary">
+							<div class="form-group mb-1">
+								<div class="form-row">
+									<div class="col">
 										Autos zuweisen
 									</div>
 								</div>
@@ -770,6 +779,16 @@
 							<div class="alert alert-info">
 								Im Modus 2 wird eine Kommaseparierte Liste mit gültigen RFID Tags hinterlegt. Gescannt werden kann an jedem möglichen RFID Leser. Heißt auch bei mehreren Ladepunkten kann an einem zentralen RFID Leser gescannt werden. Der gescannte Tag wird dem zuletzt angeschlossenenen Auto zugewiesen, schaltet den Ladepunkt frei und vermerkt dies für das Ladelog. Wird erst gescannt und dann ein Auto angeschlossen wird der Tag dem Auto zugewiesen das als nächstes ansteckt. Wird 5 Minuten nach Scannen kein Auto angeschlossen wird der Tag verworfen. Jeder Ladepunkt wird nach abstecken automatisch wieder gesperrt.
 							</div>
+							
+							<div class="form-group mb-1">
+								<div class="form-row">
+									<div class="col">
+										<input type="hidden" name="unlockscreenrfid" value="0" />
+										<input type="checkbox" name="unlockscreenrfid" id="unlockscreenrfid" value="1" <?php if ($unlockscreenrfidold == 1) { echo "checked"; } ?>> Display entsperren wenn Auto zugwiesen. Display sperrt sich automatisch nach der eingestellten Zeit.
+									</div>
+								</div>
+							</div>
+							<hr class="border-secondary">
 							<div class="form-group mb-1">
 								<div class="form-row">
 									<div class="col">

--- a/web/values.php
+++ b/web/values.php
@@ -1,4 +1,7 @@
 <?php
+ini_set('display_errors', 1);
+ini_set('display_startup_errors', 1);
+error_reporting(E_ALL);
 $result = '';
 $lines = file($_SERVER['DOCUMENT_ROOT'] . '/openWB/openwb.conf');
 foreach($lines as $line) {
@@ -158,7 +161,44 @@ foreach($lines as $line) {
 	if(strpos($line, "ssdisplay=") !== false) {
 		list(, $ssdisplayold) = explode("=", $line);
 	}
+	if(strpos($line, "unlockscreenrfid=") !== false) {
+		list(, $unlockscreenrfidold) = explode("=", $line);
+	}
+	if(strpos($line, "rfidlist=") !== false) {
+		list(, $rfidlistold) = explode("=", $line);
+	}
+	if(strpos($line, "rfidlist=") !== false) {
+		list(, $rfidlistold) = explode("=", $line);
+	}
+	if(strpos($line, "rfidlp1c1=") !== false) {
+		list(, $rfidlp1c1old) = explode("=", $line);
+	}
+	if(strpos($line, "rfidlp1c2=") !== false) {
+		list(, $rfidlp1c2old) = explode("=", $line);
+	}
+	if(strpos($line, "rfidlp1c3=") !== false) {
+		list(, $rfidlp1c3old) = explode("=", $line);
+	}
+	if(strpos($line, "rfidlp2c1=") !== false) {
+		list(, $rfidlp2c1old) = explode("=", $line);
+	}
+	if(strpos($line, "rfidlp2c2=") !== false) {
+		list(, $rfidlp2c2old) = explode("=", $line);
+	}
+	if(strpos($line, "rfidlp2c3=") !== false) {
+		list(, $rfidlp2c3old) = explode("=", $line);
+	}
 }
+
+if (!isset($_GET['rfidlist']) || strlen($_GET['rfidlist']) == 0) {
+	$rfidlist = trim($rfidlistold).",".trim($rfidlp1c1old).",".trim($rfidlp1c2old).",".trim($rfidlp1c3old).",".trim($rfidlp2c1old).",".trim($rfidlp2c2old).",".trim($rfidlp2c3old);
+	if (isset($unlockscreenrfidold) && trim($unlockscreenrfidold) == "1") {
+		header('Location: '.$_SERVER['PHP_SELF'].'?rfidlist='.$rfidlist);
+		die;
+	}
+}
+
+
 $displaypincodeold = str_replace("\n", '', $displaypincodeold);
 $themeold = preg_replace('~[\r\n]+~', '', $themeold);
 


### PR DESCRIPTION
I've implemented some UX features I found handy in day2day handling of the OpenWB:

1) The themes "cards" and "colors" showed a modal dialog that a pin is required for unlocking. One would always need to hit the rather tiny lock icon to use a locked display to show the number pad. The changed behaviour is that the PIN pad displays by default whenever an action is used requiring an unlocked screen.

2) Additionally, the "success" feedback (flashing background in green) was reduced from 1000ms to 250ms, avoiding an unnecessary delay after successful input

3) The PIN pad will submit automatically after the fourth digit is entered, avoiding the need to tap the "enter" button, reducing necessary user interactions for quicker usage.

4) Users can now unlock the screen by presenting their RFID token. The screen locks automatically after the configured time. To achieve this:
- Added a property to the RFID settings page to allow screen unlocking
- Added a new default property to openwb.conf named "unlockscreenrfid", allowing to store the respective property
- If the property is set, the values.php file will check for respective RFID token configurations in the respective settings of assigned cars (if RFID mode = 1), e.g., rfidlp1c1, rfidlp1c2, rfidlp1c3. If RFID mode = 2, the values of the config rfidlist will be used. values.php will check if the GET parameter rfidlist ist set and assigned a value, otherwise it will redict to itself append ?rfidlist=xxx,yyy,zzz
- The respective index.html will parse the HTTP request parameters and store them in a global variable
- The RFID reader acts like a keyboard. The page captures keyboard inputs (the RFID reader actually works like a keyboard) and once an RFID token is checked successfully against the configured tag ids, the screen will unlock.
- All functionalities remain untouched, so activating the charging point, setting charging mode, etc. Just additionally the screen unlocks and locks later on again.

5) Also added a debug statement with values for Hausverbrauch calculation. Not necessarily related to this PR but still helpful I find.
