### PR TITLE
smarthome shelly gen2 support und 3pro em mit add on

### DIFF
--- a/packages/modules/smarthome/shelly/off.py
+++ b/packages/modules/smarthome/shelly/off.py
@@ -26,16 +26,26 @@ if os.path.isfile(fnameg):
         gen = str(jsonin['gen'])
         model = str(jsonin['model'])
 else:
-    gen = "0"
-if (chan == 0):
-    url = "http://" + str(ipadr) + "/relay/0?turn=off"
-#    urllib.request.urlopen("http://"+str(ipadr)+"/relay/0?turn=off",
-#                           timeout=3)
+    gen = "1"
+if (gen == "1"):
+    if (chan == 0):
+        url = "http://" + str(ipadr) + "/relay/0?turn=off"
+    #    urllib.request.urlopen("http://"+str(ipadr)+"/relay/0?turn=off",
+    #                           timeout=3)
+    else:
+        chan = chan - 1
+        url = "http://" + str(ipadr) + "/relay/" + str(chan) + "?turn=off"
+    #    urllib.request.urlopen("http://"+str(ipadr)+"/relay/" + str(chan) +
+    #                           "?turn=off", timeout=3)
 else:
-    chan = chan - 1
-    url = "http://" + str(ipadr) + "/relay/" + str(chan) + "?turn=off"
-#    urllib.request.urlopen("http://"+str(ipadr)+"/relay/" + str(chan) +
-#                           "?turn=off", timeout=3)
+    if (chan > 0):
+        chan = chan - 1
+    # shelly pro 3em mit add on hat fix id 100 als switch Kanal, das Device muss auf jeden fall mit separater
+    # Leistunsmessung erfasst werden, da die Leistung auf drei verschiedenenen Kanälen angeliefert werden kann
+    if ("SPEM-003CE" in model):
+        chan = 100
+    # gen 2 will das als off cmd IPderPro3EM/rpc/Switch.Set?id=100&on=false
+    url = "http://" + str(ipadr) + "/rpc/Switch.Set?id=" + str(chan) + "&on=false"
 if (shaut == 1):
     #  print("Shelly off" + str(shaut) + user + pw)
     passman = urllib.request.HTTPPasswordMgrWithDefaultRealm()

--- a/packages/modules/smarthome/shelly/on.py
+++ b/packages/modules/smarthome/shelly/on.py
@@ -24,15 +24,25 @@ if os.path.isfile(fnameg):
         model = str(jsonin['model'])
 else:
     gen = "1"
-if (chan == 0):
-    url = "http://" + str(ipadr) + "/relay/0?turn=on"
-#    urllib.request.urlopen("http://"+str(ipadr)+"/relay/0?turn=on",
-#                           timeout=3)
+if (gen == "1"):
+    if (chan == 0):
+        url = "http://" + str(ipadr) + "/relay/0?turn=on"
+    #    urllib.request.urlopen("http://"+str(ipadr)+"/relay/0?turn=on",
+    #                           timeout=3)
+    else:
+        chan = chan - 1
+        url = "http://" + str(ipadr) + "/relay/" + str(chan) + "?turn=on"
+    #   urllib.request.urlopen("http://"+str(ipadr)+"/relay/" + str(chan) +
+    #                           "?turn=on", timeout=3)
 else:
-    chan = chan - 1
-    url = "http://" + str(ipadr) + "/relay/" + str(chan) + "?turn=on"
-#   urllib.request.urlopen("http://"+str(ipadr)+"/relay/" + str(chan) +
-#                           "?turn=on", timeout=3)
+    if (chan > 0):
+        chan = chan - 1
+    # shelly pro 3em mit add on hat fix id 100 als switch Kanal, das Device muss auf jeden fall mit separater
+    # Leistunsmessung erfasst werden, da die Leistung auf drei verschiedenenen Kanälen angeliefert werden kann
+    if ("SPEM-003CE" in model):
+        chan = 100
+    # gen 2 will das als on cmd /rpc/Switch.Set?id=100&on=true
+    url = "http://" + str(ipadr) + "/rpc/Switch.Set?id=" + str(chan) + "&on=true"
 if (shaut == 1):
     #  print("Shelly on" + str(shaut) + user + pw)
     passman = urllib.request.HTTPPasswordMgrWithDefaultRealm()

--- a/packages/modules/smarthome/shelly/watt.py
+++ b/packages/modules/smarthome/shelly/watt.py
@@ -4,10 +4,11 @@ import os
 import time
 import json
 import urllib.request
+from typing import Any
 from smarthome.smartret import writeret
 
 
-def totalPowerFromShellyJson(answer, workchan: int) -> int:
+def totalPowerFromShellyJson(answer: Any, workchan: int) -> int:
     if (workchan == 0):
         if 'meters' in answer:
             meters = answer['meters']   # shelly
@@ -135,6 +136,10 @@ try:
     if (gen == "1"):
         relais = int(answer['relays'][workchan]['ison'])
     else:
+        # shelly pro 3em mit add on hat fix id 100 als switch Kanal, das Device muss auf jeden fall mit separater
+        # Leistunsmessung erfasst werden, da die Leistung auf drei verschieden Kanäle angeliefert werden kann
+        if ("SPEM-003CE" in model):
+            workchan = 100
         sw = 'switch:' + str(workchan)
         relais = int(answer[sw]['output'])
 except Exception:


### PR DESCRIPTION
Kann für openwb 1.9 und openwb 2.0 übernommen werden. Shelly gen 2 verwenden andere on / off http cmds als gen1. Die sind nun angepasst. Shelly pro 3em ist noch etwas speziell er kann auf drei verschiedenen Kanälen die Leistung zurückliefen und es kann noch ein optionales add on verbaut werden, damit er schalten kann. Den Shelly pro 3em sollte so erfasst werden.
fall a) Nur Leistungsmessung
Unter separater Leistungsmessung dann dort Meter Auswahl den jeweile Kanal erfassen. Auswahl: Meter summiert oder Meter 2 bis 4 das entspricht -> Summe aller Leistung pro phase oder Leistung A,B, C alleine) 
fall b) Leistungsmessung und Schalten (geht nur mit  shelly addon zum schalten ) 
Shelly im gleichen Gerät zweimal erfassen. Einmal als separate Leistungsmessung wie im fall a und im oberen Teil der Gerätdefinition. Der switch hat fest die ID 100. Dort ist dann Kanal- / Meter-Auswahl im oberen Teil der Gerätedefinition irrelevant. Flake8 korrigiert