### PR TITLE
soc_vwid: main.sh - always execute as user pi

### DIFF
--- a/modules/soc_vwid/main.sh
+++ b/modules/soc_vwid/main.sh
@@ -1,4 +1,18 @@
 #!/bin/bash
+
+# -- start user pi enforcement
+# normally the soc module runs as user pi
+# When LP Configuration is stored, it is run as user www-data
+# This leads to various permission problems
+# if actual user is not pi, this section restarts the script as user pi
+usr=`id -nu`
+if [ "$usr" != "pi" ]
+then
+    sudo -u pi -c bash "$0 $*"
+    exit $?
+fi
+# -- ending user pi enforcement
+
 OPENWBBASEDIR=$(cd `dirname $0`/../../ && pwd)
 RAMDISKDIR="$OPENWBBASEDIR/ramdisk"
 MODULEDIR=$(cd `dirname $0` && pwd)

--- a/modules/soc_vwid/main.sh
+++ b/modules/soc_vwid/main.sh
@@ -8,8 +8,8 @@
 usr=`id -nu`
 if [ "$usr" != "pi" ]
 then
-    sudo -u pi -c bash "$0 $*"
-    exit $?
+	sudo -u pi -c bash "$0 $*"
+	exit $?
 fi
 # -- ending user pi enforcement
 


### PR DESCRIPTION
Die Ausführung als user www-data beim Speicher der LP Konfiguration führt immer wieder zu Permission Problemen.
Diese Änderung führt das Modul immer als user pi aus, auch beim Speichern der Konfiguration.