### PR TITLE
Update pycarwings2.py with header "User-Agent"

### DIFF
--- a/modules/soc_leaf/pycarwings2.py
+++ b/modules/soc_leaf/pycarwings2.py
@@ -118,7 +118,7 @@ class Session(object):
         else:
             params["custom_sessionid"] = ""
 
-        req = Request('POST', url=BASE_URL + endpoint, data=params).prepare()
+        req = Request('POST', url=BASE_URL + endpoint, data=params, headers={"User-Agent": ""}).prepare()
 
         log.debug("invoking carwings API: %s" % req.url)
         log.debug("params: %s" % json.dumps(


### PR DESCRIPTION
In der OpenWB V1.9.304N, im Modul pycarwings2 zur SoC Abfrage des Nissan Leaf muss der Aufruf der Nissan Carwings API in Zeile 121 um den zusätzlichen Parameter headers= {"User-Agent": ""} ergänzt werden. 

Ohne diesen Parameter antwortet die API seit einigen Tagen mit dem Fehler INVALID PARAMS. 

Der zusätzliche Parameter stammt aus der pycarwings2 Version von filcole https://github.com/filcole/pycarwings2/blob/master/pycarwings2/pycarwings2.py in Zeile 125. 

Auf einem PC läuft die SoC-Abfrage mit pycarwings2 nur mit diesem zusätzlichen Parameter. Ansonsten kommt o.g. Fehlermeldung. 

Der Parameter wurde bereits im PR https://github.com/snaptec/openWB/pull/2842 von @ddraeyer getestet, dann aber mangels Notwendigkeit doch nicht eingeführt. Inzwischen kommt die o.g. Fehlermeldung aber auch bei Aufruf der API mit der OpenWB V1.9.304N.