### PR TITLE
shelly mini gen3...

### DIFF
--- a/packages/modules/smarthome/shelly/watt.py
+++ b/packages/modules/smarthome/shelly/watt.py
@@ -121,7 +121,8 @@ try:
                 aktpower = int(answer['em:0']['c_act_power'])
             else:
                 aktpower = int(answer['em:0']['total_act_power'])
-        elif ("PM-001PCEU16" in model):  // SNPM-001PCEU16 (gen 2) und S3PM-001PCEU16 (gen 3)
+        elif ("PM-001PCEU16" in model):
+            #   "SNPM-001PCEU16" (gen 2) und "S3PM-001PCEU16" (gen 3)
             aktpower = int(answer['pm1:0']['apower'])
         else:
             aktpower = int(answer[sw]['apower'])

--- a/packages/modules/smarthome/shelly/watt.py
+++ b/packages/modules/smarthome/shelly/watt.py
@@ -121,7 +121,7 @@ try:
                 aktpower = int(answer['em:0']['c_act_power'])
             else:
                 aktpower = int(answer['em:0']['total_act_power'])
-        elif ("SNPM-001PCEU16" in model):
+        elif ("PM-001PCEU16" in model):  // SNPM-001PCEU16 (gen 2) und S3PM-001PCEU16 (gen 3)
             aktpower = int(answer['pm1:0']['apower'])
         else:
             aktpower = int(answer[sw]['apower'])


### PR DESCRIPTION
Gen 2 und gen3 shlley mini unterscheiden sich im Namen. Siehe auch
https://forum.openwb.de/viewtopic.php?p=106705#p106705 
Kann für 1.9 und 2.0 übernommen werden