### PR TITLE
acthor installierte Leistung > maximal Leistung

### DIFF
--- a/packages/modules/smarthome/acthor/watt.py
+++ b/packages/modules/smarthome/acthor/watt.py
@@ -103,6 +103,8 @@ if count5 == 0:
         neupowertarget = int((uberschuss + aktpower) * faktor)
     if neupowertarget < 0:
         neupowertarget = 0
+    if instpower > cap:
+        cap = instpower
     if neupowertarget > int(cap * faktor):
         neupowertarget = int(cap * faktor)
     # status nach handbuch Thor


### PR DESCRIPTION
Sofern die installierte Leistung grösser als die maximal Leistung vom Acthor ist, wird ggf die CAP angepasst, da sonst der Heizstab nicht voll ausgereget wird. Kann für 1.9 und 2.0 übernommen werden