### PR TITLE
Dac typ = 02

### DIFF
--- a/packages/modules/smarthome/nxdacxx/watt.py
+++ b/packages/modules/smarthome/nxdacxx/watt.py
@@ -37,7 +37,7 @@ if count5 > 3:
 with open(file_stringcount5, 'w') as f:
     f.write(str(count5))
 modbuswrite = 0
-if dactyp == 3:
+if (dactyp == 3) or (dactyp == 1):
     neupower = uberschuss + aktpoweralt
 else:
     neupower = uberschuss


### PR DESCRIPTION
Bei Dac DA02 wird neu auch die bisherige Leistungsaufnahme in die Berechnung von 0 - 10 V mit einbezogen um Schwingen zu vermeiden.
Kann für 1.9 und 2.0 übernommen werden.

https://forum.openwb.de/viewtopic.php?p=103457#p103457