### PR TITLE
Update pycarwings2.py

### DIFF
--- a/modules/soc_leaf/pycarwings2.py
+++ b/modules/soc_leaf/pycarwings2.py
@@ -118,7 +118,7 @@ class Session(object):
         else:
             params["custom_sessionid"] = ""
 
-        req = Request('POST', url=BASE_URL + endpoint, data=params, headers={"User-Agent": ""}).prepare()
+        req = Request('POST', url=BASE_URL + endpoint, data=params).prepare()
 
         log.debug("invoking carwings API: %s" % req.url)
         log.debug("params: %s" % json.dumps(

--- a/modules/soc_leaf/pycarwings2.py
+++ b/modules/soc_leaf/pycarwings2.py
@@ -72,7 +72,7 @@ from responses import *
 import base64
 from Crypto.Cipher import Blowfish
 
-BASE_URL = "https://gdcportalgw.its-mo.com/api_v210707_NE/gdc/"
+BASE_URL = "https://gdcportalgw.its-mo.com/api_v230317_NE/gdc/"
 
 log = logging.getLogger(__name__)
 
@@ -118,7 +118,7 @@ class Session(object):
         else:
             params["custom_sessionid"] = ""
 
-        req = Request('POST', url=BASE_URL + endpoint, data=params).prepare()
+        req = Request('POST', url=BASE_URL + endpoint, data=params, headers={"User-Agent": ""}).prepare()
 
         log.debug("invoking carwings API: %s" % req.url)
         log.debug("params: %s" % json.dumps(


### PR DESCRIPTION
Two changes

1st re line 75: Nissan changed the Base URL of its Carwings API. Since May 20, 2024 the old URL used by pycarwings2 in soc_leaf doesn't work anymore.

2nd re line 121: At least on a Windows 10 PC with Python 3.12 for test purpose, the additional parameter 'headers={"User-Agent": ""}' is needed to run pycarwings2.py successfully. The need for this parameter within OpenWB itself has tbc.

For more details see posts on https://forum.openwb.de/viewtopic.php?p=109761#p109761 ff