### PR TITLE
lambda pymodbus

### DIFF
--- a/packages/modules/smarthome/lambda_/watt.py
+++ b/packages/modules/smarthome/lambda_/watt.py
@@ -5,10 +5,16 @@ import time
 import struct
 import codecs
 import logging
-from pymodbus.payload import BinaryPayloadBuilder, Endian
+from pymodbus.payload import BinaryPayloadBuilder
 from pymodbus.client.sync import ModbusTcpClient
 from smarthome.smartlog import initlog
 from smarthome.smartret import writeret
+#  fix for pymodbus endian class (changes once 2023 august to enum to uppercases only,
+#   checked during runtime,
+#   not compatible betwwen openwb 1.9 (want lowercases) and openwb 2.0 (wants upercase))
+auto = "@"
+big = ">"
+little = "<"
 named_tuple = time.localtime()  # getstruct_time
 time_string = time.strftime("%m/%d/%Y, %H:%M:%S lambda watty.py", named_tuple)
 devicenumber = int(sys.argv[1])
@@ -100,7 +106,7 @@ if count5 == 0:
     # modbus write
     if modbuswrite == 1:
         # andernfalls absturz bei negativen Zahlen
-        builder = BinaryPayloadBuilder(byteorder=Endian.BIG)
+        builder = BinaryPayloadBuilder(byteorder=big)
         builder.reset()
         builder.add_16bit_int(neupower)
         pay = builder.to_registers()


### PR DESCRIPTION
 fix for pymodbus endian class (changes once 2023 august to enum to uppercases only,
  checked during runtime,
 not compatible between openwb 1.9 want lowercases ( -> BinaryPayloadBuilder(byteorder=Endian.big) and openwb 2.0 (wants upercase ( -> BinaryPayloadBuilder(byteorder=Endian.BIG)
auto = "@"
big = ">"
little = "<"
Als Lösung werden die Konstanten Werte aus der endian class (die die letzten Jahre unverändert geblieben sind) selber übergeben
siehe auch
https://forum.openwb.de/viewtopic.php?p=104639#p104639