### PR TITLE
Update openwb-install.sh fixieren von paho-mqtt<2.0.0

### DIFF
--- a/openwb-install.sh
+++ b/openwb-install.sh
@@ -101,7 +101,7 @@ echo "check for paho-mqtt"
 if python3 -c "import paho.mqtt.publish as publish" &> /dev/null; then
 	echo 'mqtt installed...'
 else
-	sudo pip3 install paho-mqtt
+	sudo pip3 install "paho-mqtt<2.0.0"
 fi
 
 #Adafruit install


### PR DESCRIPTION
Bei einer aktuellen Neuinstallation unter Buster wird ohne Eingrenzung der paho-mqtt Version die aktuelle Version 2.1.0 gezogen. Zwischen Version 1,6 und 2.0 gibt es breaking Changes die Anpassungen in verschiedenen Sourcen erforden würden. Durch die Anpassung wird die aktuellste verfügbare Version <2.0.0 für die Installation herangezogen.