### PR TITLE
victron module: read power from all phases and use im/export registers

### DIFF
--- a/packages/modules/devices/victron/counter.py
+++ b/packages/modules/devices/victron/counter.py
@@ -29,7 +29,9 @@ class VictronCounter:
         energy_meter = self.component_config.configuration.energy_meter
         with self.__tcp_client:
             if energy_meter:
-                powers = self.__tcp_client.read_holding_registers(2600, [ModbusDataType.INT_16]*3, unit=unit)
+                powers = [
+                    self.__tcp_client.read_holding_registers(reg, ModbusDataType.INT_16, unit=unit)
+                    for reg in [2600, 2601, 2602]]
                 currents = [
                     self.__tcp_client.read_holding_registers(reg, ModbusDataType.INT_16, unit=unit) / 10
                     for reg in [2617, 2619, 2621]]
@@ -37,11 +39,12 @@ class VictronCounter:
                     self.__tcp_client.read_holding_registers(reg, ModbusDataType.UINT_16, unit=unit) / 10
                     for reg in [2616, 2618, 2620]]
                 power = sum(powers)
+                imported = self.__tcp_client.read_holding_registers(2634, ModbusDataType.INT_16, unit=unit)
+                exported = self.__tcp_client.read_holding_registers(2636, ModbusDataType.INT_16, unit=unit)
             else:
                 powers = self.__tcp_client.read_holding_registers(820, [ModbusDataType.INT_16]*3, unit=unit)
                 power = sum(powers)
-
-        imported, exported = self.sim_counter.sim_count(power)
+                imported, exported = self.sim_counter.sim_count(power)
 
         if energy_meter:
             counter_state = CounterState(


### PR DESCRIPTION
I've switched from MQTT EVU to Victron and noticed, that im and export data is wrong. Something like this should fix this. I'm not sure about the `ModbusDataType.INT_16` data type for im and export though, [the [Modbus-TCP register list](https://www.victronenergy.com/upload/documents/CCGX-Modbus-TCP-register-list-3.20.xlsx) says `uint32`